### PR TITLE
fix(deck_index): reclaim focus after iframe click (#23)

### DIFF
--- a/assets/deck_index.html
+++ b/assets/deck_index.html
@@ -214,6 +214,11 @@
   fit();
   show(current);
 
+  // Reclaim focus after clicking inside iframe so keyboard nav keeps working
+  window.addEventListener('blur', () => {
+    setTimeout(() => window.focus(), 100);
+  });
+
   // Print: build a stack of all iframes so browser prints every slide
   window.addEventListener('beforeprint', () => {
     printStack.innerHTML = '';


### PR DESCRIPTION
## Summary
- 修复 `assets/deck_index.html` 中鼠标点击 iframe 内部 slide 内容后，键盘翻页失效的问题
- 在 `show(current)` 之后注册 `window.blur` 监听，延迟 100ms 调用 `window.focus()` 把焦点抢回父页面

## Root Cause
点击进入 iframe 后焦点进入子 document，父页面的 `keydown` 事件不再触发——iframe 架构固有缺陷。

## Test plan
- [x] 本地用 deck_index.html 打开任意 deck，按方向键能翻页 ✅
- [x] 点击 slide 内任意内容后，再按方向键依然能翻页 ✅
- [x] 不影响 iframe 内交互元素（100ms 延迟保证子帧 click 先完成）

Fixes #23