### PR TITLE
Enable real GPU in headless Playwright recorder

### DIFF
--- a/scripts/render-video.js
+++ b/scripts/render-video.js
@@ -94,7 +94,20 @@ console.log(`  output: ${MP4_OUT}`);
 (async () => {
   fs.mkdirSync(TMP_DIR, { recursive: true });
 
-  const browser = await chromium.launch();
+  const isWin = process.platform === 'win32';
+  const browser = await chromium.launch({
+    args: [
+      // Prefer real GPU when available; falls back to SwiftShader if no GPU
+      '--enable-gpu',
+      '--ignore-gpu-blocklist',
+      isWin ? '--use-angle=d3d11' : '--use-angle=vulkan',
+      '--enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan',
+      '--enable-unsafe-webgpu',
+      '--enable-unsafe-swiftshader',
+      // Recording-friendly: keep one process so frames stay deterministic
+      '--disable-features=CalculateNativeWinOcclusion',
+    ],
+  });
   const url = 'file://' + HTML_ABS;
 
   // ── Phase 1: WARMUP (no recording, caches fonts/assets) ─────────────


### PR DESCRIPTION
## What this changes

`scripts/render-video.js` calls `chromium.launch()` with no args, which means the headless recorder runs WebGL through ANGLE+SwiftShader on hosts that *do* have a usable GPU. WebGPU is disabled entirely. That's fine for the current 2D HTML output, but it caps quality and forecloses 3D scenes for any future render targets (three.js, react-three-fiber, WebGPU TSL).

This adds a small cross-platform args array that opts into hardware acceleration where available and keeps software fallback for CI:

- `--enable-gpu` / `--ignore-gpu-blocklist` — hardware accel
- `--use-angle=d3d11` on Windows, `--use-angle=vulkan` elsewhere — pick the right ANGLE backend
- `--enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan` — Vulkan ICD path on Linux
- `--enable-unsafe-webgpu` — opt into WebGPU in headless mode
- `--enable-unsafe-swiftshader` — preserve CI-without-GPU behavior as a safety net

## Why it's safe

These flags only take effect when a page creates a WebGL or WebGPU context. Pure CSS / DOM / Canvas2D pages (the entirety of the current skill output) render the same as before. No animation timing, no `recordVideo` behavior, no ffmpeg step changes.

## How to verify

Run any existing recipe with `node scripts/render-video.js <html>`, the output WebM should be identical. Then load a page with a WebGL canvas and check `chrome://gpu` (use a non-headless smoke run with the same flags) — it should now report "Hardware accelerated" instead of "Software only" on machines with a GPU.

## Scope

One file, one launch site, additive change. No refactor.