### PR TITLE
fix(html2pptx): inherit parent bold/italic/underline into inline-formatted text runs

### DIFF
--- a/scripts/html2pptx.js
+++ b/scripts/html2pptx.js
@@ -840,15 +840,27 @@ async function extractSlideData(page) {
 
       if (rotation !== null) baseStyle.rotate = rotation;
 
+      const isBold = computed.fontWeight === 'bold' || parseInt(computed.fontWeight) >= 600;
+      const isItalic = computed.fontStyle === 'italic';
+      const hasUnderline = computed.textDecoration.includes('underline');
       const hasFormatting = el.querySelector('b, i, u, strong, em, span, br');
 
       if (hasFormatting) {
-        // Text with inline formatting
+        // Text with inline formatting — pass parent element's computed bold/italic/underline
+        // as baseOptions so they are inherited by plain text runs (e.g. text nodes adjacent
+        // to <br> tags). Without this, a <h1 style="font-weight:900">text<br/>more</h1>
+        // would produce runs with no bold flag because parseInlineFormatting only reads
+        // computed styles on inline *elements* (b/i/span), not on bare text nodes.
         const transformStr = computed.textTransform;
-        const runs = parseInlineFormatting(el, {}, [], (str) => applyTextTransform(str, transformStr));
+        const parentRunOptions = {};
+        if (isBold && !shouldSkipBold(computed.fontFamily)) parentRunOptions.bold = true;
+        if (isItalic) parentRunOptions.italic = true;
+        if (hasUnderline) parentRunOptions.underline = true;
+
+        const runs = parseInlineFormatting(el, parentRunOptions, [], (str) => applyTextTransform(str, transformStr));
 
         // Adjust lineSpacing based on largest fontSize in runs
-        const adjustedStyle = { ...baseStyle };
+        const adjustedStyle = { ...baseStyle, ...parentRunOptions };
         if (adjustedStyle.lineSpacing) {
           const maxFontSize = Math.max(
             adjustedStyle.fontSize,
@@ -871,8 +883,6 @@ async function extractSlideData(page) {
         const textTransform = computed.textTransform;
         const transformedText = applyTextTransform(text, textTransform);
 
-        const isBold = computed.fontWeight === 'bold' || parseInt(computed.fontWeight) >= 600;
-
         elements.push({
           type: el.tagName.toLowerCase(),
           text: transformedText,
@@ -880,8 +890,8 @@ async function extractSlideData(page) {
           style: {
             ...baseStyle,
             bold: isBold && !shouldSkipBold(computed.fontFamily),
-            italic: computed.fontStyle === 'italic',
-            underline: computed.textDecoration.includes('underline')
+            italic: isItalic,
+            underline: hasUnderline
           }
         });
       }


### PR DESCRIPTION
花叔你好
我用了 huashu-design 做了一份 16 頁的網頁幻燈片。很成功。
但請 AI 使用 html2pptx 時，發現一個 bug。
以下由 claude code 生成

## 現象

標題裡只要有換行（<br>），匯出 PPTX 之後粗體就消失了。
比如這種寫法：

    <h1 style="font-weight:900">上半段<br/>下半段</h1>

網頁裡看是粗體，但匯出的 PPT 裡變成細體了。
手動在 PPT 裡點一下加粗才恢復正常。

## 原因

html2pptx.js 看到 <br> 會走一條特殊處理路線，
這條路線在整理文字時忘了把父元素的「粗體/斜體/底線」帶上，
所以換行附近的文字在 PPT 裡就丟失了格式。

## 改了什麼

在 hasFormatting 判斷之前，先從父元素 computedStyle 提取
isBold / isItalic / hasUnderline，然後：

1. 作為 parentRunOptions 傳入 parseInlineFormatting，
   讓純文字節點繼承父元素格式
2. 同時合併進 adjustedStyle，確保文字框層級也帶有正確標識

else（純文字）分支行為不變，只是改為復用已計算的變數。

## 測試

在 16 頁幻燈片中驗證，多個標題包含 <br> 換行且設置了 font-weight 700–900。
修復前：匯出 PPTX 後無粗體；修復後：正確以粗體匯出。