### PR TITLE
Add polished static homepage

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/SITE.md
+++ b/SITE.md
@@ -1,0 +1,18 @@
+# Static site for Huashu Design
+
+This folder intentionally stays dependency-free. The homepage is a single `index.html` file at the repository root so it can run on GitHub Pages without a build step.
+
+## Local preview
+
+```bash
+python3 -m http.server 4173
+```
+
+Then open http://localhost:4173.
+
+## Design notes
+
+- Editorial, portfolio-style presentation instead of a generic AI/SaaS landing page.
+- Uses existing repository showcase screenshots and links to their source HTML.
+- No external fonts, JS frameworks, analytics, or generated imagery.
+- GitHub Pages deploys the root directory through `.github/workflows/pages.yml`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,635 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Huashu Design is an HTML-native design skill for AI agents. Build prototypes, decks, launch motion and design reviews from one sentence." />
+  <title>Huashu Design — design work from a sentence</title>
+  <style>
+    :root {
+      --bg: #f4f1ea;
+      --paper: #fffdf7;
+      --ink: #151412;
+      --muted: #686057;
+      --line: rgba(21, 20, 18, .14);
+      --black: #050505;
+      --white: #fffdf7;
+      --red: #dc2f2f;
+      --gold: #b89664;
+      --green: #78866b;
+      --radius: 18px;
+      --max: 1180px;
+      --shadow: 0 30px 90px rgba(21, 20, 18, .12);
+      color-scheme: light;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background:
+        linear-gradient(90deg, rgba(21,20,18,.035) 1px, transparent 1px) 0 0 / 80px 80px,
+        linear-gradient(rgba(21,20,18,.03) 1px, transparent 1px) 0 0 / 80px 80px,
+        var(--bg);
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a { color: inherit; text-decoration: none; }
+    img, video { max-width: 100%; display: block; }
+    ::selection { background: var(--red); color: white; }
+
+    .nav {
+      position: sticky;
+      top: 0;
+      z-index: 30;
+      border-bottom: 1px solid rgba(255,255,255,.16);
+      background: rgba(5,5,5,.82);
+      color: var(--white);
+      backdrop-filter: blur(18px) saturate(140%);
+    }
+    .nav-inner {
+      max-width: var(--max);
+      height: 58px;
+      margin: 0 auto;
+      padding: 0 22px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 24px;
+    }
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 14px;
+      font-weight: 650;
+      letter-spacing: .02em;
+    }
+    .mark {
+      width: 28px;
+      height: 28px;
+      display: grid;
+      place-items: center;
+      border: 1px solid rgba(255,255,255,.28);
+      border-radius: 50%;
+      font-family: ui-serif, Georgia, serif;
+      font-size: 15px;
+    }
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 22px;
+      color: rgba(255,255,255,.72);
+      font-size: 13px;
+    }
+    .nav-links a:hover { color: white; }
+    .nav-cta {
+      padding: 9px 14px;
+      border: 1px solid rgba(255,255,255,.24);
+      border-radius: 999px;
+      color: white;
+    }
+
+    .hero {
+      background: var(--black);
+      color: var(--white);
+      min-height: calc(100svh - 58px);
+      display: grid;
+      align-items: center;
+      overflow: hidden;
+      position: relative;
+    }
+    .hero::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background:
+        radial-gradient(circle at 74% 20%, rgba(220,47,47,.18), transparent 32%),
+        linear-gradient(90deg, rgba(255,255,255,.055) 1px, transparent 1px) 0 0 / 84px 84px,
+        linear-gradient(rgba(255,255,255,.045) 1px, transparent 1px) 0 0 / 84px 84px;
+      pointer-events: none;
+    }
+    .hero-inner {
+      position: relative;
+      max-width: var(--max);
+      margin: 0 auto;
+      padding: 94px 22px 70px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.03fr) minmax(340px, .97fr);
+      gap: clamp(40px, 7vw, 92px);
+      align-items: center;
+    }
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      color: rgba(255,255,255,.68);
+      font-size: 12px;
+      letter-spacing: .17em;
+      text-transform: uppercase;
+      font-weight: 700;
+      margin-bottom: 24px;
+    }
+    .eyebrow::before {
+      content: "";
+      width: 34px;
+      height: 1px;
+      background: var(--red);
+    }
+    h1 {
+      margin: 0;
+      max-width: 850px;
+      font-size: clamp(54px, 8.7vw, 126px);
+      line-height: .88;
+      letter-spacing: -.075em;
+      font-weight: 760;
+      text-wrap: balance;
+    }
+    .hero-copy {
+      margin: 28px 0 0;
+      max-width: 620px;
+      color: rgba(255,255,255,.76);
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.34;
+      letter-spacing: -.025em;
+      text-wrap: pretty;
+    }
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 34px;
+    }
+    .button {
+      display: inline-flex;
+      min-height: 46px;
+      align-items: center;
+      justify-content: center;
+      padding: 12px 18px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 700;
+      transition: transform .18s ease, background .18s ease, border-color .18s ease;
+    }
+    .button:hover { transform: translateY(-1px); }
+    .button.primary { background: var(--white); color: var(--black); }
+    .button.secondary { border: 1px solid rgba(255,255,255,.28); color: white; }
+
+    .terminal-card {
+      border: 1px solid rgba(255,255,255,.16);
+      border-radius: 24px;
+      background: rgba(255,255,255,.06);
+      box-shadow: 0 40px 120px rgba(0,0,0,.38);
+      overflow: hidden;
+    }
+    .terminal-top {
+      height: 42px;
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      padding: 0 16px;
+      border-bottom: 1px solid rgba(255,255,255,.12);
+      color: rgba(255,255,255,.44);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 12px;
+    }
+    .dot { width: 9px; height: 9px; border-radius: 50%; background: rgba(255,255,255,.28); }
+    .terminal-body {
+      padding: clamp(24px, 4vw, 38px);
+      min-height: 440px;
+      display: grid;
+      align-content: space-between;
+      gap: 34px;
+    }
+    .prompt {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: clamp(16px, 1.7vw, 22px);
+      line-height: 1.48;
+      color: rgba(255,255,255,.92);
+    }
+    .prompt span { color: #ff7168; }
+    .artifact {
+      background: var(--paper);
+      color: var(--ink);
+      border-radius: 18px;
+      padding: 22px;
+      box-shadow: 0 20px 70px rgba(0,0,0,.28);
+    }
+    .artifact-grid {
+      display: grid;
+      grid-template-columns: 1.1fr .9fr;
+      gap: 16px;
+      align-items: end;
+      min-height: 180px;
+    }
+    .artifact-title {
+      font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+      font-size: 42px;
+      line-height: .94;
+      letter-spacing: -.055em;
+      margin: 0;
+    }
+    .artifact-bars { display: grid; gap: 8px; }
+    .artifact-bars i { display: block; height: 10px; background: var(--black); opacity: .18; border-radius: 999px; }
+    .artifact-bars i:nth-child(2) { width: 74%; opacity: .28; }
+    .artifact-bars i:nth-child(3) { width: 48%; background: var(--red); opacity: 1; }
+
+    section { position: relative; }
+    .wrap { max-width: var(--max); margin: 0 auto; padding: 0 22px; }
+    .section-pad { padding: clamp(72px, 11vw, 148px) 0; }
+    .section-head {
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      gap: clamp(28px, 7vw, 92px);
+      align-items: start;
+      margin-bottom: 48px;
+      border-top: 1px solid var(--line);
+      padding-top: 24px;
+    }
+    .kicker {
+      color: var(--muted);
+      font-size: 12px;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      font-weight: 800;
+    }
+    h2 {
+      margin: 0;
+      font-size: clamp(38px, 6vw, 84px);
+      line-height: .95;
+      letter-spacing: -.065em;
+      font-weight: 760;
+      text-wrap: balance;
+    }
+    .lead {
+      max-width: 680px;
+      margin: 22px 0 0;
+      color: var(--muted);
+      font-size: 20px;
+      line-height: 1.45;
+      letter-spacing: -.02em;
+      text-wrap: pretty;
+    }
+
+    .proof-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1px;
+      background: var(--line);
+      border: 1px solid var(--line);
+    }
+    .proof {
+      background: var(--paper);
+      min-height: 250px;
+      padding: 24px;
+      display: grid;
+      align-content: space-between;
+    }
+    .proof strong {
+      display: block;
+      font-size: clamp(46px, 6vw, 84px);
+      line-height: .86;
+      letter-spacing: -.075em;
+    }
+    .proof p { margin: 18px 0 0; color: var(--muted); line-height: 1.5; }
+    .proof small { color: var(--red); font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+
+    .gallery {
+      display: grid;
+      grid-template-columns: 1.25fr .75fr;
+      gap: 22px;
+      align-items: stretch;
+    }
+    .showcase-main, .showcase-list {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+      box-shadow: var(--shadow);
+    }
+    .showcase-main img { width: 100%; aspect-ratio: 16 / 10; object-fit: cover; object-position: top center; }
+    .showcase-caption { padding: 24px; display: flex; justify-content: space-between; gap: 20px; align-items: end; }
+    .showcase-caption h3 { margin: 0; font-size: 26px; letter-spacing: -.04em; }
+    .showcase-caption p { margin: 8px 0 0; color: var(--muted); line-height: 1.45; }
+    .style-tag { color: var(--red); font-size: 12px; letter-spacing: .14em; text-transform: uppercase; font-weight: 850; }
+    .showcase-list { padding: 16px; display: grid; gap: 14px; align-content: start; box-shadow: none; }
+    .mini {
+      display: grid;
+      grid-template-columns: 116px 1fr;
+      gap: 14px;
+      align-items: center;
+      padding: 10px;
+      border-radius: 14px;
+      background: rgba(21,20,18,.035);
+    }
+    .mini img { width: 116px; aspect-ratio: 4 / 3; object-fit: cover; object-position: top center; border-radius: 10px; border: 1px solid var(--line); }
+    .mini b { display: block; letter-spacing: -.02em; }
+    .mini span { display: block; margin-top: 5px; color: var(--muted); font-size: 13px; line-height: 1.35; }
+
+    .dark {
+      background: var(--black);
+      color: var(--white);
+    }
+    .dark .section-head { border-top-color: rgba(255,255,255,.18); }
+    .dark .lead, .dark .kicker { color: rgba(255,255,255,.62); }
+    .system-grid {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      border: 1px solid rgba(255,255,255,.16);
+      background: rgba(255,255,255,.14);
+      gap: 1px;
+    }
+    .system-cell {
+      min-height: 220px;
+      background: #0c0c0c;
+      padding: 20px;
+      display: grid;
+      align-content: space-between;
+    }
+    .system-cell b { font-size: 20px; letter-spacing: -.035em; }
+    .system-cell span { color: rgba(255,255,255,.56); font-size: 13px; line-height: 1.45; }
+    .system-cell:nth-child(1) { border-top: 5px solid var(--red); }
+    .system-cell:nth-child(2) { border-top: 5px solid var(--gold); }
+    .system-cell:nth-child(3) { border-top: 5px solid var(--green); }
+    .system-cell:nth-child(4) { border-top: 5px solid #d8d3c8; }
+    .system-cell:nth-child(5) { border-top: 5px solid #8f8f8f; }
+
+    .compare {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1px;
+      background: var(--line);
+      border: 1px solid var(--line);
+    }
+    .compare-card {
+      background: var(--paper);
+      padding: clamp(24px, 4vw, 42px);
+      min-height: 380px;
+    }
+    .compare-card h3 { margin: 0 0 26px; font-size: 32px; letter-spacing: -.045em; }
+    .compare-card ul { margin: 0; padding: 0; list-style: none; display: grid; gap: 14px; }
+    .compare-card li { display: grid; grid-template-columns: 28px 1fr; gap: 12px; color: var(--muted); line-height: 1.5; }
+    .compare-card li::before { content: ""; width: 10px; height: 10px; margin-top: 7px; border-radius: 50%; background: var(--red); }
+    .compare-card.quiet li::before { background: rgba(21,20,18,.24); }
+
+    .install {
+      background: var(--paper);
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      padding: clamp(28px, 5vw, 54px);
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 28px;
+      align-items: center;
+      box-shadow: var(--shadow);
+    }
+    .install h2 { font-size: clamp(38px, 5vw, 70px); }
+    .code {
+      margin-top: 22px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 16px 18px;
+      border-radius: 16px;
+      background: #111;
+      color: white;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 14px;
+      overflow-x: auto;
+    }
+    .copy {
+      border: 1px solid rgba(255,255,255,.18);
+      border-radius: 999px;
+      background: white;
+      color: black;
+      padding: 8px 12px;
+      cursor: pointer;
+      font: inherit;
+      white-space: nowrap;
+    }
+    .install-meta {
+      display: grid;
+      gap: 12px;
+      min-width: 210px;
+    }
+    .meta-line {
+      border-top: 1px solid var(--line);
+      padding-top: 12px;
+      color: var(--muted);
+      font-size: 14px;
+      line-height: 1.4;
+    }
+    .meta-line b { display: block; color: var(--ink); font-size: 18px; letter-spacing: -.02em; margin-bottom: 2px; }
+
+    footer {
+      padding: 36px 0 60px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .footer-inner { max-width: var(--max); margin: 0 auto; padding: 0 22px; display: flex; justify-content: space-between; gap: 20px; border-top: 1px solid var(--line); padding-top: 22px; }
+    .footer-inner a { color: var(--ink); font-weight: 700; }
+
+    @media (max-width: 920px) {
+      .hero-inner, .gallery, .compare, .install { grid-template-columns: 1fr; }
+      .terminal-body { min-height: 360px; }
+      .section-head { grid-template-columns: 1fr; }
+      .proof-grid { grid-template-columns: 1fr; }
+      .system-grid { grid-template-columns: repeat(2, 1fr); }
+      .nav-links a:not(.nav-cta) { display: none; }
+    }
+    @media (max-width: 560px) {
+      .hero-inner { padding-top: 68px; }
+      .nav-inner { padding: 0 16px; }
+      .brand span:last-child { display: none; }
+      .system-grid { grid-template-columns: 1fr; }
+      .mini { grid-template-columns: 88px 1fr; }
+      .mini img { width: 88px; }
+      .footer-inner { flex-direction: column; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
+    }
+  </style>
+</head>
+<body>
+  <nav class="nav" aria-label="Primary">
+    <div class="nav-inner">
+      <a class="brand" href="#top" aria-label="Huashu Design home"><span class="mark">花</span><span>Huashu Design</span></a>
+      <div class="nav-links">
+        <a href="#proof">What it ships</a>
+        <a href="#gallery">Gallery</a>
+        <a href="#system">System</a>
+        <a class="nav-cta" href="#install">Install</a>
+      </div>
+    </div>
+  </nav>
+
+  <main id="top">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="hero-inner">
+        <div>
+          <div class="eyebrow">HTML-native design skill</div>
+          <h1 id="hero-title">Design work from a sentence.</h1>
+          <p class="hero-copy">Huashu Design turns a plain-language brief into prototypes, decks, product motion and expert reviews that feel intentionally directed — not machine-generated decoration.</p>
+          <div class="hero-actions">
+            <a class="button primary" href="#install">Install the skill</a>
+            <a class="button secondary" href="#gallery">View generated work</a>
+          </div>
+        </div>
+
+        <div class="terminal-card" aria-label="Prompt to artifact preview">
+          <div class="terminal-top"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span style="margin-left:8px">agent session</span></div>
+          <div class="terminal-body">
+            <div class="prompt"><span>›</span> Build a launch animation, a clickable prototype, and a board-ready deck. Keep it quiet. Make it feel designed.</div>
+            <div class="artifact" aria-hidden="true">
+              <div class="artifact-grid">
+                <p class="artifact-title">A finished artifact, not a prompt dump.</p>
+                <div class="artifact-bars"><i></i><i></i><i></i></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="proof" class="section-pad">
+      <div class="wrap">
+        <div class="section-head">
+          <div class="kicker">What it ships</div>
+          <div>
+            <h2>The output is a real file you can open, present, record, export, or edit.</h2>
+            <p class="lead">The repo is not selling vibes. It packages design mechanics: brand asset protocol, 20 visual vocabularies, deck export, motion rendering, and a five-dimension critique pass.</p>
+          </div>
+        </div>
+        <div class="proof-grid">
+          <article class="proof"><small>Range</small><div><strong>3–30</strong><p>minutes from brief to prototype, deck, infographic, motion clip or review.</p></div></article>
+          <article class="proof"><small>Vocabulary</small><div><strong>20</strong><p>design philosophies that push the agent away from generic AI defaults.</p></div></article>
+          <article class="proof"><small>Output</small><div><strong>HTML</strong><p>as the source of truth, with PDF, PPTX, MP4, GIF and image exports downstream.</p></div></article>
+        </div>
+      </div>
+    </section>
+
+    <section id="gallery" class="section-pad" style="padding-top:0">
+      <div class="wrap">
+        <div class="section-head">
+          <div class="kicker">Generated samples</div>
+          <div>
+            <h2>Three design schools. Same brief. Visibly different taste.</h2>
+            <p class="lead">No fake dashboards. No purple fog. These are the actual showcase assets from the repository, presented like a portfolio instead of a README dump.</p>
+          </div>
+        </div>
+        <div class="gallery">
+          <article class="showcase-main">
+            <img src="assets/showcases/website-saas/saas-pentagram.png" alt="Pentagram-inspired SaaS website showcase" loading="lazy" />
+            <div class="showcase-caption">
+              <div><h3>Pentagram discipline</h3><p>Swiss grid, hard contrast, deliberate red accent.</p></div>
+              <div class="style-tag">Website / SaaS</div>
+            </div>
+          </article>
+          <div class="showcase-list" aria-label="More showcase styles">
+            <a class="mini" href="assets/showcases/website-saas/saas-build.html"><img src="assets/showcases/website-saas/saas-build.png" alt="Build Studio inspired SaaS preview" loading="lazy" /><span><b>Build Studio</b><span>Luxury restraint, warm gold, generous negative space.</span></span></a>
+            <a class="mini" href="assets/showcases/website-saas/saas-takram.html"><img src="assets/showcases/website-saas/saas-takram.png" alt="Takram inspired SaaS preview" loading="lazy" /><span><b>Takram</b><span>Soft technology, natural color, calm geometry.</span></span></a>
+            <a class="mini" href="assets/showcases/website-devdocs/devdocs-pentagram.html"><img src="assets/showcases/website-devdocs/devdocs-pentagram.png" alt="Developer docs preview" loading="lazy" /><span><b>Developer docs</b><span>Information-dense without becoming card soup.</span></span></a>
+            <a class="mini" href="assets/showcases/ppt/ppt-takram.html"><img src="assets/showcases/ppt/ppt-takram.png" alt="Slide deck preview" loading="lazy" /><span><b>Deck systems</b><span>Browser-native slides that can export to editable PPTX.</span></span></a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="system" class="dark section-pad">
+      <div class="wrap">
+        <div class="section-head">
+          <div class="kicker">The method</div>
+          <div>
+            <h2>It makes the agent behave less like a slot machine and more like a junior designer with a process.</h2>
+            <p class="lead">Huashu starts from context, freezes brand facts, chooses a visual school, builds actual HTML, then verifies and critiques before delivery.</p>
+          </div>
+        </div>
+        <div class="system-grid">
+          <div class="system-cell"><b>Ask</b><span>Logo, screenshots, product shots, colors, fonts and brand rules before guessing.</span></div>
+          <div class="system-cell"><b>Find</b><span>Official sources first: brand pages, press kits, product pages and launch media.</span></div>
+          <div class="system-cell"><b>Freeze</b><span>Write a brand spec so the work has stable inputs instead of vibe memory.</span></div>
+          <div class="system-cell"><b>Build</b><span>HTML prototypes, decks, animations and infographics with real interaction where needed.</span></div>
+          <div class="system-cell"><b>Review</b><span>Score hierarchy, craft, function, coherence and originality before calling it done.</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-pad">
+      <div class="wrap">
+        <div class="section-head">
+          <div class="kicker">Positioning</div>
+          <div>
+            <h2>For people who want design output without opening a design tool.</h2>
+          </div>
+        </div>
+        <div class="compare">
+          <article class="compare-card">
+            <h3>Good fit</h3>
+            <ul>
+              <li>Launch videos, product animations and explainers that need to ship quickly.</li>
+              <li>Clickable prototypes for app or web concepts when Figma fidelity is not required.</li>
+              <li>Board decks, data pages and infographics where exportable files matter.</li>
+              <li>Design direction exploration: three distinct routes instead of one generic answer.</li>
+            </ul>
+          </article>
+          <article class="compare-card quiet">
+            <h3>Not pretending</h3>
+            <ul>
+              <li>It is not a replacement for a senior art director on major brand systems.</li>
+              <li>It does not promise layer-perfect Figma or Keynote round-tripping.</li>
+              <li>It will not invent brand assets when official material is required.</li>
+              <li>It is an 80-point skill: practical, fast, open, and honest about its limits.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="install" class="section-pad" style="padding-top:0">
+      <div class="wrap">
+        <div class="install">
+          <div>
+            <div class="kicker">Install</div>
+            <h2>Add it to your agent and start with one sentence.</h2>
+            <div class="code"><code>npx skills add alchaincyf/huashu-design</code><button class="copy" type="button" data-copy="npx skills add alchaincyf/huashu-design">Copy</button></div>
+          </div>
+          <div class="install-meta">
+            <div class="meta-line"><b>MIT licensed</b>Commercial use allowed.</div>
+            <div class="meta-line"><b>Agent agnostic</b>Claude Code, Cursor, Codex, Hermes, OpenClaw.</div>
+            <div class="meta-line"><b>Bilingual</b>Chinese core prompts, English demos and README.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <div>Huashu Design · HTML-native design skill</div>
+      <div><a href="https://github.com/alchaincyf/huashu-design">GitHub</a> · <a href="README.md">README</a> · <a href="LICENSE">License</a></div>
+    </div>
+  </footer>
+
+  <script>
+    document.querySelectorAll('[data-copy]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const text = button.getAttribute('data-copy');
+        try {
+          await navigator.clipboard.writeText(text);
+          const old = button.textContent;
+          button.textContent = 'Copied';
+          setTimeout(() => { button.textContent = old; }, 1200);
+        } catch (_) {
+          button.textContent = text;
+        }
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a polished static homepage at the repo root
- Uses existing showcase screenshots instead of generic AI visuals
- Adds a dependency-free GitHub Pages workflow and SITE.md preview notes

## Verification
- Served locally with Python static server
- Checked index.html returns 200
- Verified all showcased images load in Playwright
- Verified no browser console errors and no horizontal overflow
- Published preview: https://aashowa.github.io/huashu-design/
