### PR TITLE
Add landing page track and fix webui 401 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 demos/_frames_*.png
 demos/_verify.js
 demos/_verify.mjs
+.vercel

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ demos/_frames_*.png
 demos/_verify.js
 demos/_verify.mjs
 .vercel
+
+.env.local

--- a/SKILL.md
+++ b/SKILL.md
@@ -731,6 +731,7 @@ Screen 组件接 callback props（`onEnter`、`onClose`、`onTabChange`、`onOpe
 | 反AI slop、内容规范、scale | `references/content-guidelines.md` |
 | React+Babel项目setup | `references/react-setup.md` |
 | 做幻灯片 | `references/slide-decks.md` + `assets/deck_stage.js` |
+| **做营销落地页 / 商家网站 mockup**（first-class track，section 库 + 按业态选 sections + anti-slop 清单） | `references/landing-pages.md` |
 | 导出可编辑 PPTX（html2pptx 4 条硬约束） | `references/editable-pptx.md` + `scripts/html2pptx.js` |
 | 做动画/motion（**先读 pitfalls**）| `references/animation-pitfalls.md` + `references/animations.md` + `assets/animations.jsx` |
 | **动画的正向设计语法**（Anthropic 级叙事/运动/节奏/表达风格）| `references/animation-best-practices.md`（5 段叙事+Expo easing+运动语言 8 条+3 种场景配方）|

--- a/api/context.js
+++ b/api/context.js
@@ -1,0 +1,21 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+async function listHtml(dir) {
+  try {
+    const entries = await fs.readdir(path.join(process.cwd(), dir));
+    return entries.filter((entry) => entry.endsWith(".html")).sort();
+  } catch {
+    return [];
+  }
+}
+
+module.exports = async function handler(_req, res) {
+  const demos = await listHtml("demos");
+  const showcases = await fs
+    .readdir(path.join(process.cwd(), "assets", "showcases"), { withFileTypes: true })
+    .then((entries) => entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name))
+    .catch(() => []);
+
+  res.status(200).json({ repoRoot: process.cwd(), demos, showcases });
+};

--- a/api/generate.js
+++ b/api/generate.js
@@ -78,7 +78,7 @@ function envVarNameFor(provider) {
   return "";
 }
 
-async function callOpenAICompatible({ baseUrl, apiKey, model, system, prompt }) {
+async function streamOpenAICompatible({ baseUrl, apiKey, model, system, prompt, onDelta }) {
   const headers = { "Content-Type": "application/json" };
   if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
 
@@ -88,6 +88,7 @@ async function callOpenAICompatible({ baseUrl, apiKey, model, system, prompt }) 
     body: JSON.stringify({
       model,
       temperature: 0.7,
+      stream: true,
       messages: [
         { role: "system", content: system },
         { role: "user", content: prompt },
@@ -95,13 +96,38 @@ async function callOpenAICompatible({ baseUrl, apiKey, model, system, prompt }) 
     }),
   });
 
-  const text = await response.text();
-  if (!response.ok) throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
-  const json = JSON.parse(text);
-  return json.choices?.[0]?.message?.content || "";
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const payload = trimmed.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        const json = JSON.parse(payload);
+        const delta = json.choices?.[0]?.delta?.content;
+        if (delta) onDelta(delta);
+      } catch {
+        // tolerate malformed chunk
+      }
+    }
+  }
 }
 
-async function callAnthropic({ baseUrl, apiKey, model, system, prompt }) {
+async function streamAnthropic({ baseUrl, apiKey, model, system, prompt, onDelta }) {
   if (!apiKey) throw new Error("Anthropic requires an API key.");
   const response = await fetch(`${baseUrl.replace(/\/$/, "")}/v1/messages`, {
     method: "POST",
@@ -114,15 +140,42 @@ async function callAnthropic({ baseUrl, apiKey, model, system, prompt }) {
       model,
       max_tokens: 8000,
       temperature: 0.7,
+      stream: true,
       system,
       messages: [{ role: "user", content: prompt }],
     }),
   });
 
-  const text = await response.text();
-  if (!response.ok) throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
-  const json = JSON.parse(text);
-  return json.content?.map((part) => part.text || "").join("") || "";
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const events = buffer.split("\n\n");
+    buffer = events.pop() || "";
+    for (const ev of events) {
+      const dataLine = ev.split("\n").find((line) => line.startsWith("data:"));
+      if (!dataLine) continue;
+      const payload = dataLine.slice(5).trim();
+      if (!payload) continue;
+      try {
+        const json = JSON.parse(payload);
+        if (json.type === "content_block_delta" && json.delta?.type === "text_delta") {
+          onDelta(json.delta.text);
+        }
+      } catch {
+        // tolerate malformed chunk
+      }
+    }
+  }
 }
 
 function stripFence(output) {
@@ -135,56 +188,74 @@ module.exports = async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
   const provider = (req.body && req.body.provider) || "ollama";
+  const body = req.body || {};
+  const baseUrl =
+    body.baseUrl ||
+    (provider === "anthropic"
+      ? "https://api.anthropic.com"
+      : provider === "ollama"
+        ? "http://localhost:11434/v1"
+        : provider === "ollama-cloud"
+          ? "https://ollama.com/v1"
+          : "https://api.openai.com/v1");
+  const model =
+    body.model ||
+    (provider === "anthropic"
+      ? "claude-sonnet-4-6"
+      : provider === "ollama"
+        ? "kimi-k2.6:cloud"
+        : provider === "ollama-cloud"
+          ? "kimi-k2.6"
+          : "gpt-5.4");
+  const mode = body.mode || "prototype";
+  const prompt = String(body.prompt || "").trim();
+  const apiKey = resolveApiKey(provider, body.apiKey);
+
+  if (!prompt) {
+    return res.status(400).json({ error: "Prompt is required." });
+  }
+  if (providerRequiresKey(provider) && !apiKey) {
+    const envName = envVarNameFor(provider);
+    return res.status(400).json({
+      error: `${provider} requires an API key. Enter one in the API key field, or set ${envName} in the deployment's environment variables.`,
+    });
+  }
+
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.setHeader("X-Accel-Buffering", "no");
+  if (typeof res.flushHeaders === "function") res.flushHeaders();
+
+  const writeEvent = (event, data) => {
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  };
 
   try {
-    const body = req.body || {};
-    const baseUrl =
-      body.baseUrl ||
-      (provider === "anthropic"
-        ? "https://api.anthropic.com"
-        : provider === "ollama"
-          ? "http://localhost:11434/v1"
-          : provider === "ollama-cloud"
-            ? "https://ollama.com/v1"
-          : "https://api.openai.com/v1");
-    const model =
-      body.model ||
-      (provider === "anthropic"
-        ? "claude-sonnet-4-6"
-        : provider === "ollama"
-          ? "kimi-k2.6:cloud"
-          : provider === "ollama-cloud"
-            ? "kimi-k2.6"
-            : "gpt-5.4");
-    const mode = body.mode || "prototype";
-    const prompt = String(body.prompt || "").trim();
-    const apiKey = resolveApiKey(provider, body.apiKey);
-
-    if (!prompt) {
-      return res.status(400).json({ error: "Prompt is required." });
-    }
-    if (providerRequiresKey(provider) && !apiKey) {
-      const envName = envVarNameFor(provider);
-      return res.status(400).json({
-        error: `${provider} requires an API key. Enter one in the API key field, or set ${envName} in the deployment's environment variables.`,
-      });
-    }
-
     const system = await buildContext(mode);
     const fullPrompt = [`Mode: ${mode}`, "Return a complete HTML document.", "", prompt].join("\n");
-    const generated =
-      provider === "anthropic"
-        ? await callAnthropic({ baseUrl, apiKey, model, system, prompt: fullPrompt })
-        : await callOpenAICompatible({ baseUrl, apiKey, model, system, prompt: fullPrompt });
 
-    res.status(200).json({ html: stripFence(generated), model, provider });
+    writeEvent("start", { provider, model });
+
+    const stream = provider === "anthropic" ? streamAnthropic : streamOpenAICompatible;
+    await stream({
+      baseUrl,
+      apiKey,
+      model,
+      system,
+      prompt: fullPrompt,
+      onDelta: (delta) => writeEvent("delta", { text: delta }),
+    });
+
+    writeEvent("done", { provider, model });
+    res.end();
   } catch (error) {
-    if (/^401\b/.test(error.message || "")) {
+    let message = error.message || "Unexpected server error";
+    if (/^401\b/.test(message)) {
       const envName = envVarNameFor(provider) || "the provider's API key";
-      return res.status(401).json({
-        error: `Provider rejected the API key (401). Double-check the key for ${provider}, or update ${envName} in the deployment's environment variables.`,
-      });
+      message = `Provider rejected the API key (401). Double-check the key for ${provider}, or update ${envName} in the deployment's environment variables.`;
     }
-    res.status(500).json({ error: error.message || "Unexpected server error" });
+    writeEvent("error", { error: message });
+    res.end();
   }
 };

--- a/api/generate.js
+++ b/api/generate.js
@@ -1,0 +1,142 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+function clip(text, max = 18000) {
+  return text.length > max ? `${text.slice(0, max)}\n\n[clipped]` : text;
+}
+
+async function readText(relativePath, max) {
+  return clip(await fs.readFile(path.join(process.cwd(), relativePath), "utf8"), max);
+}
+
+async function listHtml(dir) {
+  try {
+    const entries = await fs.readdir(path.join(process.cwd(), dir));
+    return entries.filter((entry) => entry.endsWith(".html")).sort();
+  } catch {
+    return [];
+  }
+}
+
+async function buildContext(mode) {
+  const [skill, workflow, styles, verification, animations, slides, demos] =
+    await Promise.all([
+      readText("SKILL.md", 12000),
+      readText("references/workflow.md", 7000),
+      readText("references/design-styles.md", 8000),
+      readText("references/verification.md", 5000),
+      mode === "motion" ? readText("references/animations.md", 7000) : "",
+      mode === "slides" ? readText("references/slide-decks.md", 7000) : "",
+      listHtml("demos"),
+    ]);
+
+  return [
+    "You are Huashu Design Studio, an HTML-native design agent.",
+    "Generate complete, self-contained HTML. Inline CSS and JavaScript are preferred.",
+    "Avoid generic AI design defaults: purple gradients, emoji-as-icons, decorative blobs, and fake product silhouettes.",
+    "Do not include markdown fences unless the user specifically asks for markdown.",
+    "",
+    "Available demo files:",
+    demos.join(", "),
+    "",
+    "Main skill excerpt:",
+    skill,
+    "",
+    "Workflow excerpt:",
+    workflow,
+    "",
+    "Design styles excerpt:",
+    styles,
+    "",
+    mode === "motion" ? `Animation excerpt:\n${animations}` : "",
+    mode === "slides" ? `Slide excerpt:\n${slides}` : "",
+    "",
+    "Verification excerpt:",
+    verification,
+  ].join("\n");
+}
+
+async function callOpenAICompatible({ baseUrl, apiKey, model, system, prompt }) {
+  const headers = { "Content-Type": "application/json" };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}/chat/completions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      temperature: 0.7,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: prompt },
+      ],
+    }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
+  const json = JSON.parse(text);
+  return json.choices?.[0]?.message?.content || "";
+}
+
+async function callAnthropic({ baseUrl, apiKey, model, system, prompt }) {
+  if (!apiKey) throw new Error("Anthropic requires an API key.");
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 8000,
+      temperature: 0.7,
+      system,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
+  const json = JSON.parse(text);
+  return json.content?.map((part) => part.text || "").join("") || "";
+}
+
+function stripFence(output) {
+  const trimmed = output.trim();
+  const match = trimmed.match(/^```(?:html)?\s*([\s\S]*?)\s*```$/i);
+  return match ? match[1].trim() : trimmed;
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+
+  try {
+    const body = req.body || {};
+    const provider = body.provider || "ollama";
+    const baseUrl =
+      body.baseUrl ||
+      (provider === "anthropic"
+        ? "https://api.anthropic.com"
+        : provider === "ollama"
+          ? "http://localhost:11434/v1"
+          : "https://api.openai.com/v1");
+    const model =
+      body.model || (provider === "anthropic" ? "claude-sonnet-4-6" : provider === "ollama" ? "kimi-k2.6:cloud" : "gpt-5.4");
+    const mode = body.mode || "prototype";
+    const prompt = String(body.prompt || "").trim();
+    if (!prompt) throw new Error("Prompt is required.");
+
+    const system = await buildContext(mode);
+    const fullPrompt = [`Mode: ${mode}`, "Return a complete HTML document.", "", prompt].join("\n");
+    const generated =
+      provider === "anthropic"
+        ? await callAnthropic({ baseUrl, apiKey: body.apiKey, model, system, prompt: fullPrompt })
+        : await callOpenAICompatible({ baseUrl, apiKey: body.apiKey, model, system, prompt: fullPrompt });
+
+    res.status(200).json({ html: stripFence(generated), model, provider });
+  } catch (error) {
+    res.status(500).json({ error: error.message || "Unexpected server error" });
+  }
+};

--- a/api/generate.js
+++ b/api/generate.js
@@ -19,7 +19,7 @@ async function listHtml(dir) {
 }
 
 async function buildContext(mode) {
-  const [skill, workflow, styles, verification, animations, slides, demos] =
+  const [skill, workflow, styles, verification, animations, slides, landing, demos] =
     await Promise.all([
       readText("SKILL.md", 12000),
       readText("references/workflow.md", 7000),
@@ -27,6 +27,7 @@ async function buildContext(mode) {
       readText("references/verification.md", 5000),
       mode === "motion" ? readText("references/animations.md", 7000) : "",
       mode === "slides" ? readText("references/slide-decks.md", 7000) : "",
+      mode === "prototype" ? readText("references/landing-pages.md", 7000) : "",
       listHtml("demos"),
     ]);
 
@@ -34,6 +35,7 @@ async function buildContext(mode) {
     "You are Huashu Design Studio, an HTML-native design agent.",
     "Generate complete, self-contained HTML. Inline CSS and JavaScript are preferred.",
     "Avoid generic AI design defaults: purple gradients, emoji-as-icons, decorative blobs, and fake product silhouettes.",
+    "For prototypes the user calls a 'website' or 'landing page', follow the Landing Page Track: pick sections by business type, use real-feeling copy, and run the anti-slop checklist before delivery.",
     "Do not include markdown fences unless the user specifically asks for markdown.",
     "",
     "Available demo files:",
@@ -50,10 +52,30 @@ async function buildContext(mode) {
     "",
     mode === "motion" ? `Animation excerpt:\n${animations}` : "",
     mode === "slides" ? `Slide excerpt:\n${slides}` : "",
+    mode === "prototype" ? `Landing page track:\n${landing}` : "",
     "",
     "Verification excerpt:",
     verification,
   ].join("\n");
+}
+
+function resolveApiKey(provider, supplied) {
+  if (supplied) return supplied;
+  if (provider === "openai") return process.env.OPENAI_API_KEY || "";
+  if (provider === "anthropic") return process.env.ANTHROPIC_API_KEY || "";
+  if (provider === "ollama-cloud") return process.env.OLLAMA_API_KEY || "";
+  return "";
+}
+
+function providerRequiresKey(provider) {
+  return provider === "openai" || provider === "anthropic" || provider === "ollama-cloud";
+}
+
+function envVarNameFor(provider) {
+  if (provider === "openai") return "OPENAI_API_KEY";
+  if (provider === "anthropic") return "ANTHROPIC_API_KEY";
+  if (provider === "ollama-cloud") return "OLLAMA_API_KEY";
+  return "";
 }
 
 async function callOpenAICompatible({ baseUrl, apiKey, model, system, prompt }) {
@@ -112,9 +134,10 @@ function stripFence(output) {
 module.exports = async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
+  const provider = (req.body && req.body.provider) || "ollama";
+
   try {
     const body = req.body || {};
-    const provider = body.provider || "ollama";
     const baseUrl =
       body.baseUrl ||
       (provider === "anthropic"
@@ -135,17 +158,33 @@ module.exports = async function handler(req, res) {
             : "gpt-5.4");
     const mode = body.mode || "prototype";
     const prompt = String(body.prompt || "").trim();
-    if (!prompt) throw new Error("Prompt is required.");
+    const apiKey = resolveApiKey(provider, body.apiKey);
+
+    if (!prompt) {
+      return res.status(400).json({ error: "Prompt is required." });
+    }
+    if (providerRequiresKey(provider) && !apiKey) {
+      const envName = envVarNameFor(provider);
+      return res.status(400).json({
+        error: `${provider} requires an API key. Enter one in the API key field, or set ${envName} in the deployment's environment variables.`,
+      });
+    }
 
     const system = await buildContext(mode);
     const fullPrompt = [`Mode: ${mode}`, "Return a complete HTML document.", "", prompt].join("\n");
     const generated =
       provider === "anthropic"
-        ? await callAnthropic({ baseUrl, apiKey: body.apiKey, model, system, prompt: fullPrompt })
-        : await callOpenAICompatible({ baseUrl, apiKey: body.apiKey, model, system, prompt: fullPrompt });
+        ? await callAnthropic({ baseUrl, apiKey, model, system, prompt: fullPrompt })
+        : await callOpenAICompatible({ baseUrl, apiKey, model, system, prompt: fullPrompt });
 
     res.status(200).json({ html: stripFence(generated), model, provider });
   } catch (error) {
+    if (/^401\b/.test(error.message || "")) {
+      const envName = envVarNameFor(provider) || "the provider's API key";
+      return res.status(401).json({
+        error: `Provider rejected the API key (401). Double-check the key for ${provider}, or update ${envName} in the deployment's environment variables.`,
+      });
+    }
     res.status(500).json({ error: error.message || "Unexpected server error" });
   }
 };

--- a/api/generate.js
+++ b/api/generate.js
@@ -121,9 +121,18 @@ module.exports = async function handler(req, res) {
         ? "https://api.anthropic.com"
         : provider === "ollama"
           ? "http://localhost:11434/v1"
+          : provider === "ollama-cloud"
+            ? "https://ollama.com/v1"
           : "https://api.openai.com/v1");
     const model =
-      body.model || (provider === "anthropic" ? "claude-sonnet-4-6" : provider === "ollama" ? "kimi-k2.6:cloud" : "gpt-5.4");
+      body.model ||
+      (provider === "anthropic"
+        ? "claude-sonnet-4-6"
+        : provider === "ollama"
+          ? "kimi-k2.6:cloud"
+          : provider === "ollama-cloud"
+            ? "kimi-k2.6"
+            : "gpt-5.4");
     const mode = body.mode || "prototype";
     const prompt = String(body.prompt || "").trim();
     if (!prompt) throw new Error("Prompt is required.");

--- a/api/mockups.js
+++ b/api/mockups.js
@@ -1,0 +1,84 @@
+const crypto = require("node:crypto");
+
+function getConvexHttpUrl() {
+  const explicit = process.env.CONVEX_HTTP_URL || process.env.CONVEX_SITE_URL;
+  if (explicit) return explicit.replace(/\/$/, "");
+
+  const convexUrl = process.env.VITE_CONVEX_URL || process.env.CONVEX_URL;
+  if (!convexUrl) return "";
+  return convexUrl.replace(/\/$/, "").replace(".convex.cloud", ".convex.site");
+}
+
+function getOrigin(req) {
+  const proto = req.headers["x-forwarded-proto"] || "https";
+  const host = req.headers["x-forwarded-host"] || req.headers.host;
+  return `${proto}://${host}`;
+}
+
+function newShareId(title = "mockup") {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 36) || "mockup";
+  return `${slug}-${crypto.randomBytes(4).toString("hex")}`;
+}
+
+async function convexRequest(path, init) {
+  const baseUrl = getConvexHttpUrl();
+  if (!baseUrl) {
+    const error = new Error("Convex is not configured. Set CONVEX_HTTP_URL in Vercel to your Convex .convex.site URL.");
+    error.status = 503;
+    throw error;
+  }
+
+  const response = await fetch(`${baseUrl}${path}`, init);
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new Error(data.error || `Convex request failed with ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+  return data;
+}
+
+module.exports = async function handler(req, res) {
+  try {
+    if (req.method === "GET") {
+      const url = new URL(req.url, "http://localhost");
+      const id = url.searchParams.get("id");
+      if (!id) return res.status(400).json({ error: "id is required." });
+      const data = await convexRequest(`/mockups?id=${encodeURIComponent(id)}`, { method: "GET" });
+      return res.status(200).json(data);
+    }
+
+    if (req.method === "POST") {
+      const body = req.body || {};
+      const title = String(body.title || body.clientName || "Client mockup").trim();
+      const shareId = body.shareId || newShareId(title);
+      const data = await convexRequest("/mockups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shareId,
+          title,
+          clientName: body.clientName,
+          contact: body.contact,
+          prompt: body.prompt,
+          html: body.html,
+          status: body.status || "draft",
+        }),
+      });
+
+      return res.status(200).json({
+        ...data,
+        shareId,
+        shareUrl: `${getOrigin(req)}/mockup/${shareId}`,
+      });
+    }
+
+    return res.status(405).json({ error: "Method not allowed" });
+  } catch (error) {
+    return res.status(error.status || 500).json({ error: error.message || "Unexpected server error" });
+  }
+};

--- a/api/mockups.js
+++ b/api/mockups.js
@@ -44,12 +44,23 @@ async function convexRequest(path, init) {
 
 module.exports = async function handler(req, res) {
   try {
+    const url = new URL(req.url, "http://localhost");
+
     if (req.method === "GET") {
-      const url = new URL(req.url, "http://localhost");
       const id = url.searchParams.get("id");
-      if (!id) return res.status(400).json({ error: "id is required." });
-      const data = await convexRequest(`/mockups?id=${encodeURIComponent(id)}`, { method: "GET" });
-      return res.status(200).json(data);
+      if (id) {
+        const data = await convexRequest(`/mockups?id=${encodeURIComponent(id)}`, { method: "GET" });
+        return res.status(200).json(data);
+      }
+      const limit = url.searchParams.get("limit");
+      const qs = limit ? `?limit=${encodeURIComponent(limit)}` : "";
+      const data = await convexRequest(`/mockups${qs}`, { method: "GET" });
+      const origin = getOrigin(req);
+      const mockups = (data.mockups || []).map((mockup) => ({
+        ...mockup,
+        shareUrl: `${origin}/mockup/${mockup.shareId}`,
+      }));
+      return res.status(200).json({ mockups });
     }
 
     if (req.method === "POST") {
@@ -75,6 +86,29 @@ module.exports = async function handler(req, res) {
         shareId,
         shareUrl: `${getOrigin(req)}/mockup/${shareId}`,
       });
+    }
+
+    if (req.method === "PATCH") {
+      const body = req.body || {};
+      if (!body.shareId) {
+        return res.status(400).json({ error: "shareId is required." });
+      }
+      const data = await convexRequest("/mockups", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return res.status(200).json({
+        ...data,
+        shareUrl: `${getOrigin(req)}/mockup/${body.shareId}`,
+      });
+    }
+
+    if (req.method === "DELETE") {
+      const id = url.searchParams.get("id");
+      if (!id) return res.status(400).json({ error: "id is required." });
+      const data = await convexRequest(`/mockups?id=${encodeURIComponent(id)}`, { method: "DELETE" });
+      return res.status(200).json(data);
     }
 
     return res.status(405).json({ error: "Method not allowed" });

--- a/api/ollama-models.js
+++ b/api/ollama-models.js
@@ -1,0 +1,13 @@
+module.exports = async function handler(_req, res) {
+  try {
+    const response = await fetch("http://localhost:11434/api/tags", {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!response.ok) return res.status(200).json({ models: [] });
+    const json = await response.json();
+    const models = (json.models || []).map((item) => item.name).filter(Boolean);
+    res.status(200).json({ models });
+  } catch {
+    res.status(200).json({ models: [] });
+  }
+};

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1,0 +1,51 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as http from "../http.js";
+import type * as mockups from "../mockups.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  http: typeof http;
+  mockups: typeof mockups;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {};

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -6,7 +6,7 @@ const http = httpRouter();
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
 };
 
@@ -58,12 +58,53 @@ http.route({
   handler: httpAction(async (ctx, request) => {
     const { searchParams } = new URL(request.url);
     const shareId = searchParams.get("id");
+
+    if (shareId) {
+      const mockup = await ctx.runQuery(internal.mockups.get, { shareId });
+      if (!mockup) return json({ error: "Mockup not found." }, { status: 404 });
+      return json({ mockup });
+    }
+
+    const limitParam = searchParams.get("limit");
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+    const mockups = await ctx.runQuery(internal.mockups.list, {
+      limit: Number.isFinite(limit) ? limit : undefined,
+    });
+    return json({ mockups });
+  }),
+});
+
+http.route({
+  path: "/mockups",
+  method: "PATCH",
+  handler: httpAction(async (ctx, request) => {
+    const body = await request.json();
+    if (!body?.shareId) {
+      return json({ error: "shareId is required." }, { status: 400 });
+    }
+    const updated = await ctx.runMutation(internal.mockups.update, {
+      shareId: String(body.shareId),
+      title: body.title !== undefined ? String(body.title) : undefined,
+      clientName: body.clientName !== undefined ? String(body.clientName) : undefined,
+      contact: body.contact !== undefined ? String(body.contact) : undefined,
+      status: body.status !== undefined ? String(body.status) : undefined,
+      html: body.html !== undefined ? String(body.html) : undefined,
+      now: Date.now(),
+    });
+    if (!updated) return json({ error: "Mockup not found." }, { status: 404 });
+    return json({ mockup: updated });
+  }),
+});
+
+http.route({
+  path: "/mockups",
+  method: "DELETE",
+  handler: httpAction(async (ctx, request) => {
+    const { searchParams } = new URL(request.url);
+    const shareId = searchParams.get("id");
     if (!shareId) return json({ error: "id is required." }, { status: 400 });
-
-    const mockup = await ctx.runQuery(internal.mockups.get, { shareId });
-    if (!mockup) return json({ error: "Mockup not found." }, { status: 404 });
-
-    return json({ mockup });
+    const result = await ctx.runMutation(internal.mockups.remove, { shareId });
+    return json(result);
   }),
 });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,0 +1,70 @@
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+const http = httpRouter();
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+function json(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...corsHeaders,
+      ...init.headers,
+    },
+  });
+}
+
+http.route({
+  path: "/mockups",
+  method: "OPTIONS",
+  handler: httpAction(async () => new Response(null, { status: 204, headers: corsHeaders })),
+});
+
+http.route({
+  path: "/mockups",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const body = await request.json();
+    if (!body?.shareId || !body?.title || !body?.html) {
+      return json({ error: "shareId, title, and html are required." }, { status: 400 });
+    }
+
+    const now = Date.now();
+    const mockup = await ctx.runMutation(internal.mockups.create, {
+      shareId: String(body.shareId),
+      title: String(body.title),
+      clientName: body.clientName ? String(body.clientName) : undefined,
+      contact: body.contact ? String(body.contact) : undefined,
+      prompt: body.prompt ? String(body.prompt) : undefined,
+      html: String(body.html),
+      status: body.status ? String(body.status) : "draft",
+      now,
+    });
+
+    return json({ mockup });
+  }),
+});
+
+http.route({
+  path: "/mockups",
+  method: "GET",
+  handler: httpAction(async (ctx, request) => {
+    const { searchParams } = new URL(request.url);
+    const shareId = searchParams.get("id");
+    if (!shareId) return json({ error: "id is required." }, { status: 400 });
+
+    const mockup = await ctx.runQuery(internal.mockups.get, { shareId });
+    if (!mockup) return json({ error: "Mockup not found." }, { status: 404 });
+
+    return json({ mockup });
+  }),
+});
+
+export default http;

--- a/convex/mockups.ts
+++ b/convex/mockups.ts
@@ -1,0 +1,50 @@
+import { v } from "convex/values";
+import { internalMutation, internalQuery } from "./_generated/server";
+
+export const create = internalMutation({
+  args: {
+    shareId: v.string(),
+    title: v.string(),
+    clientName: v.optional(v.string()),
+    contact: v.optional(v.string()),
+    prompt: v.optional(v.string()),
+    html: v.string(),
+    status: v.string(),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("mockups")
+      .withIndex("by_shareId", (q) => q.eq("shareId", args.shareId))
+      .unique();
+
+    const doc = {
+      shareId: args.shareId,
+      title: args.title,
+      clientName: args.clientName,
+      contact: args.contact,
+      prompt: args.prompt,
+      html: args.html,
+      status: args.status,
+      updatedAt: args.now,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, doc);
+      return { ...existing, ...doc };
+    }
+
+    const id = await ctx.db.insert("mockups", { ...doc, createdAt: args.now });
+    return await ctx.db.get(id);
+  },
+});
+
+export const get = internalQuery({
+  args: { shareId: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("mockups")
+      .withIndex("by_shareId", (q) => q.eq("shareId", args.shareId))
+      .unique();
+  },
+});

--- a/convex/mockups.ts
+++ b/convex/mockups.ts
@@ -48,3 +48,57 @@ export const get = internalQuery({
       .unique();
   },
 });
+
+export const list = internalQuery({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const limit = Math.min(Math.max(args.limit ?? 100, 1), 500);
+    const rows = await ctx.db.query("mockups").order("desc").take(limit);
+    return rows.map(({ html, ...rest }) => ({
+      ...rest,
+      htmlSize: html.length,
+    }));
+  },
+});
+
+export const update = internalMutation({
+  args: {
+    shareId: v.string(),
+    title: v.optional(v.string()),
+    clientName: v.optional(v.string()),
+    contact: v.optional(v.string()),
+    status: v.optional(v.string()),
+    html: v.optional(v.string()),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("mockups")
+      .withIndex("by_shareId", (q) => q.eq("shareId", args.shareId))
+      .unique();
+    if (!existing) return null;
+
+    const patch: Record<string, unknown> = { updatedAt: args.now };
+    if (args.title !== undefined) patch.title = args.title;
+    if (args.clientName !== undefined) patch.clientName = args.clientName;
+    if (args.contact !== undefined) patch.contact = args.contact;
+    if (args.status !== undefined) patch.status = args.status;
+    if (args.html !== undefined) patch.html = args.html;
+
+    await ctx.db.patch(existing._id, patch);
+    return await ctx.db.get(existing._id);
+  },
+});
+
+export const remove = internalMutation({
+  args: { shareId: v.string() },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("mockups")
+      .withIndex("by_shareId", (q) => q.eq("shareId", args.shareId))
+      .unique();
+    if (!existing) return { removed: false };
+    await ctx.db.delete(existing._id);
+    return { removed: true };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,0 +1,16 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  mockups: defineTable({
+    shareId: v.string(),
+    title: v.string(),
+    clientName: v.optional(v.string()),
+    contact: v.optional(v.string()),
+    prompt: v.optional(v.string()),
+    html: v.string(),
+    status: v.string(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  }).index("by_shareId", ["shareId"]),
+});

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  /* This TypeScript project config describes the environment that
+   * Convex functions run in and is used to typecheck them.
+   * You can modify it, but some settings are required to use Convex.
+   */
+  "compilerOptions": {
+    /* These settings are not required by Convex and can be modified. */
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+
+    /* These compiler options are required by Convex */
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,576 @@
+{
+  "name": "huashu-design",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "convex": "^1.36.1"
+      },
+      "engines": {
+        "node": "22.x"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convex": {
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.36.1.tgz",
+      "integrity": "sha512-NVnwNqU+h8jyPuS0Itvj4MPH9c2yF+tA/RNoSDpCqiLhmYD4+kZxm0dDkVM0QDzz66wem9NqheBb9YQGsHwzBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esbuild": "0.27.0",
+        "prettier": "^3.0.0",
+        "ws": "8.18.0"
+      },
+      "bin": {
+        "convex": "bin/main.js"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "@auth0/auth0-react": "^2.0.1",
+        "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+        "@clerk/react": "^6.4.3",
+        "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@auth0/auth0-react": {
+          "optional": true
+        },
+        "@clerk/clerk-react": {
+          "optional": true
+        },
+        "@clerk/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "engines": {
+    "node": "22.x"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
   "private": true,
+  "scripts": {
+    "convex:dev": "convex dev",
+    "convex:deploy": "convex deploy"
+  },
   "engines": {
     "node": "22.x"
+  },
+  "devDependencies": {
+    "convex": "^1.36.1"
   }
 }

--- a/references/landing-pages.md
+++ b/references/landing-pages.md
@@ -1,0 +1,108 @@
+# Landing Page Track
+
+> First-class deliverable: client-ready marketing landing pages.
+> Used when `mode === "prototype"` in the webui or the user asks for "a landing page", "marketing site", "homepage", "client mockup", etc.
+>
+> This is **not** the App-prototype track (no iPhone bezel, no multi-screen state machine). Output is a single long-scroll HTML page that could plausibly be hosted as `business.com`.
+
+---
+
+## 1 · What you're producing
+
+A self-contained, single-file HTML document the user can show a real prospect and say "this is what your site could look like." Therefore:
+
+- **Content must look real.** Use specific business names, service descriptions, prices, locations, hours. Never `Lorem ipsum`. Never `[Your Business Here]`. If the user didn't supply specifics, infer plausible ones from the brief (and say which you invented in the delivery message).
+- **Sections must look like a real designer chose them.** Don't dump every section template you know — pick the 4–7 that fit the business type. A barbershop doesn't need a pricing table comparison; a SaaS doesn't need an "opening hours" block.
+- **Polish > completeness.** Better to ship 5 great sections than 9 mediocre ones.
+
+---
+
+## 2 · Section library
+
+Pick from these. Don't invent generic ones ("Our Mission", "Why Choose Us") — use the specific intent below.
+
+### Hero (always)
+- **Anchor**: 1 headline (≤10 words, benefit not feature), 1 sub (≤25 words), 1 primary CTA, 1 hero visual (real photo, real product UI, or real brand mark — never a CSS gradient blob)
+- **Variants**: split (copy left, image right) · centered (single column, large image below) · full-bleed (image is the background)
+- **Anti-pattern**: vague aspirational copy ("Empowering tomorrow's vision"), three-button CTA stack, decorative hero shapes
+
+### Social proof (recommended, place near hero)
+- Logos of customers/clients, OR named testimonials with photo + role + company, OR a single oversized stat ("3,200 weddings shot since 2014")
+- One row, restrained. Six logos > thirty.
+
+### Features / What we do
+- **For services** (restaurants, agencies, trades): use a 3–4 item grid with photo + short description per service, not icon + bullet
+- **For SaaS / digital products**: use feature blocks alternating image-left / image-right, real UI screenshot per feature
+- **Anti-pattern**: identical-shape cards with three Lucide icons in primary colour
+
+### Gallery / Portfolio (services with visual output)
+- Restaurants: dish photos. Salons: hair shots. Agencies: case study thumbnails. Photographers: portfolio grid.
+- Use real-aspect-ratio image grids (CSS Grid with `aspect-ratio: 4/3`), not equal squares
+
+### Pricing (SaaS / subscription / packaged services only)
+- 2–3 tiers max, middle highlighted. Never 4+ tiers in a marketing page.
+- Each tier: name, price + period, 1-line positioning, 4–6 included items (concrete: "Up to 5 users" not "Team collaboration"), CTA
+- **Skip entirely** for restaurants, single-service businesses, custom-quote work
+
+### Testimonials (full block, distinct from social proof bar)
+- 1 oversized quote OR 3 medium ones. Always include name, role, company, photo. Vague "John D., CEO" feels fake.
+
+### FAQ (when objections are predictable)
+- 4–6 questions max. Real user questions, not marketing-disguised features.
+- Use `<details>` for native expand/collapse — don't reinvent with JS.
+
+### Booking / Contact / CTA closer (always — last section before footer)
+- Restaurants/local: opening hours, address with map, phone, booking widget placeholder
+- Services: contact form (name, email, message — three fields max) or "Book a call" CTA
+- SaaS: trial CTA + "Talk to sales" secondary
+- Always include the primary CTA from the hero, repeated.
+
+### Footer
+- 3–4 columns max. Logo + tagline, nav, contact, legal. Don't pad with empty link columns.
+
+---
+
+## 3 · Section selection by business type
+
+| Business type | Required sections (in order) |
+|---|---|
+| Restaurant / café / bar | Hero · Menu highlights · Gallery · Reviews · Hours/location · Booking CTA · Footer |
+| Local trade (plumber, electrician, barber) | Hero · Services grid · Service area map · Reviews · Booking/phone CTA · Footer |
+| Agency / studio | Hero · Selected work grid · Services list · Process · Testimonials · Contact · Footer |
+| SaaS / digital product | Hero · Logo bar · Features (alternating) · How it works · Pricing · FAQ · CTA · Footer |
+| Personal brand (coach, consultant) | Hero · About / story · Services or offerings · Testimonials · Lead magnet or CTA · Footer |
+| E-commerce single-product | Hero · Product showcase · Features · Reviews · Buy CTA · FAQ · Footer |
+| Event / launch | Hero (with date) · What/why · Speakers or agenda · Logos · Register CTA · Footer |
+
+If the business doesn't fit, pick the closest row and adjust. Never just stack every section.
+
+---
+
+## 4 · Anti-slop checklist (apply before delivery)
+
+- [ ] No purple-to-pink gradients. No `linear-gradient(135deg, ...)` as a hero background unless brand-justified.
+- [ ] No emoji-as-icon (🚀 in a feature card). Use real SVG marks or none.
+- [ ] No "Trusted by 10,000+ teams worldwide" without specifying who.
+- [ ] No three-card grid where each card is `<icon><h3><p>` and nothing distinguishes them.
+- [ ] No `<button>Get Started</button>` as the only CTA copy. Be specific: "Book a table", "Start a 14-day trial", "Get a free quote".
+- [ ] Every image is real (Unsplash/Wikimedia/brand-supplied) or a real product UI screenshot. No CSS-drawn product silhouettes.
+- [ ] If a brand was named, the brand's logo is on the page (top-left of header, in the footer, ideally both).
+- [ ] Mobile breakpoint actually works. Test with the iframe at 375px width before delivery.
+
+---
+
+## 5 · Asset rules (delegates to core asset protocol in SKILL.md)
+
+If the user named a real business: **fetch their logo and at least one real photo of the business/product before generating.** Search the web. If you can't find them, ask — don't fall back to a CSS rectangle labeled "[Logo]".
+
+If the business is fictional or the user explicitly said "no brand assets, just make it look good": pull stock photos from Unsplash that match the business type (`https://source.unsplash.com/...` or specific Unsplash photo URLs you've verified). Use one consistent visual treatment across all photos (e.g., all warm-toned, all desaturated) — mismatched photo styles is a top slop tell.
+
+---
+
+## 6 · Output format
+
+Single HTML document. Inline `<style>`. No build step, no external CSS files. JavaScript only if a section genuinely needs it (FAQ accordion can use `<details>`, booking forms can be no-JS).
+
+Header: include `<meta name="viewport" content="width=device-width, initial-scale=1">`. Use system font stack or one Google Font max — don't load three Google Fonts.
+
+The page must render correctly when loaded in an `<iframe sandbox="allow-scripts">` (this is how the webui previews it).

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,12 @@
   "installCommand": "npm install && cd webui && npm install",
   "buildCommand": "cd webui && npm run build",
   "outputDirectory": "webui/dist",
+  "rewrites": [
+    {
+      "source": "/mockup/:path*",
+      "destination": "/"
+    }
+  ],
   "functions": {
     "api/*.js": {
       "includeFiles": "{SKILL.md,references/**,demos/**,assets/showcases/**}"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "installCommand": "cd webui && npm install",
+  "buildCommand": "cd webui && npm run build",
+  "outputDirectory": "webui/dist",
+  "functions": {
+    "api/*.js": {
+      "includeFiles": "{SKILL.md,references/**,demos/**,assets/showcases/**}"
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "cd webui && npm install",
+  "installCommand": "npm install && cd webui && npm install",
   "buildCommand": "cd webui && npm run build",
   "outputDirectory": "webui/dist",
   "functions": {

--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+verification-*.png
+public/demos/
+public/skill-assets/

--- a/webui/README.md
+++ b/webui/README.md
@@ -30,3 +30,34 @@ API keys are sent to the server for the current generation request but are not p
 ## Notes
 
 The UI reads skill context from the parent repo and sends it to the selected model with your brief. Generated HTML appears in the preview iframe and editable code tab.
+
+## Client review links
+
+Saving client review links requires Convex.
+
+Local test:
+
+```bash
+cd /Users/judeokun/Documents/GitHub/huashu-design
+npx convex dev
+```
+
+Cloud deploy:
+
+```bash
+cd /Users/judeokun/Documents/GitHub/huashu-design
+npx convex login
+npx convex deploy
+```
+
+After Convex is deployed, copy the Convex HTTP Actions URL ending in `.convex.site` and set this Vercel environment variable:
+
+```text
+CONVEX_HTTP_URL=https://<your-deployment>.convex.site
+```
+
+Then redeploy Vercel. The app will save generated HTML mockups and return public links like:
+
+```text
+https://huashu-design.vercel.app/mockup/<share-id>
+```

--- a/webui/README.md
+++ b/webui/README.md
@@ -18,11 +18,14 @@ http://localhost:5177
 
 ## Providers
 
-- Ollama: `http://localhost:11434/v1`
+- Ollama Local: `http://localhost:11434/v1`
+- Ollama Cloud: `https://ollama.com/v1`
 - OpenAI-compatible APIs: any `/v1/chat/completions` endpoint
 - Anthropic: native `/v1/messages` endpoint
 
-Local Ollama normally does not need a real API key. Some SDKs require a non-empty value, but Ollama ignores it. Hosted Ollama or proxy gateways may require a real key.
+Local Ollama normally does not need a real API key. Some SDKs require a non-empty value, but Ollama ignores it. Ollama Cloud and hosted proxy gateways require a real key.
+
+API keys are sent to the server for the current generation request but are not persisted in browser local storage by this UI.
 
 ## Notes
 

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,0 +1,29 @@
+# Huashu Design Studio Web UI
+
+Local web interface for the `huashu-design` skill.
+
+## Run
+
+```bash
+cd /Users/judeokun/Documents/GitHub/huashu-design/webui
+npm install
+npm run dev
+```
+
+Open:
+
+```text
+http://localhost:5177
+```
+
+## Providers
+
+- Ollama: `http://localhost:11434/v1`
+- OpenAI-compatible APIs: any `/v1/chat/completions` endpoint
+- Anthropic: native `/v1/messages` endpoint
+
+Local Ollama normally does not need a real API key. Some SDKs require a non-empty value, but Ollama ignores it. Hosted Ollama or proxy gateways may require a real key.
+
+## Notes
+
+The UI reads skill context from the parent repo and sends it to the selected model with your brief. Generated HTML appears in the preview iframe and editable code tab.

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Huashu Design Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,0 +1,2505 @@
+{
+  "name": "huashu-design-webui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "huashu-design-webui",
+      "version": "0.1.0",
+      "dependencies": {
+        "@vitejs/plugin-react": "^5.0.0",
+        "express": "^5.1.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "vite": "^7.0.0"
+      },
+      "devDependencies": {
+        "playwright": "^1.59.1"
+      },
+      "engines": {
+        "node": "22.x"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.23",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
+      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "license": "ISC"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    }
+  }
+}

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "huashu-design-webui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": "22.x"
+  },
+  "scripts": {
+    "dev": "NODE_ENV=development node server/index.js",
+    "prebuild": "node scripts/prepare-public.mjs",
+    "build": "vite build",
+    "start": "NODE_ENV=production node server/index.js"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "^5.0.0",
+    "express": "^5.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "vite": "^7.0.0"
+  },
+  "devDependencies": {
+    "playwright": "^1.59.1"
+  }
+}

--- a/webui/scripts/prepare-public.mjs
+++ b/webui/scripts/prepare-public.mjs
@@ -1,0 +1,13 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const webuiRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(webuiRoot, "..");
+const publicRoot = path.join(webuiRoot, "public");
+
+await fs.mkdir(path.join(publicRoot, "skill-assets"), { recursive: true });
+await fs.copyFile(path.join(repoRoot, "assets", "banner.svg"), path.join(publicRoot, "skill-assets", "banner.svg"));
+await fs.rm(path.join(publicRoot, "demos"), { recursive: true, force: true });
+await fs.cp(path.join(repoRoot, "demos"), path.join(publicRoot, "demos"), { recursive: true });

--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -52,7 +52,7 @@ async function listHtml(dir) {
 }
 
 async function buildContext(mode) {
-  const [skill, workflow, styles, verification, animations, slides, demos] =
+  const [skill, workflow, styles, verification, animations, slides, landing, demos] =
     await Promise.all([
       readText("SKILL.md", 12000),
       readText("references/workflow.md", 7000),
@@ -60,6 +60,7 @@ async function buildContext(mode) {
       readText("references/verification.md", 5000),
       mode === "motion" ? readText("references/animations.md", 7000) : "",
       mode === "slides" ? readText("references/slide-decks.md", 7000) : "",
+      mode === "prototype" ? readText("references/landing-pages.md", 7000) : "",
       listHtml("demos"),
     ]);
 
@@ -69,7 +70,7 @@ async function buildContext(mode) {
     "Generate complete, self-contained HTML. Inline CSS and JavaScript are preferred.",
     "Use high-quality layout, restrained interface density, real typography decisions, and clear hierarchy.",
     "Avoid generic AI design defaults: purple gradients, emoji-as-icons, decorative blobs, and fake product silhouettes.",
-    "For clickable prototypes, make the interactions work in the HTML.",
+    "For prototypes the user calls a 'website' or 'landing page', follow the Landing Page Track: pick sections by business type, use real-feeling copy, and run the anti-slop checklist before delivery.",
     "For slide decks, use 16:9 stage sizing and keyboard navigation if relevant.",
     "For animations, expose a duration comment and keep the first frame renderable.",
     "Do not include markdown fences unless the user specifically asks for markdown.",
@@ -88,6 +89,7 @@ async function buildContext(mode) {
     "",
     mode === "motion" ? `Animation excerpt:\n${animations}` : "",
     mode === "slides" ? `Slide excerpt:\n${slides}` : "",
+    mode === "prototype" ? `Landing page track:\n${landing}` : "",
     "",
     "Verification excerpt:",
     verification,
@@ -105,6 +107,25 @@ function providerDefaults(provider) {
     return { baseUrl: "https://api.anthropic.com", model: "claude-sonnet-4-6" };
   }
   return { baseUrl: "https://api.openai.com/v1", model: "gpt-5.4" };
+}
+
+function resolveApiKey(provider, supplied) {
+  if (supplied) return supplied;
+  if (provider === "openai") return process.env.OPENAI_API_KEY || "";
+  if (provider === "anthropic") return process.env.ANTHROPIC_API_KEY || "";
+  if (provider === "ollama-cloud") return process.env.OLLAMA_API_KEY || "";
+  return "";
+}
+
+function providerRequiresKey(provider) {
+  return provider === "openai" || provider === "anthropic" || provider === "ollama-cloud";
+}
+
+function envVarNameFor(provider) {
+  if (provider === "openai") return "OPENAI_API_KEY";
+  if (provider === "anthropic") return "ANTHROPIC_API_KEY";
+  if (provider === "ollama-cloud") return "OLLAMA_API_KEY";
+  return "";
 }
 
 async function getLocalOllamaModels() {
@@ -237,16 +258,25 @@ app.get("/api/ollama-models", async (_req, res) => {
 });
 
 app.post("/api/generate", async (req, res, next) => {
+  const provider = (req.body && req.body.provider) || "ollama";
   try {
     const body = req.body || {};
-    const provider = body.provider || "ollama";
     const defaults = providerDefaults(provider);
     const baseUrl = body.baseUrl || defaults.baseUrl;
     let model = body.model || defaults.model;
     const prompt = String(body.prompt || "").trim();
     const mode = body.mode || "prototype";
+    const apiKey = resolveApiKey(provider, body.apiKey);
 
-    if (!prompt) throw new Error("Prompt is required.");
+    if (!prompt) {
+      return res.status(400).json({ error: "Prompt is required." });
+    }
+    if (providerRequiresKey(provider) && !apiKey) {
+      const envName = envVarNameFor(provider);
+      return res.status(400).json({
+        error: `${provider} requires an API key. Enter one in the API key field or set ${envName} in webui/.env.local (or the repo root .env.local).`,
+      });
+    }
     if (provider === "ollama") {
       const localModels = await getLocalOllamaModels();
       if (localModels.length && !localModels.includes(model)) {
@@ -265,11 +295,17 @@ app.post("/api/generate", async (req, res, next) => {
 
     const generated =
       provider === "anthropic"
-        ? await callAnthropic({ baseUrl, apiKey: body.apiKey, model, system, prompt: fullPrompt })
-        : await callOpenAICompatible({ baseUrl, apiKey: body.apiKey, model, system, prompt: fullPrompt });
+        ? await callAnthropic({ baseUrl, apiKey, model, system, prompt: fullPrompt })
+        : await callOpenAICompatible({ baseUrl, apiKey, model, system, prompt: fullPrompt });
 
     res.json({ html: stripFence(generated), model, provider });
   } catch (error) {
+    if (/^401\b/.test(error.message || "")) {
+      const envName = envVarNameFor(provider) || "the provider's API key";
+      return res.status(401).json({
+        error: `Provider rejected the API key (401). Double-check the key for ${provider}, or update ${envName} in .env.local.`,
+      });
+    }
     next(error);
   }
 });

--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -1,4 +1,5 @@
 import express from "express";
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +9,8 @@ const webuiRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(webuiRoot, "..");
 const isProd = process.env.NODE_ENV === "production";
 const port = Number(process.env.PORT || 5177);
+
+await loadLocalEnv();
 
 const app = express();
 app.use(express.json({ limit: "1mb" }));
@@ -21,6 +24,22 @@ function clip(text, max = 18000) {
 async function readText(relativePath, max) {
   const fullPath = path.join(repoRoot, relativePath);
   return clip(await fs.readFile(fullPath, "utf8"), max);
+}
+
+async function loadLocalEnv() {
+  if (isProd) return;
+  try {
+    const envPath = path.join(repoRoot, ".env.local");
+    const envText = await fs.readFile(envPath, "utf8");
+    for (const line of envText.split(/\r?\n/)) {
+      const match = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.+?)\s*$/);
+      if (match && !process.env[match[1]]) {
+        process.env[match[1]] = match[2].replace(/^['"]|['"]$/g, "");
+      }
+    }
+  } catch {
+    // Local Convex is optional; the save endpoint reports setup guidance.
+  }
 }
 
 async function listHtml(dir) {
@@ -162,6 +181,42 @@ function stripFence(output) {
   return match ? match[1].trim() : trimmed;
 }
 
+function getConvexHttpUrl() {
+  const explicit = process.env.CONVEX_HTTP_URL || process.env.CONVEX_SITE_URL;
+  if (explicit) return explicit.replace(/\/$/, "");
+
+  const convexUrl = process.env.VITE_CONVEX_URL || process.env.CONVEX_URL;
+  if (!convexUrl) return "";
+  return convexUrl.replace(/\/$/, "").replace(".convex.cloud", ".convex.site");
+}
+
+function newShareId(title = "mockup") {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 36) || "mockup";
+  return `${slug}-${crypto.randomBytes(4).toString("hex")}`;
+}
+
+async function convexRequest(pathname, init) {
+  const baseUrl = getConvexHttpUrl();
+  if (!baseUrl) {
+    const error = new Error("Convex is not configured. Set CONVEX_HTTP_URL to your Convex .convex.site URL.");
+    error.status = 503;
+    throw error;
+  }
+
+  const response = await fetch(`${baseUrl}${pathname}`, init);
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new Error(data.error || `Convex request failed with ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+  return data;
+}
+
 app.get("/api/context", async (_req, res, next) => {
   try {
     const [demos, showcases] = await Promise.all([
@@ -214,6 +269,45 @@ app.post("/api/generate", async (req, res, next) => {
         : await callOpenAICompatible({ baseUrl, apiKey: body.apiKey, model, system, prompt: fullPrompt });
 
     res.json({ html: stripFence(generated), model, provider });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get("/api/mockups", async (req, res, next) => {
+  try {
+    const id = String(req.query.id || "");
+    if (!id) return res.status(400).json({ error: "id is required." });
+    res.json(await convexRequest(`/mockups?id=${encodeURIComponent(id)}`, { method: "GET" }));
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post("/api/mockups", async (req, res, next) => {
+  try {
+    const body = req.body || {};
+    const title = String(body.title || body.clientName || "Client mockup").trim();
+    const shareId = body.shareId || newShareId(title);
+    const data = await convexRequest("/mockups", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        shareId,
+        title,
+        clientName: body.clientName,
+        contact: body.contact,
+        prompt: body.prompt,
+        html: body.html,
+        status: body.status || "draft",
+      }),
+    });
+
+    res.json({
+      ...data,
+      shareId,
+      shareUrl: `${req.protocol}://${req.get("host")}/mockup/${shareId}`,
+    });
   } catch (error) {
     next(error);
   }

--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -1,0 +1,240 @@
+import express from "express";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const webuiRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(webuiRoot, "..");
+const isProd = process.env.NODE_ENV === "production";
+const port = Number(process.env.PORT || 5177);
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+app.use("/skill-assets", express.static(path.join(repoRoot, "assets")));
+app.use("/demos", express.static(path.join(repoRoot, "demos")));
+
+function clip(text, max = 18000) {
+  return text.length > max ? `${text.slice(0, max)}\n\n[clipped]` : text;
+}
+
+async function readText(relativePath, max) {
+  const fullPath = path.join(repoRoot, relativePath);
+  return clip(await fs.readFile(fullPath, "utf8"), max);
+}
+
+async function listHtml(dir) {
+  try {
+    const entries = await fs.readdir(path.join(repoRoot, dir));
+    return entries.filter((entry) => entry.endsWith(".html")).sort();
+  } catch {
+    return [];
+  }
+}
+
+async function buildContext(mode) {
+  const [skill, workflow, styles, verification, animations, slides, demos] =
+    await Promise.all([
+      readText("SKILL.md", 12000),
+      readText("references/workflow.md", 7000),
+      readText("references/design-styles.md", 8000),
+      readText("references/verification.md", 5000),
+      mode === "motion" ? readText("references/animations.md", 7000) : "",
+      mode === "slides" ? readText("references/slide-decks.md", 7000) : "",
+      listHtml("demos"),
+    ]);
+
+  return [
+    "You are Huashu Design Studio, an HTML-native design agent.",
+    "Use the huashu-design skill workflow, but respond with the requested artifact only.",
+    "Generate complete, self-contained HTML. Inline CSS and JavaScript are preferred.",
+    "Use high-quality layout, restrained interface density, real typography decisions, and clear hierarchy.",
+    "Avoid generic AI design defaults: purple gradients, emoji-as-icons, decorative blobs, and fake product silhouettes.",
+    "For clickable prototypes, make the interactions work in the HTML.",
+    "For slide decks, use 16:9 stage sizing and keyboard navigation if relevant.",
+    "For animations, expose a duration comment and keep the first frame renderable.",
+    "Do not include markdown fences unless the user specifically asks for markdown.",
+    "",
+    "Available demo files:",
+    demos.join(", "),
+    "",
+    "Main skill excerpt:",
+    skill,
+    "",
+    "Workflow excerpt:",
+    workflow,
+    "",
+    "Design styles excerpt:",
+    styles,
+    "",
+    mode === "motion" ? `Animation excerpt:\n${animations}` : "",
+    mode === "slides" ? `Slide excerpt:\n${slides}` : "",
+    "",
+    "Verification excerpt:",
+    verification,
+  ].join("\n");
+}
+
+function providerDefaults(provider) {
+  if (provider === "ollama") {
+    return { baseUrl: "http://localhost:11434/v1", model: "kimi-k2.6:cloud" };
+  }
+  if (provider === "anthropic") {
+    return { baseUrl: "https://api.anthropic.com", model: "claude-sonnet-4-6" };
+  }
+  return { baseUrl: "https://api.openai.com/v1", model: "gpt-5.4" };
+}
+
+async function getLocalOllamaModels() {
+  try {
+    const response = await fetch("http://localhost:11434/api/tags", {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!response.ok) return [];
+    const json = await response.json();
+    return (json.models || []).map((item) => item.name).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function callOpenAICompatible({ baseUrl, apiKey, model, system, prompt }) {
+  const url = `${baseUrl.replace(/\/$/, "")}/chat/completions`;
+  const headers = { "Content-Type": "application/json" };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      temperature: 0.7,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: prompt },
+      ],
+    }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
+  }
+
+  const json = JSON.parse(text);
+  return json.choices?.[0]?.message?.content || "";
+}
+
+async function callAnthropic({ baseUrl, apiKey, model, system, prompt }) {
+  if (!apiKey) throw new Error("Anthropic requires an API key.");
+
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 8000,
+      temperature: 0.7,
+      system,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
+  }
+
+  const json = JSON.parse(text);
+  return json.content?.map((part) => part.text || "").join("") || "";
+}
+
+function stripFence(output) {
+  const trimmed = output.trim();
+  const match = trimmed.match(/^```(?:html)?\s*([\s\S]*?)\s*```$/i);
+  return match ? match[1].trim() : trimmed;
+}
+
+app.get("/api/context", async (_req, res, next) => {
+  try {
+    const [demos, showcases] = await Promise.all([
+      listHtml("demos"),
+      fs
+        .readdir(path.join(repoRoot, "assets", "showcases"), { withFileTypes: true })
+        .then((entries) => entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name))
+        .catch(() => []),
+    ]);
+    res.json({ repoRoot, demos, showcases });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get("/api/ollama-models", async (_req, res) => {
+  res.json({ models: await getLocalOllamaModels() });
+});
+
+app.post("/api/generate", async (req, res, next) => {
+  try {
+    const body = req.body || {};
+    const provider = body.provider || "ollama";
+    const defaults = providerDefaults(provider);
+    const baseUrl = body.baseUrl || defaults.baseUrl;
+    let model = body.model || defaults.model;
+    const prompt = String(body.prompt || "").trim();
+    const mode = body.mode || "prototype";
+
+    if (!prompt) throw new Error("Prompt is required.");
+    if (provider === "ollama") {
+      const localModels = await getLocalOllamaModels();
+      if (localModels.length && !localModels.includes(model)) {
+        model = localModels[0];
+      }
+    }
+
+    const system = await buildContext(mode);
+    const fullPrompt = [
+      `Mode: ${mode}`,
+      "Return a complete HTML document that can be loaded in an iframe preview.",
+      "If the user asks for variants, include an in-page variant selector.",
+      "",
+      prompt,
+    ].join("\n");
+
+    const generated =
+      provider === "anthropic"
+        ? await callAnthropic({ baseUrl, apiKey: body.apiKey, model, system, prompt: fullPrompt })
+        : await callOpenAICompatible({ baseUrl, apiKey: body.apiKey, model, system, prompt: fullPrompt });
+
+    res.json({ html: stripFence(generated), model, provider });
+  } catch (error) {
+    next(error);
+  }
+});
+
+if (isProd) {
+  app.use(express.static(path.join(webuiRoot, "dist")));
+  app.get("*", (_req, res) => {
+    res.sendFile(path.join(webuiRoot, "dist", "index.html"));
+  });
+} else {
+  const { createServer } = await import("vite");
+  const vite = await createServer({
+    root: webuiRoot,
+    server: { middlewareMode: true },
+    appType: "spa",
+  });
+  app.use(vite.middlewares);
+}
+
+app.use((error, _req, res, _next) => {
+  res.status(500).json({ error: error.message || "Unexpected server error" });
+});
+
+app.listen(port, () => {
+  console.log(`Huashu Design Studio running at http://localhost:${port}`);
+});

--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -79,6 +79,9 @@ function providerDefaults(provider) {
   if (provider === "ollama") {
     return { baseUrl: "http://localhost:11434/v1", model: "kimi-k2.6:cloud" };
   }
+  if (provider === "ollama-cloud") {
+    return { baseUrl: "https://ollama.com/v1", model: "kimi-k2.6" };
+  }
   if (provider === "anthropic") {
     return { baseUrl: "https://api.anthropic.com", model: "claude-sonnet-4-6" };
   }

--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -376,9 +376,19 @@ app.post("/api/generate", async (req, res) => {
 
 app.get("/api/mockups", async (req, res, next) => {
   try {
-    const id = String(req.query.id || "");
-    if (!id) return res.status(400).json({ error: "id is required." });
-    res.json(await convexRequest(`/mockups?id=${encodeURIComponent(id)}`, { method: "GET" }));
+    const id = req.query.id ? String(req.query.id) : "";
+    if (id) {
+      const data = await convexRequest(`/mockups?id=${encodeURIComponent(id)}`, { method: "GET" });
+      return res.json(data);
+    }
+    const limit = req.query.limit ? `?limit=${encodeURIComponent(String(req.query.limit))}` : "";
+    const data = await convexRequest(`/mockups${limit}`, { method: "GET" });
+    const origin = `${req.protocol}://${req.get("host")}`;
+    const mockups = (data.mockups || []).map((mockup) => ({
+      ...mockup,
+      shareUrl: `${origin}/mockup/${mockup.shareId}`,
+    }));
+    res.json({ mockups });
   } catch (error) {
     next(error);
   }
@@ -408,6 +418,35 @@ app.post("/api/mockups", async (req, res, next) => {
       shareId,
       shareUrl: `${req.protocol}://${req.get("host")}/mockup/${shareId}`,
     });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.patch("/api/mockups", async (req, res, next) => {
+  try {
+    const body = req.body || {};
+    if (!body.shareId) return res.status(400).json({ error: "shareId is required." });
+    const data = await convexRequest("/mockups", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    res.json({
+      ...data,
+      shareUrl: `${req.protocol}://${req.get("host")}/mockup/${body.shareId}`,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.delete("/api/mockups", async (req, res, next) => {
+  try {
+    const id = req.query.id ? String(req.query.id) : "";
+    if (!id) return res.status(400).json({ error: "id is required." });
+    const data = await convexRequest(`/mockups?id=${encodeURIComponent(id)}`, { method: "DELETE" });
+    res.json(data);
   } catch (error) {
     next(error);
   }

--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -141,17 +141,17 @@ async function getLocalOllamaModels() {
   }
 }
 
-async function callOpenAICompatible({ baseUrl, apiKey, model, system, prompt }) {
-  const url = `${baseUrl.replace(/\/$/, "")}/chat/completions`;
+async function streamOpenAICompatible({ baseUrl, apiKey, model, system, prompt, onDelta }) {
   const headers = { "Content-Type": "application/json" };
   if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
 
-  const response = await fetch(url, {
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}/chat/completions`, {
     method: "POST",
     headers,
     body: JSON.stringify({
       model,
       temperature: 0.7,
+      stream: true,
       messages: [
         { role: "system", content: system },
         { role: "user", content: prompt },
@@ -159,16 +159,38 @@ async function callOpenAICompatible({ baseUrl, apiKey, model, system, prompt }) 
     }),
   });
 
-  const text = await response.text();
   if (!response.ok) {
+    const text = await response.text();
     throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
   }
 
-  const json = JSON.parse(text);
-  return json.choices?.[0]?.message?.content || "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const payload = trimmed.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        const json = JSON.parse(payload);
+        const delta = json.choices?.[0]?.delta?.content;
+        if (delta) onDelta(delta);
+      } catch {
+        // tolerate malformed chunk
+      }
+    }
+  }
 }
 
-async function callAnthropic({ baseUrl, apiKey, model, system, prompt }) {
+async function streamAnthropic({ baseUrl, apiKey, model, system, prompt, onDelta }) {
   if (!apiKey) throw new Error("Anthropic requires an API key.");
 
   const response = await fetch(`${baseUrl.replace(/\/$/, "")}/v1/messages`, {
@@ -182,18 +204,42 @@ async function callAnthropic({ baseUrl, apiKey, model, system, prompt }) {
       model,
       max_tokens: 8000,
       temperature: 0.7,
+      stream: true,
       system,
       messages: [{ role: "user", content: prompt }],
     }),
   });
 
-  const text = await response.text();
   if (!response.ok) {
+    const text = await response.text();
     throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 600)}`);
   }
 
-  const json = JSON.parse(text);
-  return json.content?.map((part) => part.text || "").join("") || "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const events = buffer.split("\n\n");
+    buffer = events.pop() || "";
+    for (const ev of events) {
+      const dataLine = ev.split("\n").find((line) => line.startsWith("data:"));
+      if (!dataLine) continue;
+      const payload = dataLine.slice(5).trim();
+      if (!payload) continue;
+      try {
+        const json = JSON.parse(payload);
+        if (json.type === "content_block_delta" && json.delta?.type === "text_delta") {
+          onDelta(json.delta.text);
+        }
+      } catch {
+        // tolerate malformed chunk
+      }
+    }
+  }
 }
 
 function stripFence(output) {
@@ -257,33 +303,43 @@ app.get("/api/ollama-models", async (_req, res) => {
   res.json({ models: await getLocalOllamaModels() });
 });
 
-app.post("/api/generate", async (req, res, next) => {
+app.post("/api/generate", async (req, res) => {
   const provider = (req.body && req.body.provider) || "ollama";
+  const body = req.body || {};
+  const defaults = providerDefaults(provider);
+  const baseUrl = body.baseUrl || defaults.baseUrl;
+  let model = body.model || defaults.model;
+  const prompt = String(body.prompt || "").trim();
+  const mode = body.mode || "prototype";
+  const apiKey = resolveApiKey(provider, body.apiKey);
+
+  if (!prompt) {
+    return res.status(400).json({ error: "Prompt is required." });
+  }
+  if (providerRequiresKey(provider) && !apiKey) {
+    const envName = envVarNameFor(provider);
+    return res.status(400).json({
+      error: `${provider} requires an API key. Enter one in the API key field or set ${envName} in webui/.env.local (or the repo root .env.local).`,
+    });
+  }
+  if (provider === "ollama") {
+    const localModels = await getLocalOllamaModels();
+    if (localModels.length && !localModels.includes(model)) {
+      model = localModels[0];
+    }
+  }
+
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.setHeader("X-Accel-Buffering", "no");
+  if (typeof res.flushHeaders === "function") res.flushHeaders();
+
+  const writeEvent = (event, data) => {
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  };
+
   try {
-    const body = req.body || {};
-    const defaults = providerDefaults(provider);
-    const baseUrl = body.baseUrl || defaults.baseUrl;
-    let model = body.model || defaults.model;
-    const prompt = String(body.prompt || "").trim();
-    const mode = body.mode || "prototype";
-    const apiKey = resolveApiKey(provider, body.apiKey);
-
-    if (!prompt) {
-      return res.status(400).json({ error: "Prompt is required." });
-    }
-    if (providerRequiresKey(provider) && !apiKey) {
-      const envName = envVarNameFor(provider);
-      return res.status(400).json({
-        error: `${provider} requires an API key. Enter one in the API key field or set ${envName} in webui/.env.local (or the repo root .env.local).`,
-      });
-    }
-    if (provider === "ollama") {
-      const localModels = await getLocalOllamaModels();
-      if (localModels.length && !localModels.includes(model)) {
-        model = localModels[0];
-      }
-    }
-
     const system = await buildContext(mode);
     const fullPrompt = [
       `Mode: ${mode}`,
@@ -293,20 +349,28 @@ app.post("/api/generate", async (req, res, next) => {
       prompt,
     ].join("\n");
 
-    const generated =
-      provider === "anthropic"
-        ? await callAnthropic({ baseUrl, apiKey, model, system, prompt: fullPrompt })
-        : await callOpenAICompatible({ baseUrl, apiKey, model, system, prompt: fullPrompt });
+    writeEvent("start", { provider, model });
 
-    res.json({ html: stripFence(generated), model, provider });
+    const stream = provider === "anthropic" ? streamAnthropic : streamOpenAICompatible;
+    await stream({
+      baseUrl,
+      apiKey,
+      model,
+      system,
+      prompt: fullPrompt,
+      onDelta: (delta) => writeEvent("delta", { text: delta }),
+    });
+
+    writeEvent("done", { provider, model });
+    res.end();
   } catch (error) {
-    if (/^401\b/.test(error.message || "")) {
+    let message = error.message || "Unexpected server error";
+    if (/^401\b/.test(message)) {
       const envName = envVarNameFor(provider) || "the provider's API key";
-      return res.status(401).json({
-        error: `Provider rejected the API key (401). Double-check the key for ${provider}, or update ${envName} in .env.local.`,
-      });
+      message = `Provider rejected the API key (401). Double-check the key for ${provider}, or update ${envName} in .env.local.`;
     }
-    next(error);
+    writeEvent("error", { error: message });
+    res.end();
   }
 });
 

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -1,0 +1,248 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "./styles.css";
+
+const providerPresets = {
+  ollama: {
+    label: "Ollama",
+    baseUrl: "http://localhost:11434/v1",
+    model: "kimi-k2.6:cloud",
+    keyPlaceholder: "optional",
+  },
+  openai: {
+    label: "OpenAI",
+    baseUrl: "https://api.openai.com/v1",
+    model: "gpt-5.4",
+    keyPlaceholder: "sk-...",
+  },
+  anthropic: {
+    label: "Anthropic",
+    baseUrl: "https://api.anthropic.com",
+    model: "claude-sonnet-4-6",
+    keyPlaceholder: "sk-ant-...",
+  },
+  custom: {
+    label: "Custom",
+    baseUrl: "http://localhost:1234/v1",
+    model: "local-model",
+    keyPlaceholder: "optional",
+  },
+};
+
+const starterHtml = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Huashu Design Preview</title>
+  <style>
+    body { margin: 0; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #f7f3ea; color: #161616; }
+    .stage { min-height: 100vh; display: grid; place-items: center; padding: 48px; }
+    main { width: min(980px, 100%); display: grid; gap: 24px; }
+    h1 { font-size: clamp(44px, 7vw, 92px); line-height: .95; margin: 0; letter-spacing: 0; }
+    p { font-size: 20px; line-height: 1.5; max-width: 680px; margin: 0; color: #45423c; }
+    .bar { height: 12px; background: linear-gradient(90deg, #1e1e1e 0 42%, #d94f30 42% 68%, #2f735f 68%); border-radius: 999px; }
+  </style>
+</head>
+<body>
+  <section class="stage">
+    <main>
+      <div class="bar"></div>
+      <h1>Huashu Design Studio</h1>
+      <p>Choose a provider, describe the artifact, then generate a complete HTML design for this preview.</p>
+    </main>
+  </section>
+</body>
+</html>`;
+
+function getStoredSettings() {
+  try {
+    return JSON.parse(localStorage.getItem("huashu-webui-settings") || "{}");
+  } catch {
+    return {};
+  }
+}
+
+function App() {
+  const stored = useMemo(getStoredSettings, []);
+  const [provider, setProvider] = useState(stored.provider || "ollama");
+  const [baseUrl, setBaseUrl] = useState(stored.baseUrl || providerPresets.ollama.baseUrl);
+  const [model, setModel] = useState(stored.model || providerPresets.ollama.model);
+  const [apiKey, setApiKey] = useState(stored.apiKey || "");
+  const [mode, setMode] = useState(stored.mode || "prototype");
+  const [prompt, setPrompt] = useState(
+    stored.prompt ||
+      "Create a clickable iOS-style onboarding prototype for a focus timer app. Include 3 screens, stateful navigation, and one polished visual direction."
+  );
+  const [html, setHtml] = useState(starterHtml);
+  const [tab, setTab] = useState("preview");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [context, setContext] = useState(null);
+  const [ollamaModels, setOllamaModels] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/context")
+      .then((response) => response.json())
+      .then(setContext)
+      .catch(() => {});
+    fetch("/api/ollama-models")
+      .then((response) => response.json())
+      .then((data) => {
+        const models = data.models || [];
+        setOllamaModels(models);
+        if (!stored.model && models.length) setModel(models[0]);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(
+      "huashu-webui-settings",
+      JSON.stringify({ provider, baseUrl, model, apiKey, mode, prompt })
+    );
+  }, [provider, baseUrl, model, apiKey, mode, prompt]);
+
+  function chooseProvider(nextProvider) {
+    setProvider(nextProvider);
+    const preset = providerPresets[nextProvider];
+    setBaseUrl(preset.baseUrl);
+    setModel(preset.model);
+  }
+
+  async function generate() {
+    setBusy(true);
+    setError("");
+    try {
+      const response = await fetch("/api/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider, baseUrl, model, apiKey, mode, prompt }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Generation failed");
+      setHtml(data.html);
+      setTab("preview");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const preset = providerPresets[provider];
+
+  return (
+    <div className="app-shell">
+      <aside className="sidebar">
+        <div className="brand-row">
+          <img src="/skill-assets/banner.svg" alt="" />
+          <div>
+            <strong>Huashu Studio</strong>
+            <span>{context ? `${context.demos.length} demos loaded` : "Loading skill"}</span>
+          </div>
+        </div>
+
+        <section className="panel">
+          <label>Provider</label>
+          <div className="segmented">
+            {Object.entries(providerPresets).map(([key, item]) => (
+              <button
+                key={key}
+                className={provider === key ? "active" : ""}
+                onClick={() => chooseProvider(key)}
+                type="button"
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel grid">
+          <label htmlFor="base-url">Base URL</label>
+          <input id="base-url" value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} />
+
+          <label htmlFor="model">Model</label>
+          <input id="model" value={model} onChange={(event) => setModel(event.target.value)} />
+          {provider === "ollama" && ollamaModels.length ? (
+            <select value={model} onChange={(event) => setModel(event.target.value)}>
+              {ollamaModels.map((item) => (
+                <option key={item} value={item}>
+                  {item}
+                </option>
+              ))}
+            </select>
+          ) : null}
+
+          <label htmlFor="api-key">API key</label>
+          <input
+            id="api-key"
+            type="password"
+            value={apiKey}
+            placeholder={preset.keyPlaceholder}
+            onChange={(event) => setApiKey(event.target.value)}
+          />
+        </section>
+
+        <section className="panel">
+          <label>Artifact</label>
+          <div className="mode-grid">
+            {["prototype", "slides", "motion", "infographic", "review"].map((item) => (
+              <button key={item} className={mode === item ? "active" : ""} onClick={() => setMode(item)} type="button">
+                {item}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel grow">
+          <label htmlFor="prompt">Brief</label>
+          <textarea id="prompt" value={prompt} onChange={(event) => setPrompt(event.target.value)} />
+        </section>
+
+        {error ? <div className="error">{error}</div> : null}
+
+        <button className="primary" onClick={generate} disabled={busy} type="button">
+          {busy ? "Generating..." : "Generate HTML"}
+        </button>
+      </aside>
+
+      <main className="workspace">
+        <header className="toolbar">
+          <div>
+            <strong>{mode}</strong>
+            <span>{model}</span>
+          </div>
+          <div className="tabs">
+            <button className={tab === "preview" ? "active" : ""} onClick={() => setTab("preview")} type="button">
+              Preview
+            </button>
+            <button className={tab === "code" ? "active" : ""} onClick={() => setTab("code")} type="button">
+              Code
+            </button>
+            <button className={tab === "demos" ? "active" : ""} onClick={() => setTab("demos")} type="button">
+              Demos
+            </button>
+          </div>
+        </header>
+
+        <section className="canvas">
+          {tab === "preview" ? <iframe title="Generated preview" srcDoc={html} sandbox="allow-scripts" /> : null}
+          {tab === "code" ? <textarea className="code-editor" value={html} onChange={(event) => setHtml(event.target.value)} /> : null}
+          {tab === "demos" ? (
+            <div className="demo-grid">
+              {(context?.demos || []).map((demo) => (
+                <a key={demo} href={`/demos/${demo}`} target="_blank" rel="noreferrer">
+                  {demo.replace(".html", "")}
+                </a>
+              ))}
+            </div>
+          ) : null}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+createRoot(document.getElementById("root")).render(<App />);

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -107,6 +107,10 @@ function App() {
   const [clientName, setClientName] = useState(stored.clientName || "");
   const [contact, setContact] = useState(stored.contact || "");
   const [shareLink, setShareLink] = useState("");
+  const [currentShareId, setCurrentShareId] = useState("");
+  const [savedStatus, setSavedStatus] = useState("");
+  const [mockupList, setMockupList] = useState([]);
+  const [mockupListError, setMockupListError] = useState("");
   const [html, setHtml] = useState(starterHtml);
   const [step, setStep] = useState("lead");
   const [tab, setTab] = useState("preview");
@@ -139,6 +143,10 @@ function App() {
       JSON.stringify({ provider, baseUrl, model, mode, prompt, clientName, contact })
     );
   }, [provider, baseUrl, model, apiKey, mode, prompt, clientName, contact]);
+
+  useEffect(() => {
+    if (tab === "saved") refreshMockups();
+  }, [tab]);
 
   function chooseProvider(nextProvider) {
     setProvider(nextProvider);
@@ -221,10 +229,22 @@ function App() {
 
       if (streamError) throw new Error(streamError);
 
-      setHtml(stripFenceClient(acc));
+      const finalHtml = stripFenceClient(acc);
+      setHtml(finalHtml);
       setStreamChars(acc.length);
       setStreamStatus("");
       setStep("ship");
+
+      try {
+        const saved = await autoSaveDraft(finalHtml);
+        if (saved?.shareId) {
+          setCurrentShareId(saved.shareId);
+          setSavedStatus("draft");
+          setShareLink("");
+        }
+      } catch (autoSaveError) {
+        setError(`Generated, but auto-save failed: ${autoSaveError.message}`);
+      }
     } catch (err) {
       setError(err.message);
       setStreamStatus("");
@@ -234,31 +254,125 @@ function App() {
     }
   }
 
+  function mockupTitle() {
+    return clientName ? `${clientName} website mockup` : "Client website mockup";
+  }
+
+  async function autoSaveDraft(htmlForSave) {
+    const response = await fetch("/api/mockups", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        shareId: currentShareId || undefined,
+        title: mockupTitle(),
+        clientName,
+        contact,
+        prompt,
+        html: htmlForSave,
+        status: "draft",
+      }),
+    });
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.error || "Could not save draft");
+    return data;
+  }
+
   async function saveClientLink() {
     setBusy(true);
     setError("");
     setShareLink("");
     try {
-      const response = await fetch("/api/mockups", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: clientName ? `${clientName} website mockup` : "Client website mockup",
-          clientName,
-          contact,
-          prompt,
-          html,
-          status: "review",
-        }),
-      });
-      const data = await response.json();
-      if (!response.ok) throw new Error(data.error || "Could not save mockup");
+      let data;
+      if (currentShareId) {
+        const response = await fetch("/api/mockups", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            shareId: currentShareId,
+            title: mockupTitle(),
+            clientName,
+            contact,
+            html,
+            status: "review",
+          }),
+        });
+        data = await response.json();
+        if (!response.ok) throw new Error(data.error || "Could not update mockup");
+      } else {
+        const response = await fetch("/api/mockups", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: mockupTitle(),
+            clientName,
+            contact,
+            prompt,
+            html,
+            status: "review",
+          }),
+        });
+        data = await response.json();
+        if (!response.ok) throw new Error(data.error || "Could not save mockup");
+        if (data.shareId) setCurrentShareId(data.shareId);
+      }
+      setSavedStatus("review");
       setShareLink(data.shareUrl);
       await navigator.clipboard?.writeText(data.shareUrl).catch(() => {});
     } catch (err) {
       setError(err.message);
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function refreshMockups() {
+    setMockupListError("");
+    try {
+      const response = await fetch("/api/mockups");
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Could not load mockups");
+      setMockupList(data.mockups || []);
+    } catch (err) {
+      setMockupListError(err.message);
+    }
+  }
+
+  async function loadMockup(shareId) {
+    setError("");
+    try {
+      const response = await fetch(`/api/mockups?id=${encodeURIComponent(shareId)}`);
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Could not load mockup");
+      const mockup = data.mockup;
+      setHtml(mockup.html);
+      setCurrentShareId(mockup.shareId);
+      setSavedStatus(mockup.status || "");
+      setClientName(mockup.clientName || "");
+      setContact(mockup.contact || "");
+      if (mockup.prompt) setPrompt(mockup.prompt);
+      setShareLink(`${window.location.origin}/mockup/${mockup.shareId}`);
+      setStep("ship");
+      setTab("preview");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  async function deleteMockup(shareId) {
+    if (!window.confirm("Delete this mockup? This cannot be undone.")) return;
+    setMockupListError("");
+    try {
+      const response = await fetch(`/api/mockups?id=${encodeURIComponent(shareId)}`, { method: "DELETE" });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Could not delete mockup");
+      setMockupList((items) => items.filter((item) => item.shareId !== shareId));
+      if (shareId === currentShareId) {
+        setCurrentShareId("");
+        setSavedStatus("");
+        setShareLink("");
+      }
+    } catch (err) {
+      setMockupListError(err.message);
     }
   }
 
@@ -382,17 +496,27 @@ function App() {
           <section className="panel grow">
             <div className="section-title">
               <label>Client link</label>
-              <p>Review the preview, then save a durable link for the prospect.</p>
+              <p>Review the preview, then publish a durable link for the prospect.</p>
             </div>
             <div className="status-card">
               <strong>{clientName || "Client mockup"}</strong>
-              <span>{shareLink ? "Link copied and ready to send" : "Not saved yet"}</span>
+              <span>
+                {savedStatus === "review"
+                  ? "Published — link ready to send"
+                  : savedStatus === "draft"
+                  ? "Auto-saved as draft (private)"
+                  : "Not saved yet"}
+              </span>
             </div>
             <button className="secondary" onClick={() => setStep("direction")} type="button">
               Revise brief
             </button>
             <button className="primary" onClick={saveClientLink} disabled={busy || !html} type="button">
-              {busy ? "Saving..." : "Save client link"}
+              {busy
+                ? "Saving..."
+                : savedStatus === "review"
+                ? "Re-publish update"
+                : "Publish client link"}
             </button>
             {shareLink ? (
               <a className="share-link" href={shareLink} target="_blank" rel="noreferrer">
@@ -418,6 +542,9 @@ function App() {
             <button className={tab === "code" ? "active" : ""} onClick={() => setTab("code")} type="button">
               Code
             </button>
+            <button className={tab === "saved" ? "active" : ""} onClick={() => setTab("saved")} type="button">
+              Saved
+            </button>
             <button className={tab === "demos" ? "active" : ""} onClick={() => setTab("demos")} type="button">
               Demos
             </button>
@@ -441,6 +568,56 @@ function App() {
             </div>
           ) : null}
           {tab === "code" ? <textarea className="code-editor" value={html} onChange={(event) => setHtml(event.target.value)} /> : null}
+          {tab === "saved" ? (
+            <div className="mockup-list">
+              <header className="mockup-list-head">
+                <div>
+                  <strong>Saved mockups</strong>
+                  <span>{mockupList.length} total</span>
+                </div>
+                <button className="secondary" onClick={refreshMockups} type="button">
+                  Refresh
+                </button>
+              </header>
+              {mockupListError ? <div className="error">{mockupListError}</div> : null}
+              {mockupList.length === 0 ? (
+                <p className="muted">
+                  Generate a mockup — drafts auto-save here. Publish from the Ship step to share.
+                </p>
+              ) : (
+                <ul>
+                  {mockupList.map((item) => (
+                    <li key={item.shareId} className={item.shareId === currentShareId ? "current" : ""}>
+                      <div className="mockup-meta">
+                        <strong>{item.title}</strong>
+                        <span>
+                          <span className={`status-pill status-${item.status}`}>{item.status}</span>
+                          {item.clientName ? ` · ${item.clientName}` : ""}
+                          {" · "}
+                          {new Date(item.updatedAt).toLocaleString()}
+                          {" · "}
+                          {Math.round((item.htmlSize || 0) / 100) / 10}KB
+                        </span>
+                      </div>
+                      <div className="mockup-actions">
+                        <button onClick={() => loadMockup(item.shareId)} type="button">
+                          Load
+                        </button>
+                        {item.shareUrl ? (
+                          <a href={item.shareUrl} target="_blank" rel="noreferrer">
+                            Open
+                          </a>
+                        ) : null}
+                        <button className="danger" onClick={() => deleteMockup(item.shareId)} type="button">
+                          Delete
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ) : null}
           {tab === "demos" ? (
             <div className="demo-grid">
               {(context?.demos || []).map((demo) => (

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -4,10 +4,16 @@ import "./styles.css";
 
 const providerPresets = {
   ollama: {
-    label: "Ollama",
+    label: "Ollama Local",
     baseUrl: "http://localhost:11434/v1",
     model: "kimi-k2.6:cloud",
     keyPlaceholder: "optional",
+  },
+  "ollama-cloud": {
+    label: "Ollama Cloud",
+    baseUrl: "https://ollama.com/v1",
+    model: "kimi-k2.6",
+    keyPlaceholder: "ollama key",
   },
   openai: {
     label: "OpenAI",
@@ -68,7 +74,7 @@ function App() {
   const [provider, setProvider] = useState(stored.provider || "ollama");
   const [baseUrl, setBaseUrl] = useState(stored.baseUrl || providerPresets.ollama.baseUrl);
   const [model, setModel] = useState(stored.model || providerPresets.ollama.model);
-  const [apiKey, setApiKey] = useState(stored.apiKey || "");
+  const [apiKey, setApiKey] = useState("");
   const [mode, setMode] = useState(stored.mode || "prototype");
   const [prompt, setPrompt] = useState(
     stored.prompt ||
@@ -99,7 +105,7 @@ function App() {
   useEffect(() => {
     localStorage.setItem(
       "huashu-webui-settings",
-      JSON.stringify({ provider, baseUrl, model, apiKey, mode, prompt })
+      JSON.stringify({ provider, baseUrl, model, mode, prompt })
     );
   }, [provider, baseUrl, model, apiKey, mode, prompt]);
 

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -70,6 +70,9 @@ function getStoredSettings() {
 }
 
 function App() {
+  const shareMatch = window.location.pathname.match(/^\/mockup\/([^/]+)$/);
+  if (shareMatch) return <ClientMockup shareId={shareMatch[1]} />;
+
   const stored = useMemo(getStoredSettings, []);
   const [provider, setProvider] = useState(stored.provider || "ollama");
   const [baseUrl, setBaseUrl] = useState(stored.baseUrl || providerPresets.ollama.baseUrl);
@@ -78,8 +81,11 @@ function App() {
   const [mode, setMode] = useState(stored.mode || "prototype");
   const [prompt, setPrompt] = useState(
     stored.prompt ||
-      "Create a clickable iOS-style onboarding prototype for a focus timer app. Include 3 screens, stateful navigation, and one polished visual direction."
+      "Build a modern local-business website mockup for a restaurant lead. Use real-looking sections for hero, menu highlights, gallery, reviews, opening hours, and booking/contact CTAs. Make it polished enough to send as a preview link."
   );
+  const [clientName, setClientName] = useState(stored.clientName || "");
+  const [contact, setContact] = useState(stored.contact || "");
+  const [shareLink, setShareLink] = useState("");
   const [html, setHtml] = useState(starterHtml);
   const [tab, setTab] = useState("preview");
   const [busy, setBusy] = useState(false);
@@ -105,9 +111,9 @@ function App() {
   useEffect(() => {
     localStorage.setItem(
       "huashu-webui-settings",
-      JSON.stringify({ provider, baseUrl, model, mode, prompt })
+      JSON.stringify({ provider, baseUrl, model, mode, prompt, clientName, contact })
     );
-  }, [provider, baseUrl, model, apiKey, mode, prompt]);
+  }, [provider, baseUrl, model, apiKey, mode, prompt, clientName, contact]);
 
   function chooseProvider(nextProvider) {
     setProvider(nextProvider);
@@ -129,6 +135,34 @@ function App() {
       if (!response.ok) throw new Error(data.error || "Generation failed");
       setHtml(data.html);
       setTab("preview");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function saveClientLink() {
+    setBusy(true);
+    setError("");
+    setShareLink("");
+    try {
+      const response = await fetch("/api/mockups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: clientName ? `${clientName} website mockup` : "Client website mockup",
+          clientName,
+          contact,
+          prompt,
+          html,
+          status: "review",
+        }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Could not save mockup");
+      setShareLink(data.shareUrl);
+      await navigator.clipboard?.writeText(data.shareUrl).catch(() => {});
     } catch (err) {
       setError(err.message);
     } finally {
@@ -192,6 +226,20 @@ function App() {
         </section>
 
         <section className="panel">
+          <label>Client</label>
+          <input
+            value={clientName}
+            placeholder="Business name"
+            onChange={(event) => setClientName(event.target.value)}
+          />
+          <input
+            value={contact}
+            placeholder="Website / Instagram / phone"
+            onChange={(event) => setContact(event.target.value)}
+          />
+        </section>
+
+        <section className="panel">
           <label>Artifact</label>
           <div className="mode-grid">
             {["prototype", "slides", "motion", "infographic", "review"].map((item) => (
@@ -212,6 +260,14 @@ function App() {
         <button className="primary" onClick={generate} disabled={busy} type="button">
           {busy ? "Generating..." : "Generate HTML"}
         </button>
+        <button className="secondary" onClick={saveClientLink} disabled={busy || !html} type="button">
+          Save client link
+        </button>
+        {shareLink ? (
+          <a className="share-link" href={shareLink} target="_blank" rel="noreferrer">
+            {shareLink}
+          </a>
+        ) : null}
       </aside>
 
       <main className="workspace">
@@ -248,6 +304,53 @@ function App() {
         </section>
       </main>
     </div>
+  );
+}
+
+function ClientMockup({ shareId }) {
+  const [mockup, setMockup] = useState(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch(`/api/mockups?id=${encodeURIComponent(shareId)}`)
+      .then(async (response) => {
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || "Mockup not found");
+        setMockup(data.mockup);
+      })
+      .catch((err) => setError(err.message));
+  }, [shareId]);
+
+  if (error) {
+    return (
+      <main className="public-state">
+        <h1>Mockup unavailable</h1>
+        <p>{error}</p>
+      </main>
+    );
+  }
+
+  if (!mockup) {
+    return (
+      <main className="public-state">
+        <h1>Loading mockup</h1>
+      </main>
+    );
+  }
+
+  return (
+    <main className="public-viewer">
+      <header>
+        <div>
+          <strong>{mockup.title}</strong>
+          {mockup.clientName ? <span>{mockup.clientName}</span> : null}
+        </div>
+        <a href={`mailto:?subject=${encodeURIComponent(mockup.title)}&body=${encodeURIComponent(window.location.href)}`}>
+          Send link
+        </a>
+      </header>
+      <iframe title={mockup.title} srcDoc={mockup.html} sandbox="allow-scripts" />
+    </main>
   );
 }
 

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -76,6 +76,12 @@ const starterHtml = `<!doctype html>
 </body>
 </html>`;
 
+function stripFenceClient(output) {
+  const trimmed = output.trim();
+  const match = trimmed.match(/^```(?:html)?\s*([\s\S]*?)\s*```$/i);
+  return match ? match[1].trim() : trimmed;
+}
+
 function getStoredSettings() {
   try {
     return JSON.parse(localStorage.getItem("huashu-webui-settings") || "{}");
@@ -108,6 +114,9 @@ function App() {
   const [error, setError] = useState("");
   const [context, setContext] = useState(null);
   const [ollamaModels, setOllamaModels] = useState([]);
+  const [streamChars, setStreamChars] = useState(0);
+  const [streamElapsed, setStreamElapsed] = useState(0);
+  const [streamStatus, setStreamStatus] = useState("");
 
   useEffect(() => {
     fetch("/api/context")
@@ -141,20 +150,86 @@ function App() {
   async function generate() {
     setBusy(true);
     setError("");
+    setStreamChars(0);
+    setStreamElapsed(0);
+    setStreamStatus("Connecting...");
+    setTab("preview");
+
+    const startedAt = Date.now();
+    const tickInterval = setInterval(() => {
+      setStreamElapsed(Math.round((Date.now() - startedAt) / 1000));
+    }, 250);
+
     try {
       const response = await fetch("/api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ provider, baseUrl, model, apiKey, mode, prompt }),
       });
-      const data = await response.json();
-      if (!response.ok) throw new Error(data.error || "Generation failed");
-      setHtml(data.html);
-      setTab("preview");
+
+      const contentType = response.headers.get("content-type") || "";
+      if (!response.ok || !contentType.includes("event-stream")) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || `Generation failed (${response.status})`);
+      }
+
+      setStreamStatus("Streaming...");
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let acc = "";
+      let lastFlush = 0;
+      let streamError = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split("\n\n");
+        buffer = events.pop() || "";
+        for (const ev of events) {
+          let eventName = "message";
+          let dataStr = "";
+          for (const line of ev.split("\n")) {
+            if (line.startsWith("event:")) eventName = line.slice(6).trim();
+            else if (line.startsWith("data:")) dataStr += line.slice(5).trim();
+          }
+          if (!dataStr) continue;
+          let payload;
+          try {
+            payload = JSON.parse(dataStr);
+          } catch {
+            continue;
+          }
+          if (eventName === "error") {
+            streamError = payload.error || "Generation failed";
+            break;
+          }
+          if (eventName === "delta" && payload.text) {
+            acc += payload.text;
+            const now = Date.now();
+            if (now - lastFlush > 250) {
+              setHtml(stripFenceClient(acc));
+              setStreamChars(acc.length);
+              lastFlush = now;
+            }
+          }
+        }
+        if (streamError) break;
+      }
+
+      if (streamError) throw new Error(streamError);
+
+      setHtml(stripFenceClient(acc));
+      setStreamChars(acc.length);
+      setStreamStatus("");
       setStep("ship");
     } catch (err) {
       setError(err.message);
+      setStreamStatus("");
     } finally {
+      clearInterval(tickInterval);
       setBusy(false);
     }
   }
@@ -350,7 +425,21 @@ function App() {
         </header>
 
         <section className="canvas">
-          {tab === "preview" ? <iframe title="Generated preview" srcDoc={html} sandbox="allow-scripts" /> : null}
+          {tab === "preview" ? (
+            <div className="preview-wrap">
+              <iframe title="Generated preview" srcDoc={html} sandbox="allow-scripts" />
+              {busy ? (
+                <div className="stream-overlay" role="status" aria-live="polite">
+                  <div className="stream-pulse" />
+                  <strong>{streamStatus || "Generating"}</strong>
+                  <span>
+                    {streamElapsed}s elapsed · {streamChars.toLocaleString()} chars streamed
+                  </span>
+                  <small>The preview updates as the model writes the page.</small>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
           {tab === "code" ? <textarea className="code-editor" value={html} onChange={(event) => setHtml(event.target.value)} /> : null}
           {tab === "demos" ? (
             <div className="demo-grid">

--- a/webui/src/main.jsx
+++ b/webui/src/main.jsx
@@ -35,6 +35,21 @@ const providerPresets = {
   },
 };
 
+const steps = [
+  { id: "lead", label: "Lead" },
+  { id: "direction", label: "Direction" },
+  { id: "ai", label: "AI" },
+  { id: "ship", label: "Ship" },
+];
+
+const artifactOptions = [
+  { id: "prototype", label: "Website", hint: "Client-ready landing mockup" },
+  { id: "slides", label: "Pitch deck", hint: "16:9 presentation" },
+  { id: "motion", label: "Motion", hint: "Promo animation concept" },
+  { id: "infographic", label: "One-pager", hint: "Static sales visual" },
+  { id: "review", label: "Review", hint: "Critique an existing design" },
+];
+
 const starterHtml = `<!doctype html>
 <html lang="en">
 <head>
@@ -87,6 +102,7 @@ function App() {
   const [contact, setContact] = useState(stored.contact || "");
   const [shareLink, setShareLink] = useState("");
   const [html, setHtml] = useState(starterHtml);
+  const [step, setStep] = useState("lead");
   const [tab, setTab] = useState("preview");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
@@ -135,6 +151,7 @@ function App() {
       if (!response.ok) throw new Error(data.error || "Generation failed");
       setHtml(data.html);
       setTab("preview");
+      setStep("ship");
     } catch (err) {
       setError(err.message);
     } finally {
@@ -171,6 +188,7 @@ function App() {
   }
 
   const preset = providerPresets[provider];
+  const activeStepIndex = steps.findIndex((item) => item.id === step);
 
   return (
     <div className="app-shell">
@@ -183,98 +201,140 @@ function App() {
           </div>
         </div>
 
-        <section className="panel">
-          <label>Provider</label>
-          <div className="segmented">
-            {Object.entries(providerPresets).map(([key, item]) => (
-              <button
-                key={key}
-                className={provider === key ? "active" : ""}
-                onClick={() => chooseProvider(key)}
-                type="button"
-              >
-                {item.label}
-              </button>
-            ))}
-          </div>
-        </section>
+        <nav className="stepper" aria-label="Workflow">
+          {steps.map((item, index) => (
+            <button
+              key={item.id}
+              className={step === item.id ? "active" : index < activeStepIndex ? "done" : ""}
+              onClick={() => setStep(item.id)}
+              type="button"
+            >
+              <span>{index + 1}</span>
+              {item.label}
+            </button>
+          ))}
+        </nav>
 
-        <section className="panel grid">
-          <label htmlFor="base-url">Base URL</label>
-          <input id="base-url" value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} />
+        {step === "lead" ? (
+          <section className="panel grow">
+            <div className="section-title">
+              <label>Prospect</label>
+              <p>Capture only what makes the preview feel made for them.</p>
+            </div>
+            <input
+              value={clientName}
+              placeholder="Business name, e.g. Jones Barbecue"
+              onChange={(event) => setClientName(event.target.value)}
+            />
+            <input
+              value={contact}
+              placeholder="Current site, Instagram, or phone"
+              onChange={(event) => setContact(event.target.value)}
+            />
+            <button className="primary" onClick={() => setStep("direction")} type="button">
+              Continue
+            </button>
+          </section>
+        ) : null}
 
-          <label htmlFor="model">Model</label>
-          <input id="model" value={model} onChange={(event) => setModel(event.target.value)} />
-          {provider === "ollama" && ollamaModels.length ? (
-            <select value={model} onChange={(event) => setModel(event.target.value)}>
-              {ollamaModels.map((item) => (
-                <option key={item} value={item}>
-                  {item}
-                </option>
+        {step === "direction" ? (
+          <section className="panel grow">
+            <div className="section-title">
+              <label>Offer</label>
+              <p>Pick what Jude is sending the prospect.</p>
+            </div>
+            <div className="choice-list">
+              {artifactOptions.map((item) => (
+                <button key={item.id} className={mode === item.id ? "active" : ""} onClick={() => setMode(item.id)} type="button">
+                  <strong>{item.label}</strong>
+                  <span>{item.hint}</span>
+                </button>
               ))}
-            </select>
-          ) : null}
+            </div>
+            <label htmlFor="prompt">Creative brief</label>
+            <textarea id="prompt" value={prompt} onChange={(event) => setPrompt(event.target.value)} />
+            <button className="primary" onClick={() => setStep("ai")} type="button">
+              Continue
+            </button>
+          </section>
+        ) : null}
 
-          <label htmlFor="api-key">API key</label>
-          <input
-            id="api-key"
-            type="password"
-            value={apiKey}
-            placeholder={preset.keyPlaceholder}
-            onChange={(event) => setApiKey(event.target.value)}
-          />
-        </section>
+        {step === "ai" ? (
+          <section className="panel grow">
+            <div className="section-title">
+              <label>Model</label>
+              <p>Select the engine only when you need to change it.</p>
+            </div>
+            <div className="choice-list compact">
+              {Object.entries(providerPresets).map(([key, item]) => (
+                <button key={key} className={provider === key ? "active" : ""} onClick={() => chooseProvider(key)} type="button">
+                  <strong>{item.label}</strong>
+                  <span>{item.model}</span>
+                </button>
+              ))}
+            </div>
+            <details className="advanced">
+              <summary>Advanced provider settings</summary>
+              <label htmlFor="base-url">Base URL</label>
+              <input id="base-url" value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} />
+              <label htmlFor="model">Model</label>
+              <input id="model" value={model} onChange={(event) => setModel(event.target.value)} />
+              {provider === "ollama" && ollamaModels.length ? (
+                <select value={model} onChange={(event) => setModel(event.target.value)}>
+                  {ollamaModels.map((item) => (
+                    <option key={item} value={item}>
+                      {item}
+                    </option>
+                  ))}
+                </select>
+              ) : null}
+            </details>
+            <label htmlFor="api-key">API key</label>
+            <input
+              id="api-key"
+              type="password"
+              value={apiKey}
+              placeholder={preset.keyPlaceholder}
+              onChange={(event) => setApiKey(event.target.value)}
+            />
+            <button className="primary" onClick={generate} disabled={busy} type="button">
+              {busy ? "Generating..." : "Generate mockup"}
+            </button>
+          </section>
+        ) : null}
 
-        <section className="panel">
-          <label>Client</label>
-          <input
-            value={clientName}
-            placeholder="Business name"
-            onChange={(event) => setClientName(event.target.value)}
-          />
-          <input
-            value={contact}
-            placeholder="Website / Instagram / phone"
-            onChange={(event) => setContact(event.target.value)}
-          />
-        </section>
-
-        <section className="panel">
-          <label>Artifact</label>
-          <div className="mode-grid">
-            {["prototype", "slides", "motion", "infographic", "review"].map((item) => (
-              <button key={item} className={mode === item ? "active" : ""} onClick={() => setMode(item)} type="button">
-                {item}
-              </button>
-            ))}
-          </div>
-        </section>
-
-        <section className="panel grow">
-          <label htmlFor="prompt">Brief</label>
-          <textarea id="prompt" value={prompt} onChange={(event) => setPrompt(event.target.value)} />
-        </section>
+        {step === "ship" ? (
+          <section className="panel grow">
+            <div className="section-title">
+              <label>Client link</label>
+              <p>Review the preview, then save a durable link for the prospect.</p>
+            </div>
+            <div className="status-card">
+              <strong>{clientName || "Client mockup"}</strong>
+              <span>{shareLink ? "Link copied and ready to send" : "Not saved yet"}</span>
+            </div>
+            <button className="secondary" onClick={() => setStep("direction")} type="button">
+              Revise brief
+            </button>
+            <button className="primary" onClick={saveClientLink} disabled={busy || !html} type="button">
+              {busy ? "Saving..." : "Save client link"}
+            </button>
+            {shareLink ? (
+              <a className="share-link" href={shareLink} target="_blank" rel="noreferrer">
+                {shareLink}
+              </a>
+            ) : null}
+          </section>
+        ) : null}
 
         {error ? <div className="error">{error}</div> : null}
-
-        <button className="primary" onClick={generate} disabled={busy} type="button">
-          {busy ? "Generating..." : "Generate HTML"}
-        </button>
-        <button className="secondary" onClick={saveClientLink} disabled={busy || !html} type="button">
-          Save client link
-        </button>
-        {shareLink ? (
-          <a className="share-link" href={shareLink} target="_blank" rel="noreferrer">
-            {shareLink}
-          </a>
-        ) : null}
       </aside>
 
       <main className="workspace">
         <header className="toolbar">
           <div>
-            <strong>{mode}</strong>
-            <span>{model}</span>
+            <strong>{clientName || artifactOptions.find((item) => item.id === mode)?.label || mode}</strong>
+            <span>{providerPresets[provider]?.label} · {model}</span>
           </div>
           <div className="tabs">
             <button className={tab === "preview" ? "active" : ""} onClick={() => setTab("preview")} type="button">
@@ -342,14 +402,19 @@ function ClientMockup({ shareId }) {
     <main className="public-viewer">
       <header>
         <div>
-          <strong>{mockup.title}</strong>
-          {mockup.clientName ? <span>{mockup.clientName}</span> : null}
+          <span>Website preview</span>
+          <strong>{mockup.clientName || mockup.title}</strong>
         </div>
-        <a href={`mailto:?subject=${encodeURIComponent(mockup.title)}&body=${encodeURIComponent(window.location.href)}`}>
-          Send link
-        </a>
+        <nav>
+          <a href={`mailto:?subject=${encodeURIComponent(mockup.title)}&body=${encodeURIComponent(window.location.href)}`}>
+            Share
+          </a>
+          <a href="#preview">
+            Full preview
+          </a>
+        </nav>
       </header>
-      <iframe title={mockup.title} srcDoc={mockup.html} sandbox="allow-scripts" />
+      <iframe id="preview" title={mockup.title} srcDoc={mockup.html} sandbox="allow-scripts" />
     </main>
   );
 }

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -77,6 +77,7 @@ button {
 
 .panel.grow {
   flex: 1;
+  align-content: start;
   min-height: 0;
 }
 
@@ -87,23 +88,102 @@ label {
   letter-spacing: 0;
 }
 
-.segmented,
-.mode-grid,
+.stepper,
+.choice-list,
 .tabs {
   display: grid;
   gap: 6px;
 }
 
-.segmented {
+.stepper {
+  grid-template-columns: repeat(4, 1fr);
+  margin: 4px 0 2px;
+}
+
+.stepper button {
+  display: grid;
+  justify-items: center;
+  gap: 6px;
+  min-height: 58px;
+  border: 1px solid #d8d3c8;
+  border-radius: 7px;
+  background: #fffdfa;
+  color: #6d675f;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.stepper span {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: #ebe8df;
+  color: #171717;
+}
+
+.stepper button.active {
+  border-color: #171717;
+  color: #171717;
+  background: #fffdfa;
+}
+
+.stepper button.active span,
+.stepper button.done span {
+  background: #171717;
+  color: #fffdfa;
+}
+
+.section-title {
+  display: grid;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.section-title p {
+  margin: 0;
+  color: #6d675f;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.choice-list {
+  grid-template-columns: 1fr;
+}
+
+.choice-list button {
+  min-height: 58px;
+  display: grid;
+  gap: 4px;
+  justify-items: start;
+  padding: 11px 12px;
+  border: 1px solid #d8d3c8;
+  border-radius: 7px;
+  background: #fffdfa;
+  color: #2c2a27;
+  text-align: left;
+}
+
+.choice-list.compact {
   grid-template-columns: repeat(2, 1fr);
 }
 
-.mode-grid {
-  grid-template-columns: repeat(2, 1fr);
+.choice-list.compact button {
+  min-height: 64px;
 }
 
-.segmented button,
-.mode-grid button,
+.choice-list strong {
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.choice-list span {
+  color: #6d675f;
+  font-size: 12px;
+  line-height: 1.25;
+}
+
 .tabs button {
   min-height: 34px;
   border: 1px solid #d8d3c8;
@@ -114,12 +194,35 @@ label {
   font-weight: 700;
 }
 
-.segmented button.active,
-.mode-grid button.active,
+.choice-list button.active,
 .tabs button.active {
   border-color: #171717;
   background: #171717;
   color: #fffdfa;
+}
+
+.choice-list button.active span {
+  color: #ddd8cd;
+}
+
+.advanced {
+  display: grid;
+  gap: 9px;
+  border: 1px solid #d8d3c8;
+  border-radius: 7px;
+  padding: 10px;
+  background: #fffdfa;
+}
+
+.advanced summary {
+  cursor: pointer;
+  color: #4d4943;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.advanced[open] summary {
+  margin-bottom: 8px;
 }
 
 .grid {
@@ -144,14 +247,14 @@ select {
 }
 
 textarea {
-  min-height: 180px;
+  min-height: 220px;
   resize: none;
   padding: 12px;
   line-height: 1.45;
 }
 
 .panel.grow textarea {
-  height: 100%;
+  height: min(32vh, 300px);
 }
 
 .primary {
@@ -188,6 +291,24 @@ textarea {
   line-height: 1.35;
   overflow-wrap: anywhere;
   text-decoration: none;
+}
+
+.status-card {
+  display: grid;
+  gap: 4px;
+  padding: 14px;
+  border: 1px solid #d8d3c8;
+  border-radius: 7px;
+  background: #fffdfa;
+}
+
+.status-card strong {
+  font-size: 15px;
+}
+
+.status-card span {
+  color: #6d675f;
+  font-size: 12px;
 }
 
 .error {
@@ -273,7 +394,7 @@ iframe {
 .public-viewer {
   height: 100vh;
   display: grid;
-  grid-template-rows: 58px minmax(0, 1fr);
+  grid-template-rows: 66px minmax(0, 1fr);
   background: #ebe8df;
 }
 
@@ -287,18 +408,26 @@ iframe {
   background: #f7f4ed;
 }
 
-.public-viewer strong,
-.public-state h1 {
-  display: block;
-  font-size: 17px;
-  letter-spacing: 0;
-}
-
 .public-viewer span {
   display: block;
   margin-top: 2px;
   color: #6d675f;
   font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.public-viewer strong,
+.public-state h1 {
+  display: block;
+  margin-top: 3px;
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.public-viewer nav {
+  display: flex;
+  gap: 8px;
 }
 
 .public-viewer a {
@@ -345,5 +474,10 @@ iframe {
 
   .workspace {
     height: 72vh;
+  }
+
+  .stepper,
+  .choice-list.compact {
+    grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -339,7 +339,7 @@ textarea {
 }
 
 .tabs {
-  grid-template-columns: repeat(3, 92px);
+  grid-template-columns: repeat(4, 92px);
 }
 
 .canvas {
@@ -431,6 +431,139 @@ iframe {
   grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
   align-content: start;
   gap: 10px;
+}
+
+.mockup-list {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  padding: 18px;
+  border: 1px solid #d5d1c6;
+  border-radius: 8px;
+  background: #fffdfa;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mockup-list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.mockup-list-head strong {
+  font-size: 15px;
+  display: block;
+}
+
+.mockup-list-head span {
+  font-size: 12px;
+  color: #6b6760;
+}
+
+.mockup-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.mockup-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid #e7e3d8;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.mockup-list li.current {
+  border-color: #d94f30;
+  background: #fff7f2;
+}
+
+.mockup-meta {
+  min-width: 0;
+  flex: 1;
+}
+
+.mockup-meta strong {
+  display: block;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mockup-meta span {
+  font-size: 11px;
+  color: #6b6760;
+}
+
+.status-pill {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: #efeadc;
+  color: #45423c;
+}
+
+.status-pill.status-review {
+  background: #2f735f;
+  color: #fffdfa;
+}
+
+.status-pill.status-draft {
+  background: #efeadc;
+  color: #45423c;
+}
+
+.mockup-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.mockup-actions button,
+.mockup-actions a {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid #d5d1c6;
+  background: #fffdfa;
+  color: #161616;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.mockup-actions button:hover,
+.mockup-actions a:hover {
+  background: #f7f3ea;
+}
+
+.mockup-actions .danger {
+  color: #c62828;
+  border-color: #f1c4be;
+}
+
+.mockup-actions .danger:hover {
+  background: #fbeae8;
+}
+
+.mockup-list .muted {
+  color: #6b6760;
+  font-size: 13px;
+  margin: 8px 0 0;
 }
 
 .demo-grid a {

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -95,7 +95,7 @@ label {
 }
 
 .segmented {
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
 }
 
 .mode-grid {

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -1,0 +1,264 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #ebe8df;
+  color: #171717;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  cursor: pointer;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 380px minmax(0, 1fr);
+  background: #ebe8df;
+}
+
+.sidebar {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-right: 1px solid #d5d1c6;
+  background: #f7f4ed;
+}
+
+.brand-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 48px;
+}
+
+.brand-row img {
+  width: 42px;
+  height: 42px;
+  object-fit: contain;
+}
+
+.brand-row strong,
+.toolbar strong {
+  display: block;
+  font-size: 15px;
+  line-height: 1.2;
+}
+
+.brand-row span,
+.toolbar span {
+  display: block;
+  margin-top: 4px;
+  color: #6d675f;
+  font-size: 12px;
+}
+
+.panel {
+  display: grid;
+  gap: 9px;
+}
+
+.panel.grow {
+  flex: 1;
+  min-height: 0;
+}
+
+label {
+  color: #4d4943;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.segmented,
+.mode-grid,
+.tabs {
+  display: grid;
+  gap: 6px;
+}
+
+.segmented {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.mode-grid {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.segmented button,
+.mode-grid button,
+.tabs button {
+  min-height: 34px;
+  border: 1px solid #d8d3c8;
+  border-radius: 6px;
+  background: #fffdfa;
+  color: #2c2a27;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.segmented button.active,
+.mode-grid button.active,
+.tabs button.active {
+  border-color: #171717;
+  background: #171717;
+  color: #fffdfa;
+}
+
+.grid {
+  grid-template-columns: 1fr;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  border: 1px solid #d8d3c8;
+  border-radius: 6px;
+  background: #fffdfa;
+  color: #171717;
+  outline: none;
+}
+
+input,
+select {
+  height: 38px;
+  padding: 0 10px;
+}
+
+textarea {
+  min-height: 180px;
+  resize: none;
+  padding: 12px;
+  line-height: 1.45;
+}
+
+.panel.grow textarea {
+  height: 100%;
+}
+
+.primary {
+  min-height: 46px;
+  border-radius: 7px;
+  background: #c94f32;
+  color: white;
+  font-weight: 800;
+}
+
+.primary:disabled {
+  opacity: 0.62;
+  cursor: progress;
+}
+
+.error {
+  border: 1px solid #e1aaa0;
+  border-radius: 6px;
+  padding: 10px;
+  background: #fff2ef;
+  color: #8c1f13;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.workspace {
+  min-width: 0;
+  height: 100vh;
+  display: grid;
+  grid-template-rows: 66px minmax(0, 1fr);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid #d5d1c6;
+  background: #f7f4ed;
+}
+
+.tabs {
+  grid-template-columns: repeat(3, 92px);
+}
+
+.canvas {
+  min-height: 0;
+  padding: 18px;
+}
+
+iframe,
+.code-editor,
+.demo-grid {
+  width: 100%;
+  height: 100%;
+  border: 1px solid #d5d1c6;
+  border-radius: 8px;
+  background: #fffdfa;
+}
+
+iframe {
+  display: block;
+}
+
+.code-editor {
+  resize: none;
+  padding: 18px;
+  font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  white-space: pre;
+}
+
+.demo-grid {
+  overflow: auto;
+  padding: 18px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  align-content: start;
+  gap: 10px;
+}
+
+.demo-grid a {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border: 1px solid #e0d9cc;
+  border-radius: 7px;
+  color: #171717;
+  background: #f7f4ed;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+@media (max-width: 980px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    height: auto;
+    border-right: 0;
+    border-bottom: 1px solid #d5d1c6;
+  }
+
+  .workspace {
+    height: 72vh;
+  }
+}

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -162,9 +162,32 @@ textarea {
   font-weight: 800;
 }
 
-.primary:disabled {
+.secondary {
+  min-height: 42px;
+  border: 1px solid #171717;
+  border-radius: 7px;
+  background: #fffdfa;
+  color: #171717;
+  font-weight: 800;
+}
+
+.primary:disabled,
+.secondary:disabled {
   opacity: 0.62;
   cursor: progress;
+}
+
+.share-link {
+  display: block;
+  padding: 10px;
+  border: 1px solid #cfc8ba;
+  border-radius: 6px;
+  background: #fffdfa;
+  color: #1f5f4c;
+  font-size: 12px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  text-decoration: none;
 }
 
 .error {
@@ -245,6 +268,68 @@ iframe {
   font-size: 13px;
   font-weight: 700;
   text-decoration: none;
+}
+
+.public-viewer {
+  height: 100vh;
+  display: grid;
+  grid-template-rows: 58px minmax(0, 1fr);
+  background: #ebe8df;
+}
+
+.public-viewer header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 16px;
+  border-bottom: 1px solid #d5d1c6;
+  background: #f7f4ed;
+}
+
+.public-viewer strong,
+.public-state h1 {
+  display: block;
+  font-size: 17px;
+  letter-spacing: 0;
+}
+
+.public-viewer span {
+  display: block;
+  margin-top: 2px;
+  color: #6d675f;
+  font-size: 12px;
+}
+
+.public-viewer a {
+  border: 1px solid #171717;
+  border-radius: 6px;
+  padding: 9px 12px;
+  color: #171717;
+  background: #fffdfa;
+  font-size: 12px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.public-state {
+  min-height: 100vh;
+  display: grid;
+  place-content: center;
+  gap: 10px;
+  padding: 24px;
+  background: #f7f4ed;
+  text-align: center;
+}
+
+.public-state h1,
+.public-state p {
+  margin: 0;
+}
+
+.public-state p {
+  max-width: 560px;
+  color: #6d675f;
 }
 
 @media (max-width: 980px) {

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -349,7 +349,8 @@ textarea {
 
 iframe,
 .code-editor,
-.demo-grid {
+.demo-grid,
+.preview-wrap {
   width: 100%;
   height: 100%;
   border: 1px solid #d5d1c6;
@@ -359,6 +360,61 @@ iframe,
 
 iframe {
   display: block;
+}
+
+.preview-wrap {
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+}
+
+.preview-wrap iframe {
+  border: none;
+  border-radius: inherit;
+}
+
+.stream-overlay {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: grid;
+  gap: 4px;
+  padding: 12px 14px;
+  background: rgba(22, 22, 22, 0.92);
+  color: #f7f3ea;
+  border-radius: 8px;
+  font: 12px/1.4 Inter, ui-sans-serif, system-ui, sans-serif;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.18);
+  pointer-events: none;
+  max-width: 260px;
+}
+
+.stream-overlay strong {
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+
+.stream-overlay span {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.85;
+}
+
+.stream-overlay small {
+  opacity: 0.65;
+  font-size: 11px;
+}
+
+.stream-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #d94f30;
+  animation: stream-pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes stream-pulse {
+  0%, 100% { opacity: 0.4; transform: scale(0.85); }
+  50% { opacity: 1; transform: scale(1.1); }
 }
 
 .code-editor {


### PR DESCRIPTION
## Summary

- Promotes marketing landing pages to a first-class deliverable in the skill, so the webui's `prototype` mode (labeled "Website / Client-ready landing mockup") stops producing generic prototype output and starts producing real, business-specific landing pages.
- Stops the webui from surfacing raw upstream `401 Unauthorized: unauthorized` errors when an API key is missing or wrong — replaces them with actionable setup guidance.

## What changed

**Landing page track**
- New `references/landing-pages.md`: section library, business-type → required-sections matrix (restaurant, local trade, agency, SaaS, personal brand, e-commerce, event), anti-slop checklist, and asset rules that delegate to the existing core asset protocol.
- `webui/server/index.js` `buildContext` loads `landing-pages.md` when `mode === "prototype"` and adds a system instruction telling the agent to follow the track.
- `SKILL.md` reference table gets a row pointing agents at the new doc.

**401 fix**
- New `resolveApiKey(provider, supplied)` in `webui/server/index.js` falls back to `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `OLLAMA_API_KEY` from `.env.local` when the request body doesn't include one.
- `/api/generate` pre-validates that non-local providers have a key and returns a 400 with `"... requires an API key. Enter one in the API key field or set X in webui/.env.local"` instead of letting the upstream return an opaque 401.
- Genuine upstream 401s (wrong key) are caught and rewritten to `"Provider rejected the API key (401). Double-check the key for X, or update Y in .env.local."`.

## Why

Two real friction points hit while using the webui to generate business landing pages:

1. The `prototype` mode used the generic agent context, so output for "build a restaurant landing page" looked like a generic AI demo rather than something a designer would ship to a prospect. The landing-page track gives the agent a concrete section vocabulary, business-type guidance, and a slop checklist to apply before delivery.
2. Picking Ollama Cloud / OpenAI / Anthropic without entering a key produced a raw upstream error message that didn't tell the user what to fix. The new flow either uses a key from `.env.local` automatically or returns a clear setup message.

## Test plan

- [ ] In the webui: pick `Ollama Cloud` / `OpenAI` / `Anthropic` with no key, hit Generate → see a clear "requires an API key" message (not "401 Unauthorized: unauthorized")
- [ ] Set `OPENAI_API_KEY` (or equivalent) in `.env.local`, restart server, generate without filling the API key field → succeeds
- [ ] Generate with `prototype` mode for a restaurant brief → output uses real-feeling sections (hero/menu/gallery/reviews/hours/booking), not generic three-card grid
- [ ] Existing `slides` / `motion` modes still load their respective references (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)