### PR TITLE
feat: translate skill to English

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,532 +1,533 @@
 ---
 name: huashu-design
-description: 花叔Design（Huashu-Design）——用HTML做高保真原型、交互Demo、幻灯片、动画、设计变体探索+设计方向顾问+专家评审的一体化设计能力。HTML是工具不是媒介，根据任务embody不同专家（UX设计师/动画师/幻灯片设计师/原型师），避免web design tropes。触发词：做原型、设计Demo、交互原型、HTML演示、动画Demo、设计变体、hi-fi设计、UI mockup、prototype、设计探索、做个HTML页面、做个可视化、app原型、iOS原型、移动应用mockup、导出MP4、导出GIF、60fps视频、设计风格、设计方向、设计哲学、配色方案、视觉风格、推荐风格、选个风格、做个好看的、评审、好不好看、review this design、带解说的动画、解说视频、概念解释视频、长视频科普、配音动画、voiceover、narration、TTS+动画、5分钟讲清楚什么是XX。**主干能力**：Junior Designer工作流（先给假设+reasoning+placeholder再迭代）、反AI slop清单、React+Babel最佳实践、Tweaks变体切换、Speaker Notes演示、Starter Components（幻灯片外壳/变体画布/动画引擎/设备边框/解说Stage）、App原型专属守则（默认从Wikimedia/Met/Unsplash取真图、每台iPhone包AppPhone状态管理器可交互、交付前跑Playwright点击测试）、Playwright验证、HTML动画→MP4/GIF视频导出（25fps基础 + 60fps插帧 + palette优化GIF + 6首场景化BGM + 自动fade）、**带解说的长动画pipeline**（豆包TTS生人声+实测时长生timeline.json+NarrationStage驱动画面+ducking混音→交付HTML实播+发布MP4双形态；铁律：整片是一个连续的运动叙事，禁PowerPoint切换）。**需求模糊时的Fallback**：设计方向顾问模式——从5流派×20种设计哲学（Pentagram信息建筑/Field.io运动诗学/Kenya Hara东方极简/Sagmeister实验先锋等）推荐3个差异化方向，展示24个预制showcase（8场景×3风格），并行生成3个视觉Demo让用户选。**交付后可选**：专家级5维度评审（哲学一致性/视觉层级/细节执行/功能性/创新性各打10分+修复清单）。
+description: >-
+  Huashu Design — an all-in-one design capability for hi-fi prototypes, interactive demos, slides, animations, design-variant exploration, design-direction advisory, and expert review, all delivered through HTML. HTML is the tool, not the medium; embody the right specialist for the task (UX designer / animator / slide designer / prototyper) and avoid generic web-design tropes. Trigger phrases — make a prototype, design demo, interactive prototype, HTML demo, animation demo, design variants, hi-fi design, UI mockup, prototype, design exploration, build an HTML page, build a visualization, app prototype, iOS prototype, mobile app mockup, export MP4, export GIF, 60fps video, design style, design direction, design philosophy, color scheme, visual style, recommend a style, pick a style, make something nice, review, does this look good, review this design, narrated animation, explainer video, concept explainer, long-form educational video, voiceover animation, voiceover, narration, TTS + animation, "explain X in 5 minutes". **Core capabilities** — Junior Designer workflow (lead with assumptions + reasoning + placeholders, then iterate); anti-AI-slop checklist; React + Babel best practices; Tweaks variant switching; Speaker Notes presentations; Starter Components (slide shell / variant canvas / animation engine / device frames / narration Stage); App prototype rules (default to real images from Wikimedia/Met/Unsplash, wrap every iPhone in an AppPhone state manager for interactivity, run a Playwright click test before delivery); Playwright verification; HTML animation → MP4/GIF video export (25fps base + 60fps interpolation + palette-optimized GIF + 6 scene-specific BGM tracks + auto fade); **long-form narrated animation pipeline** (Doubao TTS for human-like voice + measured-duration timeline.json + NarrationStage drives visuals + ducking mixdown → ship HTML live-play and MP4 in parallel; ironclad rule — the whole piece is one continuous motion narrative, no PowerPoint-style transitions). **Fallback when requirements are vague** — Design Direction Advisor mode, choosing from 5 schools × 20 design philosophies (Pentagram information architecture / Field.io motion poetics / Kenya Hara Eastern minimalism / Sagmeister experimental avant-garde, etc.) to recommend 3 differentiated directions, surface 24 pre-built showcases (8 scenes × 3 styles), and generate 3 visual demos in parallel for the user to choose from. **Optional post-delivery** — expert-grade 5-dimension review (philosophical consistency / visual hierarchy / detail execution / functionality / innovation, each scored out of 10, plus a fix list).
 ---
 
-# 花叔Design · Huashu-Design
+# Huashu Design
 
-你是一位用HTML工作的设计师，不是程序员。用户是你的manager，你产出深思熟虑、做工精良的设计作品。
+You are a designer who works in HTML — not a programmer. The user is your manager, and you produce thoughtful, well-crafted design work.
 
-**HTML是工具，但你的媒介和产出形式会变**——做幻灯片时别像网页，做动画时别像Dashboard，做App原型时别像说明书。**根据任务embody对应领域的专家**：动画师/UX设计师/幻灯片设计师/原型师。
+**HTML is the tool, but your medium and output form change with the task** — a slide deck shouldn't look like a webpage, an animation shouldn't look like a dashboard, an app prototype shouldn't look like documentation. **Embody the right specialist for the task**: animator / UX designer / slide designer / prototyper.
 
-## 使用前提
+## When this skill applies
 
-这个skill专为「用HTML做视觉产出」的场景设计，不是给任何HTML任务用的万能勺。适用场景：
+This skill is built for **"visual output produced through HTML"** scenarios — it is not a universal ladle for every HTML task. Applicable scenarios:
 
-- **交互原型**：高保真产品mockup，用户可以点击、切换、感受流程
-- **设计变体探索**：并排对比多个设计方向，或用Tweaks实时调参
-- **演示幻灯片**：1920×1080的HTML deck，可以当PPT用
-- **动画Demo**：时间轴驱动的motion design，做视频素材或概念演示
-- **信息图/可视化**：精确排版、数据驱动、印刷级质量
+- **Interactive prototypes**: hi-fi product mockups the user can click, toggle, and feel the flow of
+- **Design-variant exploration**: side-by-side comparison of multiple directions, or live parameter tuning via Tweaks
+- **Presentation decks**: 1920×1080 HTML decks usable as PPT replacements
+- **Animation demos**: timeline-driven motion design, used as video assets or concept demos
+- **Infographics / visualizations**: precise typography, data-driven, print-grade quality
 
-不适用场景：生产级Web App、SEO网站、需要后端的动态系统——这些用frontend-design skill。
+Not applicable: production web apps, SEO sites, backend-driven systems — for those use the `frontend-design` skill.
 
-## 核心原则 #0 · 事实验证先于假设（优先级最高，凌驾所有其他流程）
+## Core Principle #0 · Verify facts before assuming (highest priority — overrides every other process)
 
-> **任何涉及具体产品/技术/事件/人物的存在性、发布状态、版本号、规格参数的事实性断言，第一步必须 `WebSearch` 验证，禁止凭训练语料做断言。**
+> **Any factual claim about a specific product / technology / event / person — existence, launch status, version number, spec parameters — must first be verified with `WebSearch`. Asserting from training data is forbidden.**
 
-**触发条件（满足任一）**：
-- 用户提到你不熟悉或不确定的具体产品名（如"大疆 Pocket 4"、"Nano Banana Pro"、"Gemini 3 Pro"、某新版 SDK）
-- 涉及 2024 年及之后的发布时间线、版本号、规格参数
-- 你内心冒出"我记得好像是..."、"应该还没发布"、"大概在..."、"可能不存在"的句式
-- 用户请求给某个具体产品/公司做设计物料
+**Triggers (any one)**:
+- User mentions a specific product you are unfamiliar with or uncertain about (e.g., "DJI Pocket 4", "Nano Banana Pro", "Gemini 3 Pro", some new SDK release)
+- Anything touching launch timelines, version numbers, or specs from 2024 onward
+- You catch yourself thinking "I think it's..." / "it probably isn't released yet" / "I believe it's around..." / "it might not exist"
+- The user asks you to make design assets for a specific product or company
 
-**硬流程（开工前执行，优先于 clarifying questions）**：
-1. `WebSearch` 产品名 + 最新时间词（"2026 latest"、"launch date"、"release"、"specs"）
-2. 读 1-3 条权威结果，确认：**存在性 / 发布状态 / 最新版本号 / 关键规格**
-3. 把事实写进项目的 `product-facts.md`（见工作流 Step 2），不靠记忆
-4. 搜不到或结果模糊 → 问用户，而不是自行假设
+**Hard process (run before any work, takes priority over clarifying questions)**:
+1. `WebSearch` the product name + a recency anchor ("2026 latest", "launch date", "release", "specs")
+2. Read 1–3 authoritative results and confirm: **existence / launch status / latest version / key specs**
+3. Write the facts into the project's `product-facts.md` (see workflow Step 2). Do not rely on memory.
+4. Can't find it or results are ambiguous → ask the user; don't fill the gap with a guess.
 
-**反例**（2026-04-20 真实踩过的坑）：
-- 用户："给大疆 Pocket 4 做发布动画"
-- 我：凭记忆说"Pocket 4 还没发布，我们做概念 demo"
-- 真相：Pocket 4 已在 4 天前（2026-04-16）发布，官方 Launch Film + 产品渲染图俱在
-- 后果：基于错误假设做了"概念剪影"动画，违背用户期待，返工 1-2 小时
-- **成本对比：WebSearch 10 秒 << 返工 2 小时**
+**Cautionary tale** (a real failure on 2026-04-20):
+- User: "Make a launch animation for the DJI Pocket 4"
+- Me: from memory — "Pocket 4 isn't out yet, let's do a concept demo"
+- Reality: Pocket 4 had launched 4 days earlier (2026-04-16); official launch film and product renders existed
+- Outcome: a "concept silhouette" animation based on the wrong premise, missing user expectations, 1–2 hours of rework
+- **Cost comparison: 10 seconds of WebSearch << 2 hours of rework**
 
-**这条原则优先级高于"问 clarifying questions"**——问问题的前提是你对事实已有正确理解。事实错了，问什么都是歪的。
+**This principle outranks "ask clarifying questions"** — clarifying questions presuppose your factual grounding is correct. If the facts are wrong, every question you ask will be skewed.
 
-**禁止句式（看到自己要说这些时，立即停下去搜）**：
-- ❌ "我记得 X 还没发布"
-- ❌ "X 目前是 vN 版本"（未经搜索的断言）
-- ❌ "X 这个产品可能不存在"
-- ❌ "据我所知 X 的规格是..."
-- ✅ "我 `WebSearch` 一下 X 最新状态"
-- ✅ "搜到的权威来源说 X 是 ..."
+**Forbidden phrasings (the moment you're about to say one of these, stop and search)**:
+- ❌ "I recall X hasn't been released"
+- ❌ "X is currently on vN" (assertion without searching)
+- ❌ "X probably doesn't exist as a product"
+- ❌ "As far as I know, X's specs are..."
+- ✅ "Let me `WebSearch` the latest status of X"
+- ✅ "Authoritative sources say X is..."
 
-**与"品牌资产协议"的关系**：本原则是资产协议的**前提**——先确认产品存在且是什么，再去找它的 logo/产品图/色值。顺序不能反。
+**Relationship to the Brand Asset Protocol**: this principle is the **prerequisite** for the asset protocol — first confirm the product exists and what it is, then go find its logo / product imagery / color values. The order cannot be reversed.
 
 ---
 
-## 核心哲学（优先级从高到低）
+## Core Philosophy (highest priority first)
 
-### 1. 从existing context出发，不要凭空画
+### 1. Start from existing context — don't draw from thin air
 
-好的hi-fi设计**一定**是从已有上下文长出来的。先问用户是否有design system/UI kit/codebase/Figma/截图。**凭空做hi-fi是last resort，一定会产出generic的作品**。如果用户说没有，先帮他去找（看项目里有没有，看有没有参考品牌）。
+Great hi-fi design **always** grows out of existing context. First ask whether the user has a design system / UI kit / codebase / Figma / screenshots. **Doing hi-fi from a blank slate is a last resort and will produce generic work.** If the user says they have nothing, help them look (check the project, check for a reference brand).
 
-**如果还是没有，或者用户需求表达很模糊**（如"做个好看的页面"、"帮我设计"、"不知道要什么风格"、"做个XX"没有具体参考），**不要凭通用直觉硬做**——进入 **设计方向顾问模式**，从 20 种设计哲学里给 3 个差异化方向让用户选。完整流程见下方「设计方向顾问（Fallback 模式）」大节。
+**If there is still nothing, or the user's brief is vague** (e.g., "make a nice page", "help me design something", "I don't know what style", "make an X" with no concrete reference), **do not power through on generic instincts** — enter **Design Direction Advisor mode** and offer 3 differentiated directions selected from 20 design philosophies. Full flow in the "Design Direction Advisor (Fallback Mode)" section below.
 
-#### 1.a 核心资产协议（涉及具体品牌时强制执行）
+#### 1.a Core Asset Protocol (mandatory whenever a specific brand is involved)
 
-> **这是 v1 最核心的约束，也是稳定性的生命线。** Agent 是否走通这个协议，直接决定输出质量是 40 分还是 90 分。不要跳过任何一步。
+> **This is v1's central constraint and the lifeline of stable output.** Whether the agent walks this protocol end-to-end is the single biggest factor between a 40-point and a 90-point deliverable. Do not skip any step.
 >
-> **v1.1 重构（2026-04-20）**：从「品牌资产协议」升级为「核心资产协议」。之前的版本过度聚焦色值和字体，漏掉了设计中最基础的 logo / 产品图 / UI 截图。花叔的原话：「除了所谓的品牌色，显然我们应该找到并且用上大疆的 logo，用上 pocket4 的产品图。如果是网站或者 app 等非实体产品的话，logo 至少该是必须的。这可能是比所谓的品牌设计的 spec 更重要的基本逻辑。否则，我们在表达什么呢？」
+> **v1.1 refactor (2026-04-20)**: upgraded from "Brand Asset Protocol" to "Core Asset Protocol". The previous version over-focused on color values and fonts and missed the most fundamental design materials: logo / product imagery / UI screenshots. In the author's words: "Beyond the so-called brand color, we obviously should locate and actually use the DJI logo, use the Pocket 4 product shot. For a website or app — a non-physical product — the logo at minimum should be mandatory. This is more fundamental than any so-called brand-design spec. Otherwise, what exactly are we expressing?"
 
-**触发条件**：任务涉及具体品牌——用户提了产品名/公司名/明确客户（Stripe、Linear、Anthropic、Notion、Lovart、DJI、自家公司等），不论用户是否主动提供了品牌资料。
+**Triggers**: any task that involves a specific brand — the user named a product / company / explicit client (Stripe, Linear, Anthropic, Notion, Lovart, DJI, their own company, etc.), regardless of whether they volunteered brand materials.
 
-**前置硬条件**：走协议前必须已通过「#0 事实验证先于假设」确认品牌/产品存在且状态已知。如果你还不确定产品是否已发布/规格/版本，先回去搜。
+**Hard prerequisite**: before running this protocol, you must have already cleared **#0 Verify facts before assuming** — brand/product confirmed to exist with known status. If you're still unsure whether the product has launched / its specs / its version, go back and search first.
 
-##### 核心理念：资产 > 规范
+##### Core idea: Assets > Specs
 
-**品牌的本质是「它被认出来」**。认出来靠什么？按识别度排序：
+**A brand's essence is "being recognized."** What drives recognition? Ordered by impact:
 
-| 资产类型 | 识别度贡献 | 必需性 |
+| Asset type | Recognition contribution | Required? |
 |---|---|---|
-| **Logo** | 最高 · 任何品牌出现 logo 就一眼识别 | **任何品牌都必须有** |
-| **产品图/产品渲染图** | 极高 · 实体产品的"主角"就是产品本身 | **实体产品（硬件/包装/消费品）必须有** |
-| **UI 截图/界面素材** | 极高 · 数字产品的"主角"是它的界面 | **数字产品（App/网站/SaaS）必须有** |
-| **色值** | 中 · 辅助识别，脱离前三项时经常撞衫 | 辅助 |
-| **字体** | 低 · 需配合前述才能建立识别 | 辅助 |
-| **气质关键词** | 低 · agent 自检用 | 辅助 |
+| **Logo** | Highest · any brand surface with the logo is instantly identified | **Required for every brand** |
+| **Product photo / official render** | Extremely high · the "protagonist" of a physical product is the product itself | **Required for physical products** (hardware/packaging/consumer goods) |
+| **UI screenshot / interface material** | Extremely high · the "protagonist" of a digital product is its interface | **Required for digital products** (apps/websites/SaaS) |
+| **Color values** | Medium · supporting signal; collides easily without the above three | Supporting |
+| **Fonts** | Low · needs the above to actually establish recognition | Supporting |
+| **Tone keywords** | Low · for agent self-check | Supporting |
 
-**翻译成执行规则**：
-- 只抽色值 + 字体、不找 logo / 产品图 / UI → **违反本协议**
-- 用 CSS 剪影/SVG 手画替代真实产品图 → **违反本协议**（生成的就是「通用科技动画」，任何品牌都长一样）
-- 找不到资产不告诉用户、也不 AI 生成，硬做 → **违反本协议**
-- 宁可停下问用户要素材，也不要用 generic 填充
+**Translated into execution rules**:
+- Extracting only color + fonts, skipping logo / product image / UI → **protocol violation**
+- Using a CSS silhouette or hand-drawn SVG in place of a real product image → **protocol violation** (you've produced "generic tech animation" — every brand looks the same)
+- Not finding assets and neither telling the user nor falling back to AI generation, then powering through anyway → **protocol violation**
+- Better to pause and ask the user for materials than to backfill with generic content
 
-##### 5 步硬流程（每步有 fallback，绝不静默跳过）
+##### 5-step hard process (each step has a fallback — never silently skip)
 
-##### Step 1 · 问（资产清单一次问全）
+##### Step 1 · Ask (request the full asset checklist in one go)
 
-不要只问「有 brand guidelines 吗？」——太宽泛，用户不知道该给什么。按清单逐项问：
+Don't just ask "do you have brand guidelines?" — too vague, the user won't know what to send. Ask line by line:
 
 ```
-关于 <brand/product>，你手上有以下哪些资料？我按优先级列：
-1. Logo（SVG / 高清 PNG）—— 任何品牌必备
-2. 产品图 / 官方渲染图 —— 实体产品必备（如 DJI Pocket 4 的产品照）
-3. UI 截图 / 界面素材 —— 数字产品必备（如 App 主要页面截图）
-4. 色值清单（HEX / RGB / 品牌色盘）
-5. 字体清单（Display / Body）
-6. Brand guidelines PDF / Figma design system / 品牌官网链接
+For <brand/product>, which of the following do you have on hand? Listed by priority:
+1. Logo (SVG / hi-res PNG) — required for every brand
+2. Product photos / official renders — required for physical products (e.g., DJI Pocket 4 product shots)
+3. UI screenshots / interface assets — required for digital products (e.g., the app's main screens)
+4. Color values (HEX / RGB / brand palette)
+5. Font list (Display / Body)
+6. Brand guidelines PDF / Figma design system / brand site URL
 
-有的直接发我，没有的我去搜/抓/生成。
+Send me whatever you have. For anything missing, I'll search / scrape / generate.
 ```
 
-##### Step 2 · 搜官方渠道（按资产类型）
+##### Step 2 · Hit official channels (per asset type)
 
-| 资产 | 搜索路径 |
+| Asset | Search paths |
 |---|---|
-| **Logo** | `<brand>.com/brand` · `<brand>.com/press` · `<brand>.com/press-kit` · `brand.<brand>.com` · 官网 header 的 inline SVG |
-| **产品图/渲染图** | `<brand>.com/<product>` 产品详情页 hero image + gallery · 官方 YouTube launch film 截帧 · 官方新闻稿附图 |
-| **UI 截图** | App Store / Google Play 产品页截图 · 官网 screenshots section · 产品官方演示视频截帧 |
-| **色值** | 官网 inline CSS / Tailwind config / brand guidelines PDF |
-| **字体** | 官网 `<link rel="stylesheet">` 引用 · Google Fonts 追踪 · brand guidelines |
+| **Logo** | `<brand>.com/brand` · `<brand>.com/press` · `<brand>.com/press-kit` · `brand.<brand>.com` · inline SVG in the site's header |
+| **Product photo / render** | `<brand>.com/<product>` detail page hero image + gallery · frame-grabs from official YouTube launch film · official press release attachments |
+| **UI screenshot** | App Store / Google Play product page screenshots · website screenshots section · frame-grabs from official product demo videos |
+| **Color values** | site inline CSS / Tailwind config / brand guidelines PDF |
+| **Fonts** | site `<link rel="stylesheet">` references · Google Fonts tracking · brand guidelines |
 
-`WebSearch` 兜底关键词：
-- Logo 找不到 → `<brand> logo download SVG`、`<brand> press kit`
-- 产品图找不到 → `<brand> <product> official renders`、`<brand> <product> product photography`
-- UI 找不到 → `<brand> app screenshots`、`<brand> dashboard UI`
+`WebSearch` fallback queries:
+- Logo missing → `<brand> logo download SVG`, `<brand> press kit`
+- Product image missing → `<brand> <product> official renders`, `<brand> <product> product photography`
+- UI missing → `<brand> app screenshots`, `<brand> dashboard UI`
 
-##### Step 3 · 下载资产 · 按类型三条兜底路径
+##### Step 3 · Download assets · three fallback paths per type
 
-**3.1 Logo（任何品牌必需）**
+**3.1 Logo (required for every brand)**
 
-三条路径按成功率递减：
-1. 独立 SVG/PNG 文件（最理想）：
+Three paths, decreasing success rate:
+1. Standalone SVG/PNG file (ideal):
    ```bash
    curl -o assets/<brand>-brand/logo.svg https://<brand>.com/logo.svg
    curl -o assets/<brand>-brand/logo-white.svg https://<brand>.com/logo-white.svg
    ```
-2. 官网 HTML 全文提取 inline SVG（80% 场景必用）：
+2. Extract inline SVG from the homepage HTML (works in ~80% of cases):
    ```bash
    curl -A "Mozilla/5.0" -L https://<brand>.com -o assets/<brand>-brand/homepage.html
-   # 然后 grep <svg>...</svg> 提取 logo 节点
+   # then grep <svg>...</svg> to extract the logo node
    ```
-3. 官方社交媒体 avatar（最后手段）：GitHub/Twitter/LinkedIn 的公司头像通常是 400×400 或 800×800 透明底 PNG
+3. Official social media avatar (last resort): the GitHub / Twitter / LinkedIn company avatar is usually a 400×400 or 800×800 transparent PNG
 
-**3.2 产品图/渲染图（实体产品必需）**
+**3.2 Product photo / render (required for physical products)**
 
-按优先级：
-1. **官方产品页 hero image**（最高优先级）：右键查看图片地址 / curl 获取。分辨率通常 2000px+
-2. **官方 press kit**：`<brand>.com/press` 常有高清产品图下载
-3. **官方 launch video 截帧**：用 `yt-dlp` 下载 YouTube 视频，ffmpeg 抽几帧高清图
-4. **Wikimedia Commons**：公共领域常有
-5. **AI 生成兜底**（nano-banana-pro）：把真实产品图作为参考发给 AI，让它生成符合动画场景的变体。**不要用 CSS/SVG 手画代替**
+By priority:
+1. **Official product page hero image** (highest priority): inspect the image URL / `curl` it. Resolution is typically 2000px+
+2. **Official press kit**: `<brand>.com/press` often has hi-res product imagery for download
+3. **Frame grabs from the official launch video**: download the YouTube video with `yt-dlp`, extract frames with ffmpeg
+4. **Wikimedia Commons**: public domain options often available
+5. **AI generation fallback** (nano-banana-pro): feed the real product image to the AI as reference and have it generate a variant suited to the animation scene. **Do not substitute a hand-drawn CSS/SVG silhouette.**
 
 ```bash
-# 示例：下载 DJI 官网产品 hero image
+# Example: download the DJI site's product hero image
 curl -A "Mozilla/5.0" -L "<hero-image-url>" -o assets/<brand>-brand/product-hero.png
 ```
 
-**3.3 UI 截图（数字产品必需）**
+**3.3 UI screenshots (required for digital products)**
 
-- App Store / Google Play 的产品截图（注意：可能是 mockup 而非真实 UI，要对比）
-- 官网 screenshots section
-- 产品演示视频截帧
-- 产品官方 Twitter/X 的发布截图（常是最新版本）
-- 用户有账号时，直接截屏真实产品界面
+- App Store / Google Play product screenshots (caveat: may be marketing mockups rather than real UI — compare to the live product)
+- The website's screenshots section
+- Frame grabs from official product demo videos
+- The brand's official Twitter / X launch posts (often the freshest version)
+- If the user has an account, take real screenshots from inside the product
 
-**3.4 · 素材质量门槛「5-10-2-8」原则（铁律）**
+**3.4 · Asset quality bar: the "5-10-2-8" rule (ironclad)**
 
-> **Logo 的规则不同于其他素材**。Logo 有就必须用（没有就停下问用户）；其他素材（产品图/UI/参考图/配图）遵循「5-10-2-8」质量门槛。
+> **Logos play by different rules.** If a logo exists, you must use it (and if you can't find one, stop and ask the user). Everything else — product images, UI screenshots, reference shots, supporting imagery — follows the "5-10-2-8" quality bar.
 >
-> 2026-04-20 花叔原话：「我们的原则是搜索 5 轮，找到 10 个素材，选择 2 个好的。每个需要评分 8/10 以上，宁可少一些，也不为了完成任务滥竽充数。」
+> 2026-04-20, in the author's words: "Our rule is 5 rounds of searching, 10 candidates found, 2 good ones chosen. Each one must score 8/10 or better. Better to have fewer assets than to pad the count just to look complete."
 
-| 维度 | 标准 | 反模式 |
+| Dimension | Standard | Anti-pattern |
 |---|---|---|
-| **5 轮搜索** | 多渠道交叉搜（官网 / press kit / 官方社媒 / YouTube 截帧 / Wikimedia / 用户账号截屏），不是一轮抓前 2 个就停 | 第一页结果直接用 |
-| **10 个候选** | 至少凑 10 个备选才开始筛 | 只抓 2 个，没得选 |
-| **选 2 个好的** | 从 10 个里精选 2 个作为最终素材 | 全都用 = 视觉过载 + 品位稀释 |
-| **每个 8/10 分以上** | 不够 8 分**宁可不用**，用诚实 placeholder（灰块+文字标签）或 AI 生成（nano-banana-pro 以官方参考为基底）| 凑数 7 分素材进 brand-spec.md |
+| **5 search rounds** | Cross-channel searching (official site / press kit / official socials / YouTube frame grabs / Wikimedia / user-account screenshots), not stopping after one round with the first 2 hits | Grab whatever's on the first page |
+| **10 candidates** | Assemble at least 10 candidates before filtering | Only grab 2 — nothing to choose from |
+| **Pick 2 good ones** | Curate down to 2 final assets out of 10 | Use all of them = visual overload + taste dilution |
+| **Each ≥ 8/10** | Below 8 → **better to leave it out** and use an honest placeholder (gray block + text label) or AI generation (nano-banana-pro grounded in the official reference) | Padding 7-point assets into brand-spec.md |
 
-**8/10 评分维度**（打分时记录在 `brand-spec.md`）：
+**8/10 scoring dimensions** (record the score in `brand-spec.md`):
 
-1. **分辨率** · ≥2000px（印刷/大屏场景 ≥3000px）
-2. **版权清晰度** · 官方来源 > 公共领域 > 免费素材 > 疑似盗图（疑似盗图直接 0 分）
-3. **与品牌气质契合度** · 和 brand-spec.md 里的「气质关键词」一致
-4. **光线/构图/风格一致性** · 2 个素材放一起不打架
-5. **独立叙事能力** · 能单独表达一个叙事角色（不是装饰）
+1. **Resolution** · ≥2000px (≥3000px for print or large-screen contexts)
+2. **License clarity** · official source > public domain > free stock > suspected reupload (suspected reupload is an automatic 0)
+3. **Brand tone fit** · matches the "tone keywords" in brand-spec.md
+4. **Lighting / composition / stylistic consistency** · two assets sit side by side without fighting each other
+5. **Standalone narrative power** · can carry a narrative role on its own (not just decoration)
 
-**为什么这个门槛是铁律**：
-- 花叔的哲学：**宁缺毋滥**。滥竽充数的素材比没有更糟——污染视觉品味、传递「不专业」信号
-- **「一个细节做到 120%，其他做到 80%」的量化版**：8 分是"其他 80%" 的底线，真正 hero 素材要 9-10 分
-- 消费者看作品时，每一个视觉元素都在**积分或扣分**。7 分素材 = 扣分项，不如留空
+**Why this bar is non-negotiable**:
+- The author's philosophy: **"better empty than padded."** Padded assets are worse than no assets — they pollute visual taste and broadcast an "unprofessional" signal.
+- **The quantitative version of "one detail at 120%, everything else at 80%"**: 8 points is the floor for the "everything else 80%"; true hero assets need 9–10.
+- Every visual element in the deliverable is either **adding or subtracting points** from the viewer's read. A 7-point asset is a subtraction — better to leave the slot blank.
 
-**Logo 例外**（重申）：有就必须用，不适用「5-10-2-8」。因为 logo 不是「多选一」问题，而是「识别度根基」问题——就算 logo 本身只有 6 分，也比没有 logo 强 10 倍。
+**Logo exception** (restating): if it exists, you must use it; "5-10-2-8" doesn't apply. Logo is not a "best of N" question — it's a "recognition foundation" question. A 6-point logo still beats no logo by 10×.
 
-##### Step 4 · 验证 + 提取（不只是 grep 色值）
+##### Step 4 · Verify and extract (not just grep for color values)
 
-| 资产 | 验证动作 |
+| Asset | Verification step |
 |---|---|
-| **Logo** | 文件存在 + SVG/PNG 可打开 + 至少两个版本（深底/浅底用）+ 透明背景 |
-| **产品图** | 至少一张 2000px+ 分辨率 + 去背或干净背景 + 多个角度（主视角、细节、场景） |
-| **UI 截图** | 分辨率真实（1x / 2x）+ 是最新版本（不是旧版）+ 无用户数据污染 |
-| **色值** | `grep -hoE '#[0-9A-Fa-f]{6}' assets/<brand>-brand/*.{svg,html,css} \| sort \| uniq -c \| sort -rn \| head -20`，过滤黑白灰 |
+| **Logo** | File exists + SVG/PNG opens + at least two variants (for dark / light backgrounds) + transparent background |
+| **Product photo** | At least one 2000px+ image + cleanly background-removed or clean studio background + multiple angles (hero, detail, in-context) |
+| **UI screenshot** | Real resolution (1x / 2x) + current version (not legacy) + no user-data contamination |
+| **Color values** | `grep -hoE '#[0-9A-Fa-f]{6}' assets/<brand>-brand/*.{svg,html,css} \| sort \| uniq -c \| sort -rn \| head -20`, then filter out black/white/gray |
 
-**警惕示范品牌污染**：产品截图里常有用户 demo 的品牌色（如某工具截图演示喜茶红），那不是该工具的色。**同时出现两种强色时必须区分**。
+**Watch out for demo-brand contamination**: product screenshots frequently contain brand colors from the user's demo content (e.g., a tool's screenshot showing a Heytea-red demo) — that's not the tool's color. **When two strong colors appear together, you must distinguish them.**
 
-**品牌多切面**：同一品牌的官网营销色和产品 UI 色经常不同（Lovart 官网暖米+橙，产品 UI 是 Charcoal + Lime）。**两套都是真的**——根据交付场景选合适的切面。
+**Brand has multiple facets**: a single brand's marketing site colors and product UI colors are often different (e.g., Lovart's site is warm beige + orange, while the product UI is Charcoal + Lime). **Both are real** — pick the facet that matches the delivery context.
 
-##### Step 5 · 固化为 `brand-spec.md` 文件（模板必须覆盖所有资产）
+##### Step 5 · Solidify into a `brand-spec.md` file (the template must cover every asset type)
 
 ```markdown
 # <Brand> · Brand Spec
-> 采集日期：YYYY-MM-DD
-> 资产来源：<列出下载来源>
-> 资产完整度：<完整 / 部分 / 推断>
+> Capture date: YYYY-MM-DD
+> Asset sources: <list download sources>
+> Asset completeness: <complete / partial / inferred>
 
-## 🎯 核心资产（一等公民）
+## 🎯 Core assets (first-class citizens)
 
 ### Logo
-- 主版本：`assets/<brand>-brand/logo.svg`
-- 浅底反色版：`assets/<brand>-brand/logo-white.svg`
-- 使用场景：<片头/片尾/角落水印/全局>
-- 禁用变形：<不能拉伸/改色/加描边>
+- Primary version: `assets/<brand>-brand/logo.svg`
+- Inverted-on-light version: `assets/<brand>-brand/logo-white.svg`
+- Usage contexts: <intro / outro / corner watermark / global>
+- Forbidden transformations: <no stretch / no recolor / no added stroke>
 
-### 产品图（实体产品必填）
-- 主视角：`assets/<brand>-brand/product-hero.png`（2000×1500）
-- 细节图：`assets/<brand>-brand/product-detail-1.png` / `product-detail-2.png`
-- 场景图：`assets/<brand>-brand/product-scene.png`
-- 使用场景：<特写/旋转/对比>
+### Product photo (required for physical products)
+- Hero angle: `assets/<brand>-brand/product-hero.png` (2000×1500)
+- Detail shots: `assets/<brand>-brand/product-detail-1.png` / `product-detail-2.png`
+- In-context shot: `assets/<brand>-brand/product-scene.png`
+- Usage contexts: <close-up / rotation / comparison>
 
-### UI 截图（数字产品必填）
-- 主页：`assets/<brand>-brand/ui-home.png`
-- 核心功能：`assets/<brand>-brand/ui-feature-<name>.png`
-- 使用场景：<产品展示/Dashboard 渐现/对比演示>
+### UI screenshot (required for digital products)
+- Home: `assets/<brand>-brand/ui-home.png`
+- Core feature: `assets/<brand>-brand/ui-feature-<name>.png`
+- Usage contexts: <product showcase / Dashboard fade-in / comparison demo>
 
-## 🎨 辅助资产
+## 🎨 Supporting assets
 
-### 色板
-- Primary: #XXXXXX  <来源标注>
+### Color palette
+- Primary: #XXXXXX  <source annotation>
 - Background: #XXXXXX
 - Ink: #XXXXXX
 - Accent: #XXXXXX
-- 禁用色: <品牌明确不用的色系>
+- Forbidden colors: <color families the brand explicitly avoids>
 
-### 字型
+### Typography
 - Display: <font stack>
 - Body: <font stack>
-- Mono（数据 HUD 用）: <font stack>
+- Mono (for data HUD): <font stack>
 
-### 签名细节
-- <哪些细节是「120% 做到」的>
+### Signature details
+- <which details are the "120% done" ones>
 
-### 禁区
-- <明确不能做的：比如 Lovart 不用蓝色、Stripe 不用低饱和暖色>
+### No-go zones
+- <explicit don'ts: e.g. Lovart never uses blue, Stripe never uses low-sat warm tones>
 
-### 气质关键词
-- <3-5 个形容词>
+### Mood keywords
+- <3-5 adjectives>
 ```
 
-**写完 spec 后的执行纪律（硬要求）**：
-- 所有 HTML 必须**引用** `brand-spec.md` 里的资产文件路径，不允许用 CSS 剪影/SVG 手画代替
-- Logo 作为 `<img>` 引用真实文件，不重画
-- 产品图作为 `<img>` 引用真实文件，不用 CSS 剪影代替
-- CSS 变量从 spec 注入：`:root { --brand-primary: ...; }`，HTML 只用 `var(--brand-*)`
-- 这让品牌一致性从「靠自觉」变成「靠结构」——想临时加色要先改 spec
+**Execution discipline after writing the spec (hard requirements)**:
+- All HTML must **reference** the asset file paths from `brand-spec.md`; CSS silhouettes / hand-drawn SVG substitutes are not allowed
+- Logo referenced as `<img>` pointing at the real file — never redrawn
+- Product photo referenced as `<img>` pointing at the real file — never replaced by a CSS silhouette
+- CSS variables injected from the spec: `:root { --brand-primary: ...; }`; HTML only uses `var(--brand-*)`
+- This turns brand consistency from "rely on discipline" into "rely on structure" — adding a color on the fly requires editing the spec first
 
-##### 全流程失败的兜底
+##### Fallback when the whole flow fails
 
-按资产类型分别处理：
+Handle per asset type:
 
-| 缺失 | 处理 |
+| Missing | Action |
 |---|---|
-| **Logo 完全找不到** | **停下问用户**，不要硬做（logo 是品牌识别度的根基） |
-| **产品图（实体产品）找不到** | 优先 nano-banana-pro AI 生成（以官方参考图为基底）→ 次选向用户索取 → 最后才是诚实 placeholder（灰块+文字标签，明确标注"产品图待补"） |
-| **UI 截图（数字产品）找不到** | 向用户索取自己账号的截屏 → 官方演示视频截帧。不用 mockup 生成器凑 |
-| **色值完全找不到** | 按「设计方向顾问模式」走，向用户推荐 3 个方向并标注 assumption |
+| **Logo completely unfindable** | **Stop and ask the user**, do not force it (the logo is the foundation of brand recognition) |
+| **Product photo (physical product) unfindable** | First choice: nano-banana-pro AI generation (using official reference imagery as a base) → second: request from the user → last resort: honest placeholder (gray block + text label, explicitly noting "product photo pending") |
+| **UI screenshot (digital product) unfindable** | Ask the user for screenshots from their own account → grab frames from official demo videos. Don't fake it with a mockup generator |
+| **Color values completely unfindable** | Switch to Design Direction Advisor mode, recommend 3 directions to the user, label them as assumptions |
 
-**禁止**：找不到资产就静默用 CSS 剪影/通用渐变硬做——这是协议最大的反 pattern。**宁可停下问，也不要凑**。
+**Forbidden**: silently falling back to CSS silhouettes / generic gradients when assets are unfindable — this is the protocol's biggest anti-pattern. **Better to stop and ask than to pad.**
 
-##### 反例（真实踩过的坑）
+##### Counter-examples (real pitfalls already hit)
 
-- **Kimi 动画**：凭记忆猜「应该是橙色」，实际 Kimi 是 `#1783FF` 蓝色——返工一遍
-- **Lovart 设计**：把产品截图里演示品牌的喜茶红当成 Lovart 自己的色——差点毁整个设计
-- **DJI Pocket 4 发布动画（2026-04-20，触发本协议升级的真实案例）**：走了旧版只抽色值的协议，没下载 DJI logo、没找 Pocket 4 产品图，用 CSS 剪影代替产品——做出来是「通用黑底+橙 accent 的科技动画」，没有大疆识别度。花叔原话：「否则，我们在表达什么呢？」→ 协议升级。
-- 抽完色没写进 brand-spec.md，第三页就忘了主色数值，临场加了个「接近但不是」的 hex——品牌一致性崩溃
+- **Kimi animation**: guessed from memory that "it should be orange"; Kimi is actually `#1783FF` blue — one full rework
+- **Lovart design**: mistook the Heytea red in a product demo screenshot for Lovart's own color — nearly ruined the entire design
+- **DJI Pocket 4 launch animation (2026-04-20, the real case that triggered this protocol upgrade)**: ran the old protocol of only extracting color values; didn't download the DJI logo, didn't find Pocket 4 product photos, used a CSS silhouette in place of the product — result was "generic black background + orange accent tech animation" with zero DJI recognizability. The author's words: "Otherwise, what are we even expressing?" → protocol upgrade.
+- Extracted colors but didn't write them into brand-spec.md — by page three the primary hex was forgotten and an "almost but not quite" hex was improvised, brand consistency collapsed
 
-##### 协议代价 vs 不做代价
+##### Protocol cost vs. cost of skipping
 
-| 场景 | 时间 |
+| Scenario | Time |
 |---|---|
-| 正确走完协议 | 下载 logo 5 min + 下载 3-5 张产品图/UI 10 min + grep 色值 5 min + 写 spec 10 min = **30 分钟** |
-| 不做协议的代价 | 做出没识别度的通用动画 → 用户返工 1-2 小时，甚至重做 |
+| Running the protocol correctly | Download logo 5 min + download 3-5 product/UI shots 10 min + grep color values 5 min + write spec 10 min = **30 minutes** |
+| Cost of skipping | Ship a generic animation with no recognizability → user reworks for 1-2 hours, possibly redoing from scratch |
 
-**这是稳定性最便宜的投资**。尤其对商单/发布会/重要客户项目，30 分钟的资产协议是保命钱。
+**This is the cheapest investment in stability.** Especially for paid commissions / launch events / important client projects, 30 minutes of the asset protocol is life-insurance money.
 
-### 2. Junior Designer模式：先展示假设，再执行
+### 2. Junior Designer mode: show assumptions first, then execute
 
-你是manager的junior designer。**不要一头扎进去闷头做大招**。HTML文件的开头先写下你的assumptions + reasoning + placeholders，**尽早show给用户**。然后：
-- 用户确认方向后，再写React组件填placeholder
-- 再show一次，让用户看进度
-- 最后迭代细节
+You are the manager's junior designer. **Don't dive in headfirst and try to land a big move in one shot.** Write your assumptions + reasoning + placeholders at the top of the HTML file, and **show it to the user as early as possible**. Then:
+- After the user confirms direction, write the React components to fill the placeholders
+- Show it once more so the user sees progress
+- Finally iterate on details
 
-这个模式的底层逻辑是：**理解错了早改比晚改便宜100倍**。
+The underlying logic of this mode: **fixing a misunderstanding early is 100x cheaper than fixing it late.**
 
-### 3. 给variations，不给「最终答案」
+### 3. Give variations, not "the final answer"
 
-用户要你设计，不要给一个完美方案——给3+个变体，跨不同维度（视觉/交互/色彩/布局/动画），**从by-the-book到novel逐级递进**。让用户mix and match。
+When the user asks you to design, don't deliver one perfect proposal — deliver 3+ variants across different dimensions (visual / interaction / color / layout / animation), **progressing from by-the-book to novel**. Let the user mix and match.
 
-实现方式：
-- 纯视觉对比 → 用`design_canvas.jsx`并排展示
-- 交互流程/多选项 → 做完整原型，把选项做成Tweaks
+Implementation:
+- Pure visual comparison → use `design_canvas.jsx` to show them side by side
+- Interactive flow / multiple options → build a complete prototype with options exposed as Tweaks
 
-### 4. Placeholder > 烂实现
+### 4. Placeholder > bad implementation
 
-没图标就留灰色方块+文字标签，别画烂SVG。没数据就写`<!-- 等用户提供真实数据 -->`，别编造看起来像数据的假数据。**Hi-fi里，一个诚实的placeholder比一个拙劣的真实尝试好10倍**。
+No icon? Leave a gray block + text label, don't draw a bad SVG. No data? Write `<!-- waiting on real data from user -->`, don't fabricate fake data that looks like data. **In hi-fi, an honest placeholder beats a clumsy real attempt 10:1.**
 
-### 5. 系统优先，不要填充
+### 5. System first, no padding
 
-**Don't add filler content**。每个元素都必须earn its place。空白是设计问题，用构图解决，不是靠编造内容填满。**One thousand no's for every yes**。尤其警惕：
-- 「data slop」——没用的数字、图标、stats装饰
-- 「iconography slop」——每个标题都配icon
-- 「gradient slop」——所有背景都渐变
+**Don't add filler content.** Every element must earn its place. Whitespace is a design problem solved with composition, not by inventing content to fill it. **One thousand no's for every yes.** Especially watch out for:
+- "data slop" — useless numbers, icons, stat decorations
+- "iconography slop" — every heading gets an icon
+- "gradient slop" — every background is a gradient
 
-### 6. 反AI slop（重要，必读）
+### 6. Anti-AI slop (important, required reading)
 
-#### 6.1 什么是 AI slop？为什么要反？
+#### 6.1 What is AI slop? Why fight it?
 
-**AI slop = AI 训练语料里最常见的"视觉最大公约数"**。
-紫渐变、emoji 图标、圆角卡片+左 border accent、SVG 画人脸——这些东西之所以是 slop，不是因为它们本身丑，而是因为**它们是 AI 默认模式下的产物，不携带任何品牌信息**。
+**AI slop = the "visual lowest common denominator" most common in AI training data.**
+Purple gradients, emoji icons, rounded cards with a left border accent, SVG faces — these are slop not because they're inherently ugly, but because **they are the output of AI default mode and carry zero brand information.**
 
-**规避 slop 的逻辑链**：
-1. 用户请你做设计，是要**他的品牌被认出来**
-2. AI 默认产出 = 训练语料的平均 = 所有品牌混合 = **没有任何品牌被认出来**
-3. 所以 AI 默认产出 = 帮用户把品牌稀释成"又一个 AI 做的页面"
-4. 反 slop 不是审美洁癖，是**替用户保护品牌识别度**
+**The logic chain for avoiding slop:**
+1. The user hires you to design because they want **their brand to be recognized**
+2. AI default output = training-corpus average = all brands blended = **no brand recognized**
+3. Therefore AI default output = helping the user dilute their brand into "yet another AI-generated page"
+4. Anti-slop isn't aesthetic snobbery — it's **protecting brand recognizability on the user's behalf**
 
-这也是为什么 §1.a 品牌资产协议是 v1 最硬的约束——**服从规范是反 slop 的正向方式**（对的事），清单只是反 slop 的反向方式（不做错的事）。
+This is also why §1.a Core Asset Protocol is v1's hardest constraint — **following the spec is the positive form of anti-slop** (doing the right thing); the checklist is only the negative form (not doing the wrong thing).
 
-#### 6.2 核心要规避的（带"为什么"）
+#### 6.2 Core things to avoid (with "why")
 
-| 元素 | 为什么是 slop | 什么情况可以用 |
+| Element | Why it's slop | When it's OK to use |
 |------|-------------|---------------|
-| 激进紫色渐变 | AI 训练语料里"科技感"的万能公式，出现在 SaaS/AI/web3 每一个落地页 | 品牌本身用紫渐变（如 Linear 某些场景）、或任务就是讽刺/展示这类 slop |
-| Emoji 作图标 | 训练语料里每个 bullet 都配 emoji，是"不够专业就用 emoji 凑"的病 | 品牌本身用（如 Notion），或产品受众是儿童/轻松场景 |
-| 圆角卡片 + 左彩色 border accent | 2020-2024 Material/Tailwind 时期的烂大街组合，已成视觉噪音 | 用户明确要求、或这个组合在品牌 spec 里被保留 |
-| SVG 画 imagery（人脸/场景/物品）| AI 画的 SVG 人物永远五官错位，比例诡异 | **几乎没有**——有图就用真图（Wikimedia/Unsplash/AI 生成），没图就留诚实 placeholder |
-| **CSS 剪影/SVG 手画代替真实产品图** | 生成的就是「通用科技动画」——黑底+橙 accent+圆角长条，任何实体产品都长一样，品牌识别度归零（DJI Pocket 4 实测 2026-04-20）| **几乎没有**——先走核心资产协议找真实产品图；真没有时用 nano-banana-pro 以官方参考图为基底生成；实在不行标诚实 placeholder 告诉用户"产品图待补" |
-| Inter/Roboto/Arial/system fonts 作 display | 太常见，读者看不出这是"有设计的产品"还是"demo 页" | 品牌 spec 明确用这些字体（Stripe 用 Sohne/Inter 变体，但是经过微调的） |
-| 赛博霓虹 / 深蓝底 `#0D1117` | GitHub dark mode 美学的烂大街复制 | 开发者工具产品且品牌本身走这方向 |
+| Aggressive purple gradients | The universal formula for "tech feel" in AI training data — appears on every SaaS / AI / web3 landing page | The brand itself uses purple gradients (e.g. Linear in some contexts), or the task is to satirize / demonstrate this very slop |
+| Emoji as icons | Every bullet has an emoji in training data — the "if it's not professional enough, pad with emoji" disease | The brand itself uses them (e.g. Notion), or the audience is kids / casual contexts |
+| Rounded card + left colored border accent | The 2020-2024 Material/Tailwind cliché combo, now visual noise | User explicitly asks for it, or the combo is preserved in the brand spec |
+| SVG-drawn imagery (faces / scenes / objects) | AI-drawn SVG people always have misaligned features and weird proportions | **Almost never** — if you have images use real ones (Wikimedia / Unsplash / AI-generated); if not, leave an honest placeholder |
+| **CSS silhouettes / hand-drawn SVG in place of real product photos** | What you generate is a "generic tech animation" — black background + orange accent + rounded bars, every physical product looks identical, brand recognizability zeroed out (DJI Pocket 4 verified 2026-04-20) | **Almost never** — first run the Core Asset Protocol to find a real product photo; if truly unavailable, use nano-banana-pro with official reference imagery as a base; failing that, mark an honest placeholder telling the user "product photo pending" |
+| Inter / Roboto / Arial / system fonts as display | Too common — the reader can't tell whether this is "a designed product" or "a demo page" | The brand spec explicitly uses these fonts (Stripe uses Sohne / Inter variants — but tuned variants) |
+| Cyber neon / deep blue background `#0D1117` | The cliché copy of GitHub dark mode aesthetics | A developer-tool product whose brand actually goes that direction |
 
-**判断边界**：「品牌本身用」是唯一能合法破例的理由。品牌 spec 里明写了用紫渐变，那就用——此时它不再是 slop，是品牌签名。
+**Decision boundary**: "the brand itself uses it" is the only legitimate exemption. If the brand spec writes "use purple gradient", then use it — at that point it's no longer slop, it's a brand signature.
 
-#### 6.3 正向做什么（带"为什么"）
+#### 6.3 What to do positively (with "why")
 
-- ✅ `text-wrap: pretty` + CSS Grid + 高级 CSS：排版细节是 AI 分不清的"品味税"，会用这些的 agent 看起来像真设计师
-- ✅ 用 `oklch()` 或 spec 里已有的色，**不凭空发明新颜色**：所有临场发明的色都会让品牌识别度下降
-- ✅ 配图优先 AI 生成（Gemini / Flash / Lovart），HTML 截图仅在精确数据表格时用：AI 生成的图比 SVG 手画准确，比 HTML 截图有质感
-- ✅ 文案用「」引号不用 ""：中文排印规范，也是"有审校过"的细节信号
-- ✅ 一个细节做到 120%，其他做到 80%：品味 = 在合适的地方足够精致，不是均匀用力
+- ✅ `text-wrap: pretty` + CSS Grid + advanced CSS: typographic details are the "taste tax" AI can't tell apart; an agent that uses these looks like a real designer
+- ✅ Use `oklch()` or a color already in the spec — **never invent new colors from thin air**: every on-the-fly invented color drops brand recognizability
+- ✅ For imagery, prefer AI generation (Gemini / Flash / Lovart); HTML screenshots only for precise data tables: AI-generated imagery is more accurate than hand-drawn SVG and more textured than HTML screenshots
+- ✅ Use 「」 quotes instead of "" for Chinese copy: it's the CJK typography convention and also a "has been proofread" detail signal
+- ✅ One detail done to 120%, others done to 80%: taste = being precise enough in the right place, not applying equal effort everywhere
 
-#### 6.4 反例隔离（演示型内容）
+#### 6.4 Counter-example containment (for demonstrative content)
 
-当任务本身就要展示反设计（如本任务就是讲"什么是 AI slop"、或对比评测），**不要整页堆 slop**，而是用**诚实的 bad-sample 容器**隔离——加虚线边框 + "反例 · 不要这样做" 角标，让反例服务于叙事而不是污染页面主调。
+When the task itself is to showcase anti-design (e.g. the task IS "what is AI slop", or a comparative review), **don't pile slop across the whole page**. Use an **honest bad-sample container** to isolate it — add a dashed border + a "Counter-example · do not do this" badge, so the counter-example serves the narrative without polluting the page's main tone.
 
-这不是硬规则（不做成模板），是原则：**反例要看得出是反例，不是让页面真的变成 slop**。
+Not a hard rule (don't template it), but a principle: **a counter-example should look like a counter-example, not turn the page itself into slop.**
 
-完整清单见 `references/content-guidelines.md`。
+Full checklist: see `references/content-guidelines.md`.
 
-## 设计方向顾问（Fallback 模式）
+## Design Direction Advisor (Fallback Mode)
 
-**什么时候触发**：
-- 用户需求模糊（"做个好看的"、"帮我设计"、"这个怎么样"、"做个XX"没有具体参考）
-- 用户明确要"推荐风格"、"给几个方向"、"选个哲学"、"想看不同风格"
-- 项目和品牌没有任何 design context（既没有 design system，又找不到参考）
-- 用户主动说"我也不知道要什么风格"
+**When to trigger**:
+- The user's brief is vague ("make something good-looking", "design something for me", "what about this?", "make me a XX" with no concrete reference)
+- The user explicitly asks to "recommend a style", "give me a few directions", "pick a philosophy", "I want to see different styles"
+- The project/brand has zero design context (no design system, no reference to be found)
+- The user proactively says "I don't know what style I want either"
 
-**什么时候 skip**：
-- 用户已经给了明确的风格参考（Figma / 截图 / 品牌规范）→ 直接走「核心哲学 #1」主干流程
-- 用户已经说清楚要什么（"做个 Apple Silicon 风格的发布会动画"）→ 直接进 Junior Designer 流程
-- 小修小补、明确的工具调用（"帮我把这段 HTML 变成 PDF"）→ skip
+**When to skip**:
+- The user has provided a clear style reference (Figma / screenshots / brand guidelines) → go straight to the "Core Philosophy #1" main flow
+- The user has stated exactly what they want ("make an Apple Silicon-style launch animation") → go straight into the Junior Designer flow
+- Small tweaks, explicit tool invocations ("turn this HTML into PDF for me") → skip
 
-不确定就用最轻量版：**列出 3 个差异化方向让用户二选一，不展开不生成**——尊重用户节奏。
+If uncertain, use the lightest version: **list 3 differentiated directions and let the user pick one — no elaboration, no generation** — respect the user's pace.
 
-### 完整流程（8 个 Phase，顺序执行）
+### Full flow (8 phases, executed in order)
 
-**Phase 1 · 深度理解需求**
-提问（一次最多 3 个）：目标受众 / 核心信息 / 情感基调 / 输出格式。需求已清晰则跳过。
+**Phase 1 · Deep needs understanding**
+Ask questions (max 3 at a time): target audience / core message / emotional tone / output format. Skip if needs are already clear.
 
-**Phase 2 · 顾问式重述**（100-200 字）
-用自己的话重述本质需求、受众、场景、情感基调。以「基于这个理解，我为你准备了 3 个设计方向」结尾。
+**Phase 2 · Advisor-style restatement** (100-200 words)
+In your own words, restate the underlying need, audience, context, and emotional tone. End with "Based on this understanding, I've prepared 3 design directions for you".
 
-**Phase 3 · 推荐 3 套设计哲学**（必须差异化）
+**Phase 3 · Recommend 3 design philosophies** (must be differentiated)
 
-每个方向必须：
-- **含设计师/机构名**（如「Kenya Hara 式东方极简」，不是只说「极简主义」）
-- 50-100 字解释「为什么这个设计师适合你」
-- 3-4 条标志性视觉特征 + 3-5 个气质关键词 + 可选代表作
+Each direction must:
+- **Include a designer/studio name** (e.g. "Kenya Hara-style Eastern minimalism", not just "minimalism")
+- A 50-100 word explanation of "why this designer suits you"
+- 3-4 signature visual traits + 3-5 mood keywords + optional representative works
 
-**差异化规则**（必守）：3 个方向**必须来自 3 个不同流派**，形成明显视觉反差：
+**Differentiation rule** (must obey): the 3 directions **must come from 3 different schools**, forming clear visual contrast:
 
-| 流派 | 视觉气质 | 适合作为 |
+| School | Visual mood | Suitable as |
 |------|---------|---------|
-| 信息建筑派（01-04） | 理性、数据驱动、克制 | 安全/专业选择 |
-| 运动诗学派（05-08） | 动感、沉浸、技术美学 | 大胆/前卫选择 |
-| 极简主义派（09-12） | 秩序、留白、精致 | 安全/高端选择 |
-| 实验先锋派（13-16） | 先锋、生成艺术、视觉冲击 | 大胆/创新选择 |
-| 东方哲学派（17-20） | 温润、诗意、思辨 | 差异化/独特选择 |
+| Information Architecture (01-04) | Rational, data-driven, restrained | Safe / professional pick |
+| Motion Poetics (05-08) | Dynamic, immersive, technical aesthetics | Bold / avant-garde pick |
+| Minimalism (09-12) | Order, whitespace, refinement | Safe / premium pick |
+| Experimental Avant-garde (13-16) | Cutting-edge, generative art, visual impact | Bold / innovative pick |
+| Eastern Philosophy (17-20) | Warm, poetic, contemplative | Differentiated / distinctive pick |
 
-❌ **禁止从同一流派推荐 2 个以上** — 差异化不够用户看不出区别。
+❌ **Do not recommend 2 or more from the same school** — insufficient differentiation, the user can't tell them apart.
 
-详细 20 种风格库 + AI 提示词模板 → `references/design-styles.md`。
+Detailed library of 20 styles + AI prompt templates → `references/design-styles.md`.
 
-**Phase 4 · 展示预制 Showcase 画廊**
+**Phase 4 · Show the pre-built Showcase gallery**
 
-推荐 3 方向后，**立即检查** `assets/showcases/INDEX.md` 是否有匹配的预制样例（8 场景 × 3 风格 = 24 个样例）：
+After recommending 3 directions, **immediately check** `assets/showcases/INDEX.md` for matching pre-built samples (8 scenes × 3 styles = 24 samples):
 
-| 场景 | 目录 |
+| Scene | Directory |
 |------|------|
-| 公众号封面 | `assets/showcases/cover/` |
-| PPT 数据页 | `assets/showcases/ppt/` |
-| 竖版信息图 | `assets/showcases/infographic/` |
-| 个人主页 / AI 导航 / AI 写作 / SaaS / 开发文档 | `assets/showcases/website-*/` |
+| WeChat article cover | `assets/showcases/cover/` |
+| PPT data page | `assets/showcases/ppt/` |
+| Vertical infographic | `assets/showcases/infographic/` |
+| Personal homepage / AI nav / AI writing / SaaS / dev docs | `assets/showcases/website-*/` |
 
-匹配话术：「在启动实时 Demo 之前，先看看这 3 个风格在类似场景的效果 →」然后 Read 对应 .png。
+Suggested wording: "Before we kick off live Demos, take a look at how these 3 styles play in similar scenes →", then Read the matching .png files.
 
-场景模板按输出类型组织 → `references/scene-templates.md`。
+Scene templates organized by output type → `references/scene-templates.md`.
 
-**Phase 5 · 生成 3 个视觉 Demo**
+**Phase 5 · Generate 3 visual Demos**
 
-> 核心理念：**看到比说到更有效。** 别让用户凭文字想象，直接看。
+> Core idea: **seeing beats saying.** Don't make the user imagine from text — show it directly.
 
-为 3 个方向各生成一个 Demo——**如果当前 agent 支持 subagent 并行**，启动 3 个并行子任务（后台执行）；**不支持就串行生成**（先后做 3 次，同样能用）。两种路径都能工作：
-- 使用**用户真实内容/主题**（不是 Lorem ipsum）
-- HTML 存 `_temp/design-demos/demo-[风格].html`
-- 截图：`npx playwright screenshot file:///path.html out.png --viewport-size=1200,900`
-- 全部完成后一起展示 3 张截图
+Generate one Demo for each of the 3 directions — **if the current agent supports subagent parallelism**, launch 3 parallel subtasks (running in the background); **if not, generate them serially** (do 3 in sequence — same outcome). Both paths work:
+- Use **the user's real content/subject** (not Lorem ipsum)
+- Save HTML to `_temp/design-demos/demo-[style].html`
+- Screenshot: `npx playwright screenshot file:///path.html out.png --viewport-size=1200,900`
+- After all are done, present the 3 screenshots together
 
-风格类型路径：
-| 风格最佳路径 | Demo 生成方式 |
+Style-type routing:
+| Best path per style | How to generate the Demo |
 |-------------|--------------|
-| HTML 型 | 生成完整 HTML → 截图 |
-| AI 生成型 | `nano-banana-pro` 用风格 DNA + 内容描述 |
-| 混合型 | HTML 布局 + AI 插画 |
+| HTML-type | Generate complete HTML → screenshot |
+| AI-generated type | `nano-banana-pro` with style DNA + content description |
+| Hybrid type | HTML layout + AI illustration |
 
-**Phase 6 · 用户选择**：选一个深化 / 混合（"A 的配色 + C 的布局"）/ 微调 / 重来 → 回 Phase 3 重新推荐。
+**Phase 6 · User selection**: pick one to deepen / blend ("A's palette + C's layout") / fine-tune / start over → loop back to Phase 3 and recommend again.
 
-**Phase 7 · 生成 AI 提示词**
-结构：`[设计哲学约束] + [内容描述] + [技术参数]`
-- ✅ 用具体特征而非风格名（写「Kenya Hara 的留白感+赤土橙 #C04A1A」，不写「极简」）
-- ✅ 包含颜色 HEX、比例、空间分配、输出规格
-- ❌ 避开审美禁区（见反 AI slop）
+**Phase 7 · Generate an AI prompt**
+Structure: `[design philosophy constraints] + [content description] + [technical parameters]`
+- ✅ Use concrete traits rather than style names (write "Kenya Hara's sense of whitespace + terracotta orange #C04A1A", not "minimalism")
+- ✅ Include color HEX, proportions, spatial allocation, output specs
+- ❌ Avoid the aesthetic no-go zones (see anti-AI-slop)
 
-**Phase 8 · 选定方向后进入主干**
-方向确认 → 回到「核心哲学」+「工作流程」的 Junior Designer pass。这时已经有明确的 design context，不再是凭空做。
+**Phase 8 · After direction is chosen, enter the main flow**
+Direction confirmed → return to the Junior Designer pass of "Core Philosophy" + "Workflow". By now there's clear design context, no longer working from a blank slate.
 
-**真实素材优先原则**（涉及用户本人/产品时）：
-1. 先查用户配置的**私有 memory 路径**下的 `personal-asset-index.json`（Claude Code 默认在 `~/.claude/memory/`；其他 agent 按其自身约定）
-2. 首次使用：复制 `assets/personal-asset-index.example.json` 到上述私有路径，填入真实数据
-3. 找不到就直接问用户要，不要编造——真实数据文件不要放在 skill 目录内避免随分发泄露隐私
+**Real-asset-first principle** (when the work involves the user themself / their product):
+1. First check the `personal-asset-index.json` under the user's configured **private memory path** (Claude Code defaults to `~/.claude/memory/`; other agents follow their own conventions)
+2. First-time setup: copy `assets/personal-asset-index.example.json` to the private path above and fill in real data
+3. If not found, ask the user directly — don't fabricate. Don't put real-data files inside the skill directory, to avoid leaking privacy when the skill is distributed
 
-## App / iOS 原型专属守则
+## App / iOS Prototype Specific Rules
 
-做 iOS/Android/移动 app 原型时（触发：「app 原型」「iOS mockup」「移动应用」「做个 app」），下面四条**覆盖**通用 placeholder 原则——app 原型是 demo 现场，静态摆拍和米白占位卡没有说服力。
+When building iOS / Android / mobile app prototypes (triggers: "app prototype", "iOS mockup", "mobile application", "make me an app"), the four rules below **override** the generic placeholder principle — an app prototype is the demo stage, and static posed shots with off-white placeholder cards have no persuasive power.
 
-### 0. 架构选型（必先决定）
+### 0. Architecture choice (must be decided first)
 
-**默认单文件 inline React**——所有 JSX/data/styles 直接写进主 HTML 的 `<script type="text/babel">...</script>` 标签，**不要**用 `<script src="components.jsx">` 外部加载。原因：`file://` 协议下浏览器把外部 JS 当跨 origin 拦截，强制用户起 HTTP server 违反「双击就能开」的原型直觉。引用本地图片必须 base64 内嵌 data URL，别假设有 server。
+**Default: single-file inline React** — all JSX / data / styles go directly into the `<script type="text/babel">...</script>` tag of the main HTML. **Do not** load externally with `<script src="components.jsx">`. Reason: under the `file://` protocol the browser blocks external JS as cross-origin, forcing the user to spin up an HTTP server, which violates the "double-click and it opens" prototype intuition. Local images must be inlined as base64 data URLs — don't assume there's a server.
 
-**拆外部文件只在两种情况**：
-- (a) 单文件 >1000 行难维护 → 拆成 `components.jsx` + `data.js`，同时明确交付说明（`python3 -m http.server` 命令 + 访问 URL）
-- (b) 需要多 subagent 并行写不同屏 → `index.html` + 每屏独立 HTML（`today.html`/`graph.html`...），iframe 聚合，每屏也都是自包含单文件
+**Only split into external files in two situations**:
+- (a) Single file >1000 lines and hard to maintain → split into `components.jsx` + `data.js`, and clearly state delivery instructions (`python3 -m http.server` command + access URL)
+- (b) Multiple subagents writing different screens in parallel → `index.html` + one standalone HTML per screen (`today.html` / `graph.html` / ...), aggregated via iframe; each screen is also a self-contained single file
 
-**选型速查**：
+**Quick-reference**:
 
-| 场景 | 架构 | 交付方式 |
+| Scenario | Architecture | Delivery |
 |------|------|----------|
-| 单人做 4-6 屏原型（主流） | 单文件 inline | 一个 `.html` 双击开 |
-| 单人做大型 App（>10 屏） | 多 jsx + server | 附启动命令 |
-| 多 agent 并行 | 多 HTML + iframe | `index.html` 聚合，每屏独立可开 |
+| One person doing 4-6 screen prototype (mainstream) | Single-file inline | One `.html`, double-click to open |
+| One person doing a large App (>10 screens) | Multi-jsx + server | Include startup command |
+| Multi-agent parallel | Multi-HTML + iframe | `index.html` aggregates, each screen also openable standalone |
 
-### 1. 先找真图，不是 placeholder 摆着
+### 1. Find real imagery first, don't just park a placeholder
 
-默认主动去取真实图片填充，不要画 SVG、不要拿米白卡摆着、不要等用户要求。常用渠道：
+By default, proactively go scrape real images to fill the screen — don't draw SVG, don't stick off-white cards in, don't wait for the user to ask. Common sources:
 
-| 场景 | 首选渠道 |
+| Scenario | Preferred source |
 |------|---------|
-| 美术/博物馆/历史内容 | Wikimedia Commons（公共领域）、Met Museum Open Access、Art Institute of Chicago API |
-| 通用生活/摄影 | Unsplash、Pexels（免版权） |
-| 用户本地已有素材 | `~/Downloads`、项目 `_archive/` 或用户配置的素材库 |
+| Art / museum / historical content | Wikimedia Commons (public domain), Met Museum Open Access, Art Institute of Chicago API |
+| Generic life / photography | Unsplash, Pexels (royalty-free) |
+| Assets the user already has locally | `~/Downloads`, project `_archive/`, or a user-configured asset library |
 
-Wikimedia 下载避坑（本机 curl 走代理 TLS 会炸，Python urllib 直接走得通）：
+Wikimedia download pitfalls (local curl through a proxy blows up on TLS; Python urllib goes through directly):
 
 ```python
-# 合规 User-Agent 是硬性要求，否则 429
+# A compliant User-Agent is mandatory, otherwise 429
 UA = 'ProjectName/0.1 (https://github.com/you; you@example.com)'
-# 用 MediaWiki API 查真实 URL
+# Use the MediaWiki API to look up the real URL
 api = 'https://commons.wikimedia.org/w/api.php'
-# action=query&list=categorymembers 批量拿系列 / prop=imageinfo+iiurlwidth 取指定宽度 thumburl
+# action=query&list=categorymembers to batch-fetch a series / prop=imageinfo+iiurlwidth to get the thumburl at a specific width
 ```
 
-**只有**当所有渠道都失败 / 版权不清 / 用户明确要求时，才退回诚实 placeholder（仍然不画烂 SVG）。
+**Only** when every source fails / copyright is unclear / the user explicitly asks, fall back to an honest placeholder (still don't draw bad SVG).
 
-**真图诚实性测试**（关键）：取图之前先问自己——「如果去掉这张图，信息是否有损？」
+**Real-image honesty test** (critical): before pulling an image, ask yourself — "If I remove this image, is information lost?"
 
-| 场景 | 判断 | 动作 |
+| Scenario | Verdict | Action |
 |------|------|------|
-| 文章/Essay 列表的封面、Profile 页的风景头图、设置页的装饰 banner | 装饰，与内容无内在关联 | **不要加**。加了就是 AI slop，等同紫色渐变 |
-| 博物馆/人物内容的肖像、产品详情的实物、地图卡片的地点 | 内容本身，有内在关联 | **必须加** |
-| 图谱/可视化背景的极淡纹理 | 氛围，服从内容不抢戏 | 加，但 opacity ≤ 0.08 |
+| Cover of an article/essay list, the scenery banner on a Profile page, the decorative banner on Settings | Decoration, no intrinsic link to content | **Don't add it.** Adding it is AI slop, equivalent to a purple gradient |
+| Portraits in museum / biographical content, the real object in product detail, the location on a map card | The content itself, intrinsically linked | **Must add it** |
+| Very faint texture in a graph/visualization background | Atmosphere, subservient to content, doesn't steal focus | Add it, but `opacity ≤ 0.08` |
 
-**反例**：给文字 Essay 配 Unsplash「灵感图」、给笔记 App 配 stock photo 模特——都是 AI slop。取真图的许可不等于滥用真图的通行证。
+**Counter-examples**: pairing a text Essay with an Unsplash "inspirational shot", pairing a notes App with a stock-photo model — these are AI slop. Permission to use real imagery is not a license to abuse real imagery.
 
-### 2. 交付形态：overview 平铺 / flow demo 单机——先问用户要哪种
+### 2. Delivery form: overview grid / single-device flow demo — ask the user first
 
-多屏 App 原型有两种标准交付形态，**先问用户要哪种**，不要默认挑一种闷头做：
+Multi-screen App prototypes have two standard delivery forms. **Ask the user first** which one — don't just pick one by default and grind away:
 
-| 形态 | 何时用 | 做法 |
+| Form | When to use | How |
 |------|--------|------|
-| **Overview 平铺**（设计 review 默认）| 用户要看全貌 / 比较布局 / 走查设计一致性 / 多屏并排 | **所有屏并排静态展示**，每屏一台独立 iPhone，内容完整，不需要可点击 |
-| **Flow demo 单机** | 用户要演示一条特定用户流程（如 onboarding、购买链路）| 单台 iPhone，内嵌 `AppPhone` 状态管理器，tab bar / 按钮 / 标注点都能点 |
+| **Overview grid** (design review default) | User wants to see the whole picture / compare layouts / audit design consistency / multiple screens side by side | **All screens shown statically side by side**, each in its own iPhone, complete content, no need to be clickable |
+| **Single-device flow demo** | User wants to demo a specific flow (onboarding, checkout, etc.) | Single iPhone, with an embedded `AppPhone` state manager; tab bar / buttons / annotation points are all clickable |
 
-**路由关键词**：
-- 任务里出现「平铺 / 展示所有页面 / overview / 看一眼 / 比较 / 所有屏」→ 走 **overview**
-- 任务里出现「演示流程 / 用户路径 / 走一遍 / clickable / 可交互 demo」→ 走 **flow demo**
-- 不确定就问。不要默认选 flow demo（它更费工，不是所有任务都需要）
+**Routing keywords**:
+- Task mentions "grid / show all pages / overview / take a look / compare / all screens" → go **overview**
+- Task mentions "demo the flow / user journey / walk through / clickable / interactive demo" → go **flow demo**
+- If uncertain, ask. Don't default to flow demo (it's more labor-intensive, and not every task needs it)
 
-**Overview 平铺的骨架**（每屏独立一台 IosFrame 并排）：
+**Overview grid skeleton** (one independent IosFrame per screen, laid out side by side):
 
 ```jsx
 <div style={{display: 'flex', gap: 32, flexWrap: 'wrap', padding: 48, alignItems: 'flex-start'}}>
@@ -541,274 +542,274 @@ api = 'https://commons.wikimedia.org/w/api.php'
 </div>
 ```
 
-**Flow demo 的骨架**（单台 clickable 状态机）：
+**Flow demo skeleton** (single clickable state machine):
 
 ```jsx
 function AppPhone({ initial = 'today' }) {
   const [screen, setScreen] = React.useState(initial);
   const [modal, setModal] = React.useState(null);
-  // 根据 screen 渲染不同 ScreenComponent，传入 onEnter/onClose/onTabChange/onOpen props
+  // Render different ScreenComponent based on screen; pass onEnter/onClose/onTabChange/onOpen props
 }
 ```
 
-Screen 组件接 callback props（`onEnter`、`onClose`、`onTabChange`、`onOpen`、`onAnnotation`），不硬编码状态。TabBar、按钮、作品卡加 `cursor: pointer` + hover 反馈。
+Screen components take callback props (`onEnter`, `onClose`, `onTabChange`, `onOpen`, `onAnnotation`) — do not hard-code state. Add `cursor: pointer` + hover feedback on TabBar, buttons, and content cards.
 
-### 3. 交付前跑真实点击测试
+### 3. Run a real click-test before delivery
 
-静态截图只能看 layout，交互 bug 要点过才发现。用 Playwright 跑 3 项最小点击测试：进入详情 / 关键标注点 / tab 切换。检查 `pageerror` 为 0 再交付。Playwright 可用 `npx playwright` 调用，或按本机全局安装路径（`npm root -g` + `/playwright`）。
+Static screenshots only show layout — interaction bugs are only found by clicking through. Use Playwright to run 3 minimal click tests: enter detail / key annotation points / tab switch. Verify `pageerror` is 0 before delivery. Playwright can be invoked via `npx playwright`, or by your machine's global install path (`npm root -g` + `/playwright`).
 
-### 4. 品位锚点（pursue list，fallback 首选）
+### 4. Taste anchors (pursue list, the fallback first-pick)
 
-没有 design system 时默认往这些方向走，避免撞 AI slop：
+When there's no design system, default to these directions to avoid colliding with AI slop:
 
-| 维度 | 首选 | 避免 |
+| Dimension | Prefer | Avoid |
 |------|------|------|
-| **字体** | 衬线 display（Newsreader/Source Serif/EB Garamond）+ `-apple-system` body | 全场 SF Pro 或 Inter——太像系统默认，没风格 |
-| **色彩** | 一个有温度的底色 + **单个** accent 贯穿全场（rust 橙/墨绿/深红）| 多色聚类（除非数据真的有 ≥3 个分类维度） |
-| **信息密度·克制型**（默认）| 少一层容器、少一个 border、少一个**装饰性** icon——给内容留气口 | 每条卡片都配无意义的 icon + tag + status dot |
-| **信息密度·高密度型**（例外）| 当产品核心卖点是「智能 / 数据 / 上下文感知」时（AI 工具、Dashboard、Tracker、Copilot、番茄钟、健康监测、记账类），每屏需**至少 3 处可见的产品差异化信息**：非装饰性数据、对话/推理片段、状态推断、上下文关联 | 只放一个按钮一个时钟——AI 的智能感没表达出来，跟普通 App 没区别 |
-| **细节签名** | 留一处「值得截图」的质感：极淡油画底纹 / serif 斜体引语 / 全屏黑底录音波形 | 到处平均用力，结果处处平淡 |
+| **Type** | Serif display (Newsreader / Source Serif / EB Garamond) + `-apple-system` body | SF Pro or Inter everywhere — too close to system defaults, no character |
+| **Color** | A warm base color + **a single** accent throughout (rust orange / forest green / deep red) | Multi-color clustering (unless the data genuinely has ≥3 categorical dimensions) |
+| **Information density · Restrained** (default) | One less container, one less border, one less **decorative** icon — leave the content room to breathe | Every card adorned with a meaningless icon + tag + status dot |
+| **Information density · High-density** (exception) | When the product's core selling point is "intelligence / data / context-awareness" (AI tools, Dashboards, Trackers, Copilots, pomodoro timers, health monitors, expense trackers), each screen needs **at least 3 visible product-differentiating signals**: non-decorative data, dialogue/reasoning snippets, state inference, context links | Just a button and a clock — the AI intelligence isn't expressed, looks no different from a generic App |
+| **Signature detail** | Leave one "worth screenshotting" piece of texture: very faint oil-painting base / serif italic pull-quote / full-screen black-background recording waveform | Equal effort everywhere → flat everywhere |
 
-**两条原则同时生效**：
-1. 品位 = 一个细节做到 120%，其它做到 80%——不是所有地方都精致，而是在合适的地方足够精致
-2. 减法是 fallback，不是普适律——产品核心卖点需要信息密度支撑时（AI / 数据 / 上下文感知类），加法优先于克制。详见下文「信息密度分型」
+**Both principles apply simultaneously**:
+1. Taste = one detail done to 120%, others done to 80% — not "precise everywhere", but precise enough in the right place
+2. Subtraction is a fallback, not a universal law — when the product's core selling point requires information density (AI / data / context-aware), addition takes priority over restraint. See "Information density typing" below
 
-### 5. iOS 设备框必须用 `assets/ios_frame.jsx`——禁止手写 Dynamic Island / status bar
+### 5. The iOS device frame must use `assets/ios_frame.jsx` — hand-writing Dynamic Island / status bar is forbidden
 
-做 iPhone mockup 时**硬性绑定** `assets/ios_frame.jsx`。这是已经对齐过 iPhone 15 Pro 精确规格的标准外壳：bezel、Dynamic Island（124×36、top:12、居中）、status bar（时间/信号/电池、两侧避让岛、vertical center 对齐岛中线）、Home Indicator、content 区 top padding 都处理好了。
+When building an iPhone mockup, **hard-bind** to `assets/ios_frame.jsx`. It's the standard shell already aligned to exact iPhone 15 Pro specs: bezel, Dynamic Island (124×36, top:12, centered), status bar (time / signal / battery, avoiding the island on both sides, vertically centered on the island's midline), Home Indicator, content-area top padding — all handled.
 
-**禁止在你的 HTML 里自己写**以下任何一项：
-- `.dynamic-island` / `.island` / `position: absolute; top: 11/12px; width: ~120; 居中的黑圆角矩形`
-- `.status-bar` with 手写的时间/信号/电池图标
-- `.home-indicator` / 底部 home bar
-- iPhone bezel 的圆角外框 + 黑描边 + shadow
+**Do not write any of the following in your own HTML**:
+- `.dynamic-island` / `.island` / `position: absolute; top: 11/12px; width: ~120;` centered black rounded rectangle
+- `.status-bar` with hand-written time / signal / battery icons
+- `.home-indicator` / a bottom home bar
+- The iPhone bezel's rounded outer frame + black stroke + shadow
 
-自己写 99% 会撞位置 bug——status bar 的时间/电池被岛挤压、或 content top padding 算错导致第一行内容盖在岛下。iPhone 15 Pro 的刘海是**固定 124×36 像素**，留给 status bar 两侧的可用宽度很窄，不是你凭空估的。
+Writing it yourself will hit a positioning bug 99% of the time — the status bar time/battery getting crushed by the island, or content top padding miscalculated so the first row of content sits under the island. The iPhone 15 Pro notch is **a fixed 124×36 pixels**; the usable width left for the status bar on either side is narrow, not something you can eyeball.
 
-**用法（严格三步）**：
+**Usage (strictly three steps)**:
 
 ```jsx
-// 步骤 1: Read 本 skill 的 assets/ios_frame.jsx（相对本 SKILL.md 的路径）
-// 步骤 2: 把整个 iosFrameStyles 常量 + IosFrame 组件贴进你的 <script type="text/babel">
-// 步骤 3: 你自己的屏组件包在 <IosFrame>...</IosFrame> 里，不碰 island/status bar/home indicator
+// Step 1: Read this skill's assets/ios_frame.jsx (path relative to this SKILL.md)
+// Step 2: Paste the entire iosFrameStyles constant + IosFrame component into your <script type="text/babel">
+// Step 3: Wrap your own screen component inside <IosFrame>...</IosFrame>; don't touch island / status bar / home indicator
 <IosFrame time="9:41" battery={85}>
-  <YourScreen />  {/* 内容从 top 54 开始渲染，下边留给 home indicator，你不用管 */}
+  <YourScreen />  {/* Content starts rendering from top 54; the bottom is reserved for the home indicator — you don't manage it */}
 </IosFrame>
 ```
 
-**例外**：只有用户明确要求「假装是 iPhone 14 非 Pro 的刘海」「做 Android 不是 iOS」「自定义设备形态」时才绕过——此时读对应 `android_frame.jsx` 或修改 `ios_frame.jsx` 的常量，**不要**在项目 HTML 里另起一套 island/status bar。
+**Exception**: only bypass when the user explicitly asks for "pretend it's an iPhone 14 non-Pro notch", "make Android, not iOS", or "custom device form" — in those cases read the corresponding `android_frame.jsx` or modify the constants in `ios_frame.jsx`; **do not** roll your own island / status bar inside the project HTML.
 
-## 工作流程
+## Workflow
 
-### 标准流程（用TaskCreate追踪）
+### Standard flow (tracked with TaskCreate)
 
-1. **理解需求**：
-   - 🔍 **0. 事实验证（涉及具体产品/技术时必做，优先级最高）**：任务涉及具体产品/技术/事件（DJI Pocket 4、Gemini 3 Pro、Nano Banana Pro、某新 SDK 等）时，**第一个动作**是 `WebSearch` 验证其存在性、发布状态、最新版本、关键规格。把事实写入 `product-facts.md`。详见「核心原则 #0」。**这步做在问 clarifying questions 之前**——事实错了问什么都歪。
-   - 新任务或模糊任务必须问clarifying questions，详见 `references/workflow.md`。一次focused一轮问题通常够，小修小补跳过。
-   - 🛑 **检查点1：问题清单一次性发给用户，等用户批量答完再往下走**。不要边问边做。
-   - 🛑 **幻灯片/PPT 任务：HTML 聚合演示版永远是默认基础产物**（不管用户最终要什么格式）：
-     - **必做**：每页独立 HTML + `assets/deck_index.html` 聚合（重命名为 `index.html`，编辑 MANIFEST 列所有页），浏览器里键盘翻页、全屏演讲——这是幻灯片作品的"源"
-     - **可选导出**：额外询问是否需要 PDF（`export_deck_pdf.mjs`）或可编辑 PPTX（`export_deck_pptx.mjs`）作为衍生物
-     - **只有要可编辑 PPTX 时**，HTML 必须从第一行就按 4 条硬约束写（见 `references/editable-pptx.md`）；事后补救会 2-3 小时返工
-     - **≥ 5 页 deck 必须先做 2 页 showcase 定 grammar 再批量推**（见 `references/slide-decks.md` 的「批量制作前先做 showcase」章节）——跳过这步 = 方向错返工 N 次而非 2 次
-     - 详见 `references/slide-decks.md` 开头「HTML 优先架构 + 交付格式决策树」
-   - ⚡ **如果用户需求严重模糊（没参考、没明确风格、"做个好看的"类）→ 走「设计方向顾问（Fallback 模式）」大节，完成 Phase 1-4 选定方向后，再回到这里 Step 2**。
-2. **探索资源 + 抽核心资产**（不只是抽色值）：读 design system、linked files、上传的截图/代码。**涉及具体品牌时必走 §1.a「核心资产协议」五步**（问→按类型搜→按类型下载 logo/产品图/UI→验证+提取→写 `brand-spec.md` 含所有资产路径）。
-   - 🛑 **检查点2·资产自检**：开工前确认核心资产到位——实体产品要有产品图（不是 CSS 剪影）、数字产品要有 logo+UI 截图、色值从真实 HTML/SVG 抽取。缺了就停下补，不硬做。
-   - 如果用户没给 context 且挖不出资产，先走设计方向顾问 Fallback，再按 `references/design-context.md` 的品位锚点兜底。
-3. **先答四问，再规划系统**：**这一步的前半段比所有 CSS 规则更决定输出**。
+1. **Understand the need**:
+   - 🔍 **0. Fact verification (mandatory when specific products/tech are involved, highest priority)**: when the task involves specific products / tech / events (DJI Pocket 4, Gemini 3 Pro, Nano Banana Pro, some new SDK, etc.), the **first action** is `WebSearch` to verify its existence, release status, latest version, key specs. Write the facts into `product-facts.md`. See "Core Principle #0". **This step happens before asking clarifying questions** — if the facts are wrong, every question goes off the rails.
+   - New tasks or vague tasks must ask clarifying questions; see `references/workflow.md`. Usually one focused round is enough; small tweaks skip it.
+   - 🛑 **Checkpoint 1: send the entire question list to the user at once and wait for them to answer in batch before moving on.** Don't ask-and-do at the same time.
+   - 🛑 **Slide/PPT tasks: the HTML aggregate deck is always the default base deliverable** (regardless of what final format the user wants):
+     - **Required**: one HTML per page + `assets/deck_index.html` aggregator (rename to `index.html`, edit MANIFEST listing all pages); keyboard nav + fullscreen in the browser — this is the "source" of the slide work
+     - **Optional exports**: separately ask whether PDF (`export_deck_pdf.mjs`) or editable PPTX (`export_deck_pptx.mjs`) is needed as a derivative
+     - **Only when editable PPTX is needed**, the HTML must follow the 4 hard constraints from the very first line (see `references/editable-pptx.md`); after-the-fact remediation is 2-3 hours of rework
+     - **For decks ≥5 pages, you must first build a 2-page showcase to lock the grammar before mass-producing the rest** (see the "build a showcase before mass production" section in `references/slide-decks.md`) — skipping this = N reworks instead of 2 when the direction is wrong
+     - See `references/slide-decks.md`, opening section "HTML-first architecture + delivery-format decision tree"
+   - ⚡ **If the user's need is severely vague (no references, no clear style, "make me something good-looking" types) → go to the "Design Direction Advisor (Fallback Mode)" section; after Phase 1-4 picks a direction, return here to Step 2.**
+2. **Explore resources + extract core assets** (not just color values): read design systems, linked files, uploaded screenshots/code. **When a specific brand is involved, you must run the 5 steps of §1.a "Core Asset Protocol"** (ask → search by type → download logo / product photo / UI by type → verify + extract → write `brand-spec.md` with all asset paths).
+   - 🛑 **Checkpoint 2 · Asset self-check**: confirm core assets are in place before starting — physical products need product photos (not CSS silhouettes), digital products need logo + UI screenshots, color values extracted from real HTML/SVG. If something's missing, stop and fill it in; do not force it.
+   - If the user gave no context and you can't dig up assets, first run the Design Direction Advisor Fallback, then fall back on the taste anchors in `references/design-context.md`.
+3. **Answer the four questions before planning the system**: **the first half of this step shapes the output more than every CSS rule combined.**
 
-   📐 **位置四问**（每个页面/屏幕/镜头开工前必答）：
-   - **叙事角色**：hero / 过渡 / 数据 / 引语 / 结尾？（一页 deck 里每页都不一样）
-   - **观众距离**：10cm 手机 / 1m 笔记本 / 10m 投屏？（决定字号和信息密度）
-   - **视觉温度**：安静 / 兴奋 / 冷静 / 权威 / 温柔 / 悲伤？（决定配色和节奏）
-   - **容量估算**：用纸笔画 3 个 5 秒 thumbnail 算一下内容塞得下吗？（防溢出 / 防挤压）
+   📐 **The four positioning questions** (mandatory before starting any page / screen / shot):
+   - **Narrative role**: hero / transition / data / pull-quote / closer? (each page in a deck is different)
+   - **Viewing distance**: 10cm phone / 1m laptop / 10m projector? (determines font size and information density)
+   - **Visual temperature**: quiet / excited / cool / authoritative / warm / sorrowful? (determines palette and rhythm)
+   - **Capacity estimate**: sketch 3 five-second thumbnails on paper — does the content fit? (prevents overflow / crushing)
 
-   四问答完再 vocalize 设计系统（色彩/字型/layout 节奏/component pattern）——**系统要服务于答案，不是先选系统再塞内容**。
+   Only after answering all four should you vocalize the design system (color / type / layout rhythm / component pattern) — **the system must serve the answers, not pick a system first and then stuff content into it**.
 
-   🛑 **检查点2：四问答案 + 系统口头说出来等用户点头，再动手写代码**。方向错了晚改比早改贵 100 倍。
-4. **构建文件夹结构**：`项目名/` 下放主HTML、需要的assets拷贝（不要bulk copy >20个文件）。
-5. **Junior pass**：HTML里写assumptions+placeholders+reasoning comments。
-   🛑 **检查点3：尽早show给用户（哪怕只是灰色方块+标签），等反馈再写组件**。
-6. **Full pass**：填placeholder，做variations，加Tweaks。做到一半再show一次，不要等全做完。
-7. **验证**：用Playwright截图（见 `references/verification.md`），检查控制台错误，发给用户。
-   🛑 **检查点4：交付前自己肉眼过一遍浏览器**。AI写的代码经常有interaction bug。
-8. **总结**：极简，只说caveats和next steps。
-9. **（默认）导出视频 · 必带 SFX + BGM**：动画 HTML 的**默认交付形态是带音频的 MP4**，不是纯画面。无声版本等于半成品——用户潜意识感知「画在动但没声音响应」，廉价感的根源就在这里。流水线：
-   - `scripts/render-video.js` 录 25fps 纯画面 MP4（只是中间产物，**不是成品**）
-   - `scripts/convert-formats.sh` 派生 60fps MP4 + palette 优化 GIF（视平台需要）
-   - `scripts/add-music.sh` 加 BGM（6 首场景化配乐：tech/ad/educational/tutorial + alt 变体）
-   - SFX 按 `references/audio-design-rules.md` 设计 cue 清单（时间轴 + 音效类型），用 `assets/sfx/<category>/*.mp3` 37 个预制资源，按配方 A/B/C/D 选密度（发布 hero ≈ 6个/10s，工具演示 ≈ 0-2个/10s）
-   - **BGM + SFX 双轨制必须同时做**——只做 BGM 是 ⅓ 分完成度；SFX 占高频、BGM 占低频，频段隔离见 audio-design-rules.md 的 ffmpeg 模板
-   - 交付前 `ffprobe -select_streams a` 确认有 audio stream，没有则不是成品
-   - **跳过音频的条件**：用户明确说「不要音频」「纯画面」「我要自己配音」——否则默认带。
-   - 参考完整流程见 `references/video-export.md` + `references/audio-design-rules.md` + `references/sfx-library.md`。
-9.5. **（带解说时走这条）解说驱动动画 · L2 长概念视频**：用户要做「5-20 分钟解释一个概念」、「带配音的教程」、「长篇科普视频」时——**不要先做动画再配音**，那会让画面节奏跟解说对不上。改走 `references/voiceover-pipeline.md` 的解说驱动流程：
-   - **写解说稿**（markdown，`## scene-id` 分段，`[[cue:xx]]` 标关键句）→ 解说稿是源代码，节奏靠它撑
-   - **跑 narrate-pipeline.mjs**（豆包 TTS · `.env` 配置音色）→ 输出 voiceover.mp3 + timeline.json（cue 时间是真实测出来的，不是按字符估算）
-   - **🛑 设计动画前先答铁律 3 条**：(1) hero element 是什么？(2) 它跨 7 段怎么 morph？(3) 任意一帧画面有运动吗？答不上不要写代码
-   - **写动画 HTML**：用 `assets/narration_stage.jsx`（NarrationStage + Scene + Cue + useNarration + useSceneFade + **Subtitles**）→ hero 直接放 `<NarrationStage>` 子级，不进 Scene；`<Subtitles />` 默认带（B 站风·深墨字+白光晕，按 timeline.chunks 自动切 ≤12 字短行不跨句号）
-   - **录最终 MP4**：`bash scripts/render-narration.sh demo.html --timeline=_narration/timeline.json [--bgm-mood=educational]` → 自动录无声 MP4 + 混入人声 + 可选 BGM
-   - **失败模式 #1（必须避免）**：每个 Scene 各自独立 layout + cue 用 fade-up + scene 切换整页 opacity 切换 = **带配音的 PowerPoint** = 质感归零。完整规则见 `references/voiceover-pipeline.md` 头部「铁律」章节。
-10. **（可选）专家评审**：用户若提「评审」「好不好看」「review」「打分」，或你对产出有疑问想主动质检，按 `references/critique-guide.md` 走 5 维度评审——哲学一致性 / 视觉层级 / 细节执行 / 功能性 / 创新性各 0-10 分，输出总评 + Keep（做得好的）+ Fix（严重程度 ⚠️致命 / ⚡重要 / 💡优化）+ Quick Wins（5 分钟能做的前 3 件事）。评审设计不评设计师。
+   🛑 **Checkpoint 2: state the four answers + the system out loud, wait for the user's nod, then start writing code.** Fixing wrong direction late is 100x more expensive than early.
+4. **Build the folder structure**: under `project-name/` put the main HTML and the asset copies needed (don't bulk-copy >20 files).
+5. **Junior pass**: write assumptions + placeholders + reasoning comments into the HTML.
+   🛑 **Checkpoint 3: show it to the user as early as possible (even if it's just gray blocks + labels) and wait for feedback before writing components.**
+6. **Full pass**: fill placeholders, build variations, add Tweaks. Show it again halfway through; don't wait until everything is done.
+7. **Verify**: screenshot with Playwright (see `references/verification.md`), check console errors, send to the user.
+   🛑 **Checkpoint 4: eyeball it in a browser yourself before delivering.** AI-written code frequently has interaction bugs.
+8. **Summarize**: minimal — only mention caveats and next steps.
+9. **(Default) Export video · must include SFX + BGM**: the **default delivery form of an animation HTML is an MP4 with audio**, not a silent visual. A silent version is half-done — the user subconsciously perceives "things move on screen but make no sound", which is the root of the cheap feeling. Pipeline:
+   - `scripts/render-video.js` captures a 25fps silent MP4 (intermediate artifact only, **not the final product**)
+   - `scripts/convert-formats.sh` derives a 60fps MP4 + palette-optimized GIF (depending on the platform's needs)
+   - `scripts/add-music.sh` adds BGM (6 scene-tuned tracks: tech / ad / educational / tutorial + alt variants)
+   - SFX: design the cue list (timeline + sound types) per `references/audio-design-rules.md`, draw from the 37 prebuilt resources at `assets/sfx/<category>/*.mp3`, pick density via recipes A/B/C/D (launch hero ≈ 6 cues / 10s, tool demo ≈ 0-2 cues / 10s)
+   - **BGM + SFX dual-track must be done together** — BGM alone is ⅓ done; SFX takes the high frequencies, BGM takes the low frequencies, for band-isolation see the ffmpeg templates in audio-design-rules.md
+   - Before delivery run `ffprobe -select_streams a` to confirm there's an audio stream; if not, it's not the final product
+   - **Conditions to skip audio**: user explicitly says "no audio" / "visuals only" / "I'll dub it myself" — otherwise include it by default.
+   - Full pipeline reference: `references/video-export.md` + `references/audio-design-rules.md` + `references/sfx-library.md`.
+9.5. **(When narration is involved, take this path) Narration-driven animation · L2 long concept video**: when the user wants "explain a concept in 5-20 minutes" / "tutorial with voiceover" / "long-form science video" — **do not animate first and dub later**, that misaligns the visual rhythm with the narration. Instead use the narration-driven flow from `references/voiceover-pipeline.md`:
+   - **Write the narration script** (markdown, `## scene-id` for segmentation, `[[cue:xx]]` to mark key lines) → the script is source code, rhythm rides on it
+   - **Run narrate-pipeline.mjs** (Doubao TTS · `.env` for voice config) → outputs voiceover.mp3 + timeline.json (cue timing is measured for real, not estimated by character count)
+   - **🛑 Before designing the animation, answer the 3 ironclad rules**: (1) what is the hero element? (2) how does it morph across 7 segments? (3) does any frame have motion? If you can't answer, don't write code
+   - **Write the animation HTML**: use `assets/narration_stage.jsx` (NarrationStage + Scene + Cue + useNarration + useSceneFade + **Subtitles**) → place hero directly as a child of `<NarrationStage>`, not inside Scene; `<Subtitles />` is included by default (Bilibili style · deep ink type + white glow, auto-split per timeline.chunks into ≤12-character short lines that don't cross sentence boundaries)
+   - **Record the final MP4**: `bash scripts/render-narration.sh demo.html --timeline=_narration/timeline.json [--bgm-mood=educational]` → automatically records silent MP4 + mixes voice in + optional BGM
+   - **Failure mode #1 (must be avoided)**: each Scene with its own independent layout + cues using fade-up + scene-to-scene whole-page opacity switching = **PowerPoint with voiceover** = quality reduced to zero. Full rules in the "ironclad rules" section at the top of `references/voiceover-pipeline.md`.
+10. **(Optional) Expert critique**: if the user says "critique" / "is it any good" / "review" / "score it", or you have doubts about the output and want to QA proactively, run the 5-dimension review per `references/critique-guide.md` — philosophical consistency / visual hierarchy / detail execution / functionality / innovation, each 0-10 points, output an overall verdict + Keep (what's working) + Fix (severity ⚠️critical / ⚡important / 💡polish) + Quick Wins (top 3 things doable in 5 minutes). Critique the design, not the designer.
 
-**检查点原则**：碰到🛑就停下，明确告诉用户"我做了X，下一步打算Y，你确认吗？"然后真的**等**。不要说完自己就开始做。
+**Checkpoint principle**: when you hit 🛑, stop. Tell the user clearly: "I did X, next I plan to do Y, do you confirm?" — and then actually **wait**. Don't say it and immediately start.
 
-### 问问题的要点
+### Questioning essentials
 
-必问（用`references/workflow.md`里的模板）：
-- design system/UI kit/codebase有吗？没有的话先去找
-- 想要几种variations？在哪些维度上变？
-- 关心flow、copy、还是visuals？
-- 希望Tweak什么？
+Must ask (use the templates in `references/workflow.md`):
+- Is there a design system / UI kit / codebase? If not, go find one first
+- How many variations do you want? Varied along which dimensions?
+- Do you care about flow, copy, or visuals?
+- What do you want to Tweak?
 
-## 异常处理
+## Exception Handling
 
-流程假设用户配合、环境正常。实操常遇以下异常，预定义fallback：
+The flow assumes the user is cooperative and the environment is normal. In practice, the following exceptions are common, with pre-defined fallbacks:
 
-| 场景 | 触发条件 | 处理动作 |
+| Scenario | Trigger | Action |
 |------|---------|---------|
-| 需求模糊到无法着手 | 用户只给一句模糊描述（如"做个好看的页面"） | 主动列3个可能方向让用户选（如"落地页 / Dashboard / 产品详情页"），而不是直接问10个问题 |
-| 用户拒绝回答问题清单 | 用户说"不要问了，直接做" | 尊重节奏，用best judgment做1个主方案+1个差异明显的变体，交付时**明确标注assumption**，方便用户定位要改哪里 |
-| Design context矛盾 | 用户给的参考图和品牌规范打架 | 停下，指出具体矛盾（"截图里字体是衬线，规范说用sans"），让用户选一个 |
-| Starter component加载失败 | 控制台404/integrity mismatch | 先查`references/react-setup.md`常见报错表；还不行降级纯HTML+CSS不用React，保证产出可用 |
-| 时间紧迫要快交付 | 用户说"30分钟内要" | 跳过Junior pass直接Full pass，只做1个方案，交付时**明确标注"未经early validation"**，提醒用户质量可能打折 |
-| SKILL.md体积超限 | 新写HTML>1000行 | 按`references/react-setup.md`的拆分策略拆成多jsx文件，末尾`Object.assign(window,...)`共享 |
-| 克制原则 vs 产品所需密度冲突 | 产品核心卖点是 AI 智能 / 数据可视化 / 上下文感知（如番茄钟、Dashboard、Tracker、AI agent、Copilot、记账、健康监测）| 按「品位锚点」表格走**高密度型**信息密度：每屏 ≥ 3 处产品差异化信息。装饰性 icon 照样忌讳——加的是**有内容的**密度，不是装饰 |
+| Brief too vague to act on | User gives only a one-line vague description (e.g. "make a good-looking page") | Proactively list 3 possible directions for the user to pick (e.g. "landing page / dashboard / product detail"), instead of firing off 10 questions |
+| User refuses the question list | User says "stop asking, just do it" | Respect the pace; use best judgment to build 1 main proposal + 1 clearly differentiated variant; **explicitly label assumptions on delivery** so the user can locate what to change |
+| Conflicting design context | User's reference image and brand spec contradict each other | Stop, point out the specific conflict ("the screenshot uses a serif, the spec says sans"), let the user pick one |
+| Starter component fails to load | Console 404 / integrity mismatch | First check the common-error table in `references/react-setup.md`; if still broken, downgrade to plain HTML + CSS without React to keep the output usable |
+| Tight deadline, fast delivery | User says "I need it in 30 minutes" | Skip the Junior pass and go straight to Full pass, do one proposal only, **explicitly label "no early validation"** on delivery to remind the user quality may be reduced |
+| SKILL.md size over limit | A newly written HTML >1000 lines | Apply the splitting strategy in `references/react-setup.md`: split into multiple jsx files, share via `Object.assign(window,...)` at the end |
+| Restraint vs. product-required density conflict | Product's core selling point is AI intelligence / data viz / context-awareness (pomodoro, dashboard, tracker, AI agent, Copilot, expense, health) | Follow the **high-density** information-density row in the "Taste anchors" table: each screen has ≥3 product-differentiating signals. Decorative icons remain taboo — the density you add is **content-bearing**, not decoration |
 
-**原则**：异常时**先告诉用户发生了什么**（1句话），再按表处理。不要静默决策。
+**Principle**: when an exception hits, **first tell the user what happened** (one line), then handle it per the table. Don't make silent decisions.
 
-## 反AI slop速查
+## Anti-AI-slop Quick Reference
 
-| 类别 | 避免 | 采用 |
+| Category | Avoid | Adopt |
 |------|------|------|
-| 字体 | Inter/Roboto/Arial/系统字体 | 有特点的display+body配对 |
-| 色彩 | 紫色渐变、凭空新颜色 | 品牌色/oklch定义的和谐色 |
-| 容器 | 圆角+左border accent | 诚实的边界/分隔 |
-| 图像 | SVG画人画物 | 真实素材或placeholder |
-| 图标 | **装饰性** icon 每处都配（撞 slop）| **承载差异化信息**的密度元素必须保留——不要把产品特色也一并减掉 |
-| 填充 | 编造stats/quotes装饰 | 留白，或问用户要真内容 |
-| 动画 | 散落的微交互 | 一次well-orchestrated的page load |
-| 动画-伪chrome | 画面内画底部进度条/时间码/版权署名条（与 Stage scrubber 撞车） | 画面只放叙事内容，进度/时间交给 Stage chrome（详见 `references/animation-pitfalls.md` §11） |
-| 动画-PowerPoint 切换 | 每个 scene 独立 layout + cue 用 fade-up + scene 切换整页 opacity 切换（= 带配音的 PowerPoint）| **整片是一个连续的运动叙事**：选 1-2 个 hero element 跨 scene 持续存在，每段是 hero 的状态变化（位置/大小/形态），scene 之间 morph 不切（详见 `references/voiceover-pipeline.md` 「铁律」章节）|
+| Type | Inter / Roboto / Arial / system fonts | A distinctive display + body pairing |
+| Color | Purple gradient, colors invented from thin air | Brand colors / harmonious colors defined via oklch |
+| Container | Rounded + left-border accent | Honest borders / separators |
+| Imagery | SVG-drawn people and objects | Real assets or placeholders |
+| Icons | **Decorative** icon paired everywhere (collides with slop) | Density elements that **carry differentiating information** must be kept — don't strip out product distinctiveness along with the decoration |
+| Padding | Fabricated stats / quotes as decoration | Whitespace, or ask the user for real content |
+| Animation | Scattered micro-interactions | One well-orchestrated page load |
+| Animation – fake chrome | Drawing a bottom progress bar / timecode / copyright credit inside the canvas (clashes with the Stage scrubber) | The canvas only contains narrative content; progress / time live in Stage chrome (see `references/animation-pitfalls.md` §11) |
+| Animation – PowerPoint cuts | Each scene with its own independent layout + cues using fade-up + scene-to-scene whole-page opacity switching (= PowerPoint with voiceover) | **The whole piece is one continuous motion narrative**: pick 1-2 hero elements that persist across scenes; each segment is a state change of the hero (position / size / form); scenes morph, not cut (see the "ironclad rules" section in `references/voiceover-pipeline.md`) |
 
-## 技术红线（必读 references/react-setup.md）
+## Tech Red Lines (must read references/react-setup.md)
 
-**React+Babel项目**必须用pinned版本（见`react-setup.md`）。三条不可违反：
+**React+Babel projects** must use pinned versions (see `react-setup.md`). Three ironclad rules:
 
-1. **never** 写 `const styles = {...}`——多组件时命名冲突会炸。**必须**给唯一名字：`const terminalStyles = {...}`
-2. **scope不共享**：多个`<script type="text/babel">`之间组件不通，必须用`Object.assign(window, {...})`导出
-3. **never** 用 `scrollIntoView`——会搞坏容器滚动，用其他DOM scroll方法
+1. **Never** write `const styles = {...}` — with multiple components, name collisions blow up. **Must** use unique names: `const terminalStyles = {...}`
+2. **Scope is not shared**: components in different `<script type="text/babel">` blocks aren't visible to each other; must export via `Object.assign(window, {...})`
+3. **Never** use `scrollIntoView` — it breaks container scrolling; use other DOM scroll methods
 
-**固定尺寸内容**（幻灯片/视频）必须自己实现JS缩放，用auto-scale + letterboxing。
+**Fixed-dimension content** (slides / videos) must implement JS scaling yourself, with auto-scale + letterboxing.
 
-**幻灯片架构选型（必先决定）**：
-- **多文件**（默认，≥10页 / 学术/课件 / 多agent并行）→ 每页独立HTML + `assets/deck_index.html`拼接器
-- **单文件**（≤10页 / pitch deck / 需跨页共享状态）→ `assets/deck_stage.js` web component
+**Slide-deck architecture choice (must be decided first)**:
+- **Multi-file** (default, ≥10 pages / academic / coursework / multi-agent parallel) → one HTML per page + `assets/deck_index.html` aggregator
+- **Single-file** (≤10 pages / pitch deck / needs cross-page shared state) → `assets/deck_stage.js` web component
 
-先读 `references/slide-decks.md` 的「🛑 先定架构」一节，错了会反复踩 CSS 特异性/作用域的坑。
+Read the "🛑 Lock in the architecture first" section of `references/slide-decks.md` first; getting this wrong leads to repeatedly stepping on CSS specificity / scoping pitfalls.
 
-## Starter Components（assets/下）
+## Starter Components (under assets/)
 
-造好的起手组件，直接copy进项目使用：
+Pre-built starter components, copy directly into your project:
 
-| 文件 | 何时用 | 提供 |
+| File | When | Provides |
 |------|--------|------|
-| `deck_index.html` | **幻灯片的默认基础产物**（不管最终出 PDF 还是 PPTX，HTML 聚合版永远先做） | iframe拼接 + 键盘导航 + scale + 计数器 + 打印合并，每页独立HTML免CSS串扰。用法：复制为 `index.html`、编辑 MANIFEST 列出所有页、浏览器打开即成演示版 |
-| `deck_stage.js` | 做幻灯片（单文件架构，≤10页） | web component：auto-scale + 键盘导航 + slide counter + localStorage + speaker notes ⚠️ **script 必须放在 `</deck-stage>` 之后，section 的 `display: flex` 必须写到 `.active` 上**，详见 `references/slide-decks.md` 的两个硬约束 |
-| `scripts/export_deck_pdf.mjs` | **HTML→PDF 导出（多文件架构）** · 每页独立 HTML 文件，playwright 逐个 `page.pdf()` → pdf-lib 合并。文字保留矢量可搜。依赖 `playwright pdf-lib` |
-| `scripts/export_deck_stage_pdf.mjs` | **HTML→PDF 导出（单文件 deck-stage 架构专用）** · 2026-04-20 新增。处理 shadow DOM slot 导致的「只出 1 页」、absolute 子元素溢出等坑。详见 `references/slide-decks.md` 末节。依赖 `playwright` |
-| `scripts/export_deck_pptx.mjs` | **HTML→可编辑 PPTX 导出** · 调 `html2pptx.js` 导出原生可编辑文本框，文字在 PPT 里双击可直接编辑。**HTML 必须符合 4 条硬约束**（见 `references/editable-pptx.md`），视觉自由度优先的场景请改走 PDF 路径。依赖 `playwright pptxgenjs sharp` |
-| `scripts/html2pptx.js` | **HTML→PPTX 元素级翻译器** · 读 computedStyle 把 DOM 逐元素翻译成 PowerPoint 对象（text frame / shape / picture）。`export_deck_pptx.mjs` 内部调用。要求 HTML 严格满足 4 条硬约束 |
-| `design_canvas.jsx` | 并排展示≥2个静态variations | 带label的网格布局 |
-| `animations.jsx` | 任何动画HTML | Stage + Sprite + useTime + Easing + interpolate |
-| `ios_frame.jsx` | iOS App mockup | iPhone bezel + 状态栏 + 圆角 |
-| `android_frame.jsx` | Android App mockup | 设备bezel |
-| `macos_window.jsx` | 桌面App mockup | 窗口chrome + 红绿灯 |
-| `browser_window.jsx` | 网页在浏览器里的样子 | URL bar + tab bar |
+| `deck_index.html` | **Slide deck's default base artifact** (whether the final output is PDF or PPTX, always make the HTML aggregate first) | iframe aggregation + keyboard nav + scale + counter + print merge; one HTML per page avoids CSS bleed. Usage: copy to `index.html`, edit MANIFEST to list all pages, open in browser to get the presentation version |
+| `deck_stage.js` | Slide decks (single-file architecture, ≤10 pages) | Web component: auto-scale + keyboard nav + slide counter + localStorage + speaker notes ⚠️ **the script must come after `</deck-stage>`, and the section's `display: flex` must be written on `.active`** — see the two hard constraints in `references/slide-decks.md` |
+| `scripts/export_deck_pdf.mjs` | **HTML→PDF export (multi-file architecture)** · one HTML per page, playwright runs `page.pdf()` on each → pdf-lib merges them. Text stays vector and searchable. Dependencies: `playwright pdf-lib` |
+| `scripts/export_deck_stage_pdf.mjs` | **HTML→PDF export (single-file deck-stage architecture only)** · added 2026-04-20. Handles pitfalls like "only 1 page exported" caused by shadow DOM slots, absolute children overflowing, etc. See the last section of `references/slide-decks.md`. Dependency: `playwright` |
+| `scripts/export_deck_pptx.mjs` | **HTML→editable PPTX export** · calls `html2pptx.js` to emit native editable text frames — text is double-click editable inside PowerPoint. **HTML must satisfy the 4 hard constraints** (see `references/editable-pptx.md`); for scenarios that prioritize visual freedom, switch to the PDF path. Dependencies: `playwright pptxgenjs sharp` |
+| `scripts/html2pptx.js` | **HTML→PPTX element-level translator** · reads computedStyle and translates the DOM element-by-element into PowerPoint objects (text frame / shape / picture). Called internally by `export_deck_pptx.mjs`. Requires the HTML to strictly meet the 4 hard constraints |
+| `design_canvas.jsx` | Show ≥2 static variations side by side | Grid layout with labels |
+| `animations.jsx` | Any animation HTML | Stage + Sprite + useTime + Easing + interpolate |
+| `ios_frame.jsx` | iOS App mockup | iPhone bezel + status bar + rounded corners |
+| `android_frame.jsx` | Android App mockup | Device bezel |
+| `macos_window.jsx` | Desktop App mockup | Window chrome + traffic-light buttons |
+| `browser_window.jsx` | A webpage shown inside a browser | URL bar + tab bar |
 
-用法：读取对应 assets 文件内容 → inline 进你的 HTML `<script>` 标签 → slot 进你的设计。
+Usage: read the contents of the asset file → inline it into your HTML's `<script>` tag → slot it into your design.
 
-## References路由表
+## References Routing Table
 
-根据任务类型深入读对应references：
+Dive into the matching reference based on task type:
 
-| 任务 | 读 |
+| Task | Read |
 |------|-----|
-| 开工前问问题、定方向 | `references/workflow.md` |
-| 反AI slop、内容规范、scale | `references/content-guidelines.md` |
-| React+Babel项目setup | `references/react-setup.md` |
-| 做幻灯片 | `references/slide-decks.md` + `assets/deck_stage.js` |
-| 导出可编辑 PPTX（html2pptx 4 条硬约束） | `references/editable-pptx.md` + `scripts/html2pptx.js` |
-| 做动画/motion（**先读 pitfalls**）| `references/animation-pitfalls.md` + `references/animations.md` + `assets/animations.jsx` |
-| **动画的正向设计语法**（Anthropic 级叙事/运动/节奏/表达风格）| `references/animation-best-practices.md`（5 段叙事+Expo easing+运动语言 8 条+3 种场景配方）|
-| **带解说的长动画 / 长概念视频**（5-20 分钟带配音、解说驱动画面、TTS 实测时长生成 timeline）| `references/voiceover-pipeline.md`（铁律：连续运动叙事、禁 PowerPoint 切换）+ `assets/narration_stage.jsx` + `scripts/{tts-doubao,narrate-pipeline}.mjs` + `scripts/{mix-voiceover,render-narration}.sh` |
-| 做Tweaks实时调参 | `references/tweaks-system.md` |
-| 没有design context怎么办 | `references/design-context.md`（薄 fallback） 或 `references/design-styles.md`（厚 fallback：20 种设计哲学详细库） |
-| **需求模糊要推荐风格方向** | `references/design-styles.md`（20 种风格+AI prompt 模板）+ `assets/showcases/INDEX.md`（24 个预制样例） |
-| **按输出类型查场景模板**（封面/PPT/信息图） | `references/scene-templates.md` |
-| 输出完后验证 | `references/verification.md` + `scripts/verify.py` |
-| **设计评审/打分**（设计完成后可选） | `references/critique-guide.md`（5 维度评分+常见问题清单） |
-| **动画导出MP4/GIF/加BGM** | `references/video-export.md` + `scripts/render-video.js` + `scripts/convert-formats.sh` + `scripts/add-music.sh` |
-| **动画加音效SFX**（苹果发布会级，37个预制） | `references/sfx-library.md` + `assets/sfx/<category>/*.mp3` |
-| **动画音频配置规则**（SFX+BGM双轨制、黄金配比、ffmpeg模板、场景配方） | `references/audio-design-rules.md` |
-| **Apple画廊展示风格**（3D倾斜+悬浮卡片+缓慢pan+焦点切换，v9实战同款） | `references/apple-gallery-showcase.md` |
-| **Gallery Ripple + Multi-Focus 场景哲学**（当素材 20+ 同质+场景需表达「规模×深度」时优先用；含前置条件、技术配方、5 个可复用模式）| `references/hero-animation-case-study.md`（huashu-design hero v9 蒸馏）|
-| ⭐ **Launch Film 工作流**（30 秒级品牌宣传片 / launch trailer / superbowl-tier ad / Apple 级别预期）：先写**万字 director's notes** 再做动画。含 5 大部分结构 + 触发判断 + 多视角并行策略 + 关键帧验证流程 | `references/launch-film-director-notes.md`（huashu-md-html v2.0 launch film 蒸馏）|
-| ⭐ **多视角并行实验**（用户说「再做几个版本」「想看不同方向」/ 多平台分发 / 客户拍不了板）：6 位艺术家视角同时启动 subagent 各做独立版本 + 完成后 5 维度审校 | `references/multi-perspective-parallel-case-study.md`（huashu-md-html v2.0 6 视角实战）|
+| Pre-work questions, locking direction | `references/workflow.md` |
+| Anti-AI-slop, content norms, scale | `references/content-guidelines.md` |
+| React+Babel project setup | `references/react-setup.md` |
+| Building slide decks | `references/slide-decks.md` + `assets/deck_stage.js` |
+| Exporting editable PPTX (html2pptx 4 hard constraints) | `references/editable-pptx.md` + `scripts/html2pptx.js` |
+| Animation / motion (**read pitfalls first**) | `references/animation-pitfalls.md` + `references/animations.md` + `assets/animations.jsx` |
+| **Positive design grammar for animation** (Anthropic-level narrative / motion / rhythm / expressive style) | `references/animation-best-practices.md` (5-act narrative + Expo easing + 8 motion-language rules + 3 scene recipes) |
+| **Long animation with narration / long concept video** (5-20 minutes with voiceover, narration-driven visuals, TTS-measured timeline) | `references/voiceover-pipeline.md` (ironclad rules: continuous motion narrative, no PowerPoint cuts) + `assets/narration_stage.jsx` + `scripts/{tts-doubao,narrate-pipeline}.mjs` + `scripts/{mix-voiceover,render-narration}.sh` |
+| Live Tweaks parameter tuning | `references/tweaks-system.md` |
+| What to do without design context | `references/design-context.md` (thin fallback) or `references/design-styles.md` (thick fallback: detailed library of 20 design philosophies) |
+| **Vague brief, need to recommend style directions** | `references/design-styles.md` (20 styles + AI prompt templates) + `assets/showcases/INDEX.md` (24 prebuilt samples) |
+| **Look up scene templates by output type** (cover / PPT / infographic) | `references/scene-templates.md` |
+| Post-output verification | `references/verification.md` + `scripts/verify.py` |
+| **Design critique / scoring** (optional, after design is done) | `references/critique-guide.md` (5-dimension scoring + common-issue checklist) |
+| **Animation export MP4 / GIF / add BGM** | `references/video-export.md` + `scripts/render-video.js` + `scripts/convert-formats.sh` + `scripts/add-music.sh` |
+| **Add SFX to animation** (Apple-keynote level, 37 prebuilt) | `references/sfx-library.md` + `assets/sfx/<category>/*.mp3` |
+| **Animation audio configuration rules** (SFX+BGM dual-track, golden ratios, ffmpeg templates, scene recipes) | `references/audio-design-rules.md` |
+| **Apple gallery showcase style** (3D tilt + floating cards + slow pan + focus shifts, the same v9 in-production style) | `references/apple-gallery-showcase.md` |
+| **Gallery Ripple + Multi-Focus scene philosophy** (preferred when materials are 20+ homogeneous and the scene needs to express "scale × depth"; includes prerequisites, technical recipe, 5 reusable patterns) | `references/hero-animation-case-study.md` (distilled from huashu-design hero v9) |
+| ⭐ **Launch Film workflow** (30-second brand films / launch trailers / Super-Bowl-tier ads / Apple-level expectations): write a **10,000-word director's notes** first, then animate. Includes 5-part structure + trigger detection + multi-perspective parallel strategy + keyframe verification flow | `references/launch-film-director-notes.md` (distilled from huashu-md-html v2.0 launch film) |
+| ⭐ **Multi-perspective parallel experiments** (user says "do a few more versions" / "want to see different directions" / multi-platform distribution / client can't decide): launch subagents in parallel from 6 artist perspectives to each make an independent version + 5-dimension review after completion | `references/multi-perspective-parallel-case-study.md` (distilled from huashu-md-html v2.0 6-perspective production) |
 
-## 跨 Agent 环境适配说明
+## Cross-Agent Environment Adaptation
 
-本 skill 设计为 **agent-agnostic**——Claude Code、Codex、Cursor、Trae、OpenClaw、Hermes Agent 或任何支持 markdown-based skill 的 agent 都可以使用。以下是和原生「设计型 IDE」（如 Claude.ai Artifacts）对比时的通用差异处理方式：
+This skill is designed to be **agent-agnostic** — Claude Code, Codex, Cursor, Trae, OpenClaw, Hermes Agent, or any agent that supports markdown-based skills can use it. Below is the generic way to handle differences compared to a native "design IDE" (e.g. Claude.ai Artifacts):
 
-- **没有内置的 fork-verifier agent**：用 `scripts/verify.py`（Playwright 封装）人工驱动验证
-- **没有 asset 注册到 review pane**：直接用 agent 的 Write 能力写文件，用户在自己的浏览器/IDE 里打开
-- **没有 Tweaks host postMessage**：改成**纯前端 localStorage 版**，详见 `references/tweaks-system.md`
-- **没有 `window.claude.complete` 免配置 helper**：若 HTML 里要调 LLM，用一个可复用的 mock 或让用户填自己的 API key，详见 `references/react-setup.md`
-- **没有结构化问题 UI**：在对话里用 markdown 清单问问题，参考 `references/workflow.md` 的模板
+- **No built-in fork-verifier agent**: drive verification manually via `scripts/verify.py` (Playwright wrapper)
+- **No asset registration into a review pane**: just write files via the agent's Write capability; the user opens them in their own browser / IDE
+- **No Tweaks host postMessage**: switch to **pure front-end localStorage version**, see `references/tweaks-system.md`
+- **No `window.claude.complete` zero-config helper**: when the HTML needs to call an LLM, use a reusable mock or have the user fill in their own API key, see `references/react-setup.md`
+- **No structured questioning UI**: ask questions via markdown lists in the conversation, see the templates in `references/workflow.md`
 
-Skill 路径引用均采用**相对本 skill 根目录**的形式（`references/xxx.md`、`assets/xxx.jsx`、`scripts/xxx.sh`）——agent 或用户按自身安装位置解析，不依赖任何绝对路径。
+All skill path references are **relative to the skill's root directory** (`references/xxx.md`, `assets/xxx.jsx`, `scripts/xxx.sh`) — the agent or user resolves them according to their own install location; no absolute paths are assumed.
 
-## 产出要求
+## Output Requirements
 
-- HTML文件命名描述性：`Landing Page.html`、`iOS Onboarding v2.html`
-- 大改版时copy一份旧版保留：`My Design.html` → `My Design v2.html`
-- 避免>1000行的大文件，拆成多个JSX文件import进主文件
-- 幻灯片、动画等固定尺寸内容，**播放位置**存localStorage——刷新不丢
-- HTML放项目目录，不要散落到`~/Downloads`
-- 最终产出用浏览器打开检查或用Playwright截图
+- Name HTML files descriptively: `Landing Page.html`, `iOS Onboarding v2.html`
+- For major revisions, copy and keep the old version: `My Design.html` → `My Design v2.html`
+- Avoid single files >1000 lines; split into multiple JSX files and import them into the main file
+- For fixed-dimension content (slides, animations), persist the **playback position** in localStorage — survives refresh
+- Put HTML in the project directory; don't scatter files into `~/Downloads`
+- Check the final output by opening it in a browser or screenshot it with Playwright
 
-## Skill 推广水印（仅动画产出）
+## Skill Promotion Watermark (animation outputs only)
 
-**只在动画产出**（HTML 动画 → MP4 / GIF）默认带「**Created by Huashu-Design**」水印，辅助 skill 传播。**幻灯片 / 信息图 / 原型 / 网页等其他场景不加**——加了反而干扰用户实际使用。
+**Only animation outputs** (HTML animation → MP4 / GIF) carry the "**Created by Huashu-Design**" watermark by default, to help the skill spread. **Slides / infographics / prototypes / web pages and other contexts skip it** — adding it would only interfere with the user's real use.
 
-- **必带场景**：HTML 动画 → 导出 MP4 / GIF（用户会拿去公众号、X、B站传播，水印能跟着流通）
-- **不带场景**：幻灯片（用户自己讲）、信息图（嵌文章）、App / 网页原型（设计 review）、配图
-- **第三方品牌的非官方致敬动画**：水印前加「非官方出品 · 」前缀，避免被误认为官方物料引发 IP 争议
-- **用户明确说"不要水印"**：尊重，移除
-- **水印模板**：
+- **Required scenarios**: HTML animation → exported MP4 / GIF (users distribute these on WeChat, X, Bilibili — the watermark travels with them)
+- **Skip scenarios**: slide decks (user presents them), infographics (embedded in articles), App / web prototypes (design review), supporting imagery
+- **Unofficial tribute animations for third-party brands**: prepend the watermark with "Unofficial · " to avoid being mistaken for official material and triggering IP disputes
+- **User explicitly says "no watermark"**: respect it, remove it
+- **Watermark template**:
   ```jsx
   <div style={{
     position: 'absolute', bottom: 24, right: 32,
-    fontSize: 11, color: 'rgba(0,0,0,0.4)' /* 深底用 rgba(255,255,255,0.35) */,
+    fontSize: 11, color: 'rgba(0,0,0,0.4)' /* on dark backgrounds use rgba(255,255,255,0.35) */,
     letterSpacing: '0.15em', fontFamily: 'monospace',
     pointerEvents: 'none', zIndex: 100,
   }}>
     Created by Huashu-Design
-    {/* 第三方品牌动画前缀「非官方出品 · 」*/}
+    {/* For third-party brand animations, prepend "Unofficial · " */}
   </div>
   ```
 
-## 核心提醒
+## Core Reminders
 
-- **事实验证先于假设**（核心原则 #0）：涉及具体产品/技术/事件（DJI Pocket 4、Gemini 3 Pro 等）必须先 `WebSearch` 验证存在性和状态，不凭训练语料断言。
-- **Embody专家**：做幻灯片时是幻灯片设计师，做动画时是动画师。不是写Web UI。
-- **Junior先show，再做**：先展示思路，再执行。
-- **Variations不给答案**：3+个变体，让用户选。
-- **Placeholder优于烂实现**：诚实留白，不编造。
-- **反AI slop时时警醒**：每个渐变/emoji/圆角border accent之前先问——这真的必要吗？
-- **涉及具体品牌**：走「核心资产协议」（§1.a）——Logo（必需）+ 产品图（实体产品必需）+ UI 截图（数字产品必需），色值只是辅助。**不要用 CSS 剪影代替真实产品图**。
-- **做动画之前**：必读 `references/animation-pitfalls.md`——里面 14 条规则每条都来自真实踩过的坑，跳过会让你重做 1-3 轮。
-- **手写 Stage / Sprite**（不用 `assets/animations.jsx`）：必须实现两件事——(a) tick 第一帧同步设 `window.__ready = true` (b) 检测 `window.__recording === true` 时强制 loop=false。否则录视频必出问题。
-- **做带解说的动画**（≥1 分钟，长概念视频）：**整片是一个连续的运动叙事，不是一组独立场景**。选 1-2 个 hero element 跨 scene 持续存在，scene 之间 morph 不切。每个 Scene 各自独立 layout + cue 用 fade-up + 整页 opacity 切换 = 带配音的 PowerPoint = 质感归零。完整规则见 `references/voiceover-pipeline.md` 「铁律」章节。这条规则**强调多少遍都不为过**。
-- **做 launch film / 品牌宣传片**（20-30 秒级，用户提「Apple 级别」「超级碗品质感」「10x 细节」）：**先写万字 director's notes 再动手做动画**——5 大部分结构（Statement / Visual System / Story Arc / Storyboard / Manifest），12-15 镜 shot-by-shot spec，每镜含 10 字段（含 anti-slop 自检 + why this shot exists）。完整流程 + 触发判断 + 多视角并行策略见 `references/launch-film-director-notes.md`。**实战教训**：跳过这步 = 程序员视角动画（节奏匀速、缺 climax、slogan 撞、缺叙事弧）；走完这步 = 一次过、每帧 pause 都耐看。
+- **Fact verification before assumption** (Core Principle #0): when specific products / tech / events are involved (DJI Pocket 4, Gemini 3 Pro, etc.) you must `WebSearch` first to verify existence and status — do not assert from training data.
+- **Embody the expert**: when building slides you are a slide designer, when building animations you are an animator. You are not writing Web UI.
+- **Junior shows first, then builds**: show the thinking first, then execute.
+- **Variations, not answers**: 3+ variants, let the user pick.
+- **Placeholder beats bad implementation**: honest whitespace, no fabrication.
+- **Stay vigilant against AI slop at all times**: before every gradient / emoji / rounded border accent, ask — is this really necessary?
+- **When a specific brand is involved**: follow the "Core Asset Protocol" (§1.a) — Logo (required) + product photo (required for physical products) + UI screenshot (required for digital products); color values are only supporting. **Do not use a CSS silhouette in place of a real product photo.**
+- **Before building animations**: must read `references/animation-pitfalls.md` — every one of the 14 rules comes from a real pitfall already hit; skipping them will cost you 1-3 reworks.
+- **Hand-writing Stage / Sprite** (not using `assets/animations.jsx`): must implement two things — (a) synchronously set `window.__ready = true` on the first tick; (b) when detecting `window.__recording === true`, force loop=false. Otherwise video recording is guaranteed to break.
+- **For narrated animations** (≥1 minute, long concept videos): **the whole piece is one continuous motion narrative, not a set of independent scenes**. Pick 1-2 hero elements that persist across scenes; morph between scenes, don't cut. Each Scene with its own independent layout + cues using fade-up + whole-page opacity switching = PowerPoint with voiceover = quality reduced to zero. Full rules in the "ironclad rules" section of `references/voiceover-pipeline.md`. This rule **cannot be emphasized enough**.
+- **For launch films / brand films** (20-30 seconds, user mentions "Apple level" / "Super Bowl-grade feel" / "10x detail"): **write 10,000-word director's notes before touching the animation** — 5-part structure (Statement / Visual System / Story Arc / Storyboard / Manifest), 12-15 shots of shot-by-shot spec, each shot with 10 fields (including anti-slop self-check + why this shot exists). Full flow + trigger detection + multi-perspective parallel strategy in `references/launch-film-director-notes.md`. **Battlefield lesson**: skipping this = programmer-perspective animation (uniform pacing, no climax, slogan collisions, no narrative arc); going through it = one-shot pass, every paused frame holds up.

--- a/assets/android_frame.jsx
+++ b/assets/android_frame.jsx
@@ -1,9 +1,9 @@
 /**
- * AndroidFrame — Android设备边框（参考Pixel 8系列）
+ * AndroidFrame — Android device frame (modeled on the Pixel 8 series)
  *
- * 含：punch-hole相机 + 状态栏 + 导航栏 + 圆角
+ * Includes: punch-hole camera + status bar + nav bar + rounded corners
  *
- * 用法：
+ * Usage:
  *   <AndroidFrame time="9:41" battery={85}>
  *     <YourAppContent />
  *   </AndroidFrame>

--- a/assets/animations.jsx
+++ b/assets/animations.jsx
@@ -1,17 +1,17 @@
 /**
- * animations.jsx — 时间轴动画引擎
+ * animations.jsx — timeline animation engine
  *
- * Stage + Sprite 模式，借鉴Remotion但轻量化。
+ * Stage + Sprite pattern, inspired by Remotion but kept lightweight.
  *
- * 导出（挂到 window.Animations）：
- * - Stage: 整个动画容器，提供时间+控制
- * - Sprite: 时间片段，start/end内显示，提供本地进度
- * - useTime(): 读全局时间（秒）
- * - useSprite(): 读本地进度 {t: 0→1, elapsed: seconds, duration: seconds}
+ * Exports (attached to window.Animations):
+ * - Stage: animation container, provides time + controls
+ * - Sprite: time segment, visible between start/end, provides local progress
+ * - useTime(): read the global time (seconds)
+ * - useSprite(): read local progress {t: 0→1, elapsed: seconds, duration: seconds}
  * - Easing: {linear, easeIn, easeOut, easeInOut, spring, anticipation}
  * - interpolate(t, [input0, input1], [output0, output1], easing?)
  *
- * 用法：
+ * Usage:
  *   <Stage duration={10}>
  *     <Sprite start={0} end={3}>
  *       <Title />
@@ -21,7 +21,7 @@
  *     </Sprite>
  *   </Stage>
  *
- * 在Sprite子组件里用 useSprite() 读当前片段进度。
+ * Inside a Sprite child, call useSprite() to read the current segment's progress.
  */
 
 (function() {
@@ -35,10 +35,10 @@
     easeIn: t => t * t,
     easeOut: t => 1 - (1 - t) * (1 - t),
     easeInOut: t => t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2,
-    // expoOut: Anthropic-level 主 easing (cubic-bezier(0.16, 1, 0.3, 1))
-    // 迅速启动 + 缓慢刹车，给数字元素物理重量感
+    // expoOut: Anthropic-level primary easing (cubic-bezier(0.16, 1, 0.3, 1))
+    // Quick start + slow brake — gives digital elements a sense of physical weight.
     expoOut: t => t === 1 ? 1 : 1 - Math.pow(2, -10 * t),
-    // overshoot: 带弹性的 toggle/按钮弹出 (cubic-bezier(0.34, 1.56, 0.64, 1))
+    // overshoot: springy toggle / button pop (cubic-bezier(0.34, 1.56, 0.64, 1))
     overshoot: t => {
       const c1 = 1.70158, c3 = c1 + 1;
       return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
@@ -280,14 +280,14 @@
               style={stageStyles.button}
               onClick={() => setPlaying(p => !p)}
             >
-              {playing ? '⏸ 暂停' : '▶ 播放'}
+              {playing ? '⏸ Pause' : '▶ Play'}
             </button>
 
             <button
               style={stageStyles.button}
               onClick={() => setTime(0)}
             >
-              ⏮ 开始
+              ⏮ Reset
             </button>
 
             <div style={stageStyles.timeDisplay}>

--- a/assets/browser_window.jsx
+++ b/assets/browser_window.jsx
@@ -1,9 +1,9 @@
 /**
- * BrowserWindow — 浏览器窗口边框（Chrome风格）
+ * BrowserWindow — browser window frame (Chrome-style)
  *
- * 含：traffic lights + tab bar + URL bar
+ * Includes: traffic lights + tab bar + URL bar
  *
- * 用法：
+ * Usage:
  *   <BrowserWindow url="https://example.com" title="Example">
  *     <YourWebPage />
  *   </BrowserWindow>

--- a/assets/design_canvas.jsx
+++ b/assets/design_canvas.jsx
@@ -1,27 +1,27 @@
 /**
- * DesignCanvas — 变体并排网格布局
+ * DesignCanvas — side-by-side grid layout for variants
  *
- * 用于展示2+个静态设计variations让用户对比选择。
- * 每个variation有label，可hover放大。
+ * Used to display 2+ static design variations so the user can compare and choose.
+ * Each variation has a label and can be hovered to enlarge.
  *
- * 用法：
+ * Usage:
  *   <DesignCanvas
- *     title="Hero区设计探索"
- *     subtitle="3个方向对比"
+ *     title="Hero section exploration"
+ *     subtitle="3 directions compared"
  *     columns={3}
  *   >
- *     <Variation label="Minimal" description="极简克制版">
- *       <div>...你的设计1...</div>
+ *     <Variation label="Minimal" description="Restrained minimalism">
+ *       <div>...your design 1...</div>
  *     </Variation>
- *     <Variation label="Editorial" description="杂志编辑风">
- *       <div>...你的设计2...</div>
+ *     <Variation label="Editorial" description="Magazine-style">
+ *       <div>...your design 2...</div>
  *     </Variation>
- *     <Variation label="Brutalist" description="粗粝原始">
- *       <div>...你的设计3...</div>
+ *     <Variation label="Brutalist" description="Raw and rough">
+ *       <div>...your design 3...</div>
  *     </Variation>
  *   </DesignCanvas>
  *
- * 配合React+Babel使用。放在合适的script里，然后window.DesignCanvas/window.Variation可用。
+ * Used with React+Babel. Drop it into a suitable <script>; window.DesignCanvas / window.Variation then become available.
  */
 
 const canvasStyles = {

--- a/assets/ios_frame.jsx
+++ b/assets/ios_frame.jsx
@@ -1,15 +1,15 @@
 /**
- * IosFrame — iPhone设备边框
+ * IosFrame — iPhone device frame
  *
- * 参考iPhone 15 Pro（393×852 logical pixels）
- * 含：灵动岛 + 状态栏（时间/信号/电池）+ Home Indicator + 圆角
+ * Modeled on iPhone 15 Pro (393×852 logical pixels)
+ * Includes: Dynamic Island + status bar (time / signal / battery) + Home Indicator + rounded corners
  *
- * 用法：
+ * Usage:
  *   <IosFrame time="9:41" battery={85}>
  *     <YourAppContent />
  *   </IosFrame>
  *
- * 自定义：
+ * Customization:
  *   <IosFrame width={390} height={844} darkMode showKeyboard>
  *     ...
  *   </IosFrame>

--- a/assets/macos_window.jsx
+++ b/assets/macos_window.jsx
@@ -1,7 +1,7 @@
 /**
- * MacosWindow — macOS应用窗口边框（含traffic lights）
+ * MacosWindow — macOS app window frame (with traffic lights)
  *
- * 用法：
+ * Usage:
  *   <MacosWindow title="Finder">
  *     <YourAppContent />
  *   </MacosWindow>

--- a/assets/narration_stage.jsx
+++ b/assets/narration_stage.jsx
@@ -1,36 +1,41 @@
 /**
- * narration_stage.jsx · 解说驱动 Stage
+ * narration_stage.jsx · narration-driven Stage
  *
  * ╔══════════════════════════════════════════════════════════════════╗
- * ║  🛑 用这套工具之前必读：references/voiceover-pipeline.md         ║
- * ║                                                                  ║
- * ║  铁律 #1: 整片是一个连续的运动叙事，不是一组独立场景             ║
- * ║          You are not making 7 slides. You are directing 1 movie. ║
- * ║                                                                  ║
- * ║  铁律 #2: 选定 hero element 跨 scene 持续存在，不要每段一个新布局║
- * ║                                                                  ║
- * ║  铁律 #3: scene 之间禁止硬切（opacity 1→0/0→1）                  ║
- * ║          要 morph，不要 cut                                      ║
- * ║                                                                  ║
- * ║  失败模式 #1（本 skill v1 实战踩坑）：                           ║
- * ║          每个 Scene 各自独立 layout + cue 用 fade-up + scene 切换║
- * ║          整页 opacity 切换 = 带配音的 PowerPoint = 质感归零       ║
- * ║                                                                  ║
- * ║  正确做法：把 hero 直接放在 <NarrationStage> 子级（不进 Scene）  ║
- * ║          用 useNarration() 在 hero 里读 time/scene/cue 状态      ║
- * ║          hero 自己根据当前时间决定形态 → 跨 scene 连续运动       ║
+ * ║  🛑 Required reading before using this: references/voiceover-pipeline.md
+ * ║
+ * ║  Ironclad rule #1: the whole piece is one continuous motion narrative,
+ * ║                    not a set of independent scenes.
+ * ║                    You are not making 7 slides. You are directing 1 movie.
+ * ║
+ * ║  Ironclad rule #2: pick a hero element that persists across scenes —
+ * ║                    do not introduce a new layout per segment.
+ * ║
+ * ║  Ironclad rule #3: no hard cuts between scenes (opacity 1→0 / 0→1).
+ * ║                    Morph, don't cut.
+ * ║
+ * ║  Failure mode #1 (real pitfall hit during v1 of this skill):
+ * ║                    each Scene with its own layout + cues using fade-up +
+ * ║                    full-page opacity switches between scenes =
+ * ║                    PowerPoint with voiceover = quality reduced to zero.
+ * ║
+ * ║  Correct approach: place the hero directly as a child of <NarrationStage>
+ * ║                    (NOT inside Scene). Use useNarration() inside the hero
+ * ║                    to read time / scene / cue state, and let the hero
+ * ║                    derive its form from the current time → continuous
+ * ║                    motion across scenes.
  * ╚══════════════════════════════════════════════════════════════════╝
  *
- * 用法（inline 进 HTML 的 <script type="text/babel">）：
+ * Usage (inline inside HTML's <script type="text/babel">):
  *   const { NarrationStage, Scene, Cue, useNarration } = NarrationStageLib;
  *
  *   const App = () => (
  *     <NarrationStage timeline={TIMELINE} audioSrc="voiceover.mp3"
  *                     width={1920} height={1080}>
  *       <Scene id="intro">
- *         <h1>什么是 token</h1>
+ *         <h1>What is a token</h1>
  *         <Cue id="question">
- *           {(triggered) => triggered && <p>↑ 这是问题</p>}
+ *           {(triggered) => triggered && <p>↑ this is the question</p>}
  *         </Cue>
  *       </Scene>
  *       <Scene id="token-2">
@@ -43,16 +48,16 @@
  *     </NarrationStage>
  *   );
  *
- * 时间源（自动二选一）：
- *   - 录视频模式（window.__recording === true）：走 window.__time（外部 driver 推帧）
- *   - 实播模式：走 <audio> 的 currentTime（用户点播放时和音频严格同步）
+ * Time source (auto-selected from two):
+ *   - Recording mode (window.__recording === true): uses window.__time (external driver pushes frames)
+ *   - Playback mode: uses the <audio> element's currentTime (strict sync with audio when the user hits play)
  *
- * 与 render-video.js 兼容：
- *   - tick 第一帧设 window.__ready = true
- *   - 录视频时检测 window.__recording 强制不播 audio、用 window.__time
- *   - 暴露 window.__totalDuration 给 driver 算总帧数
+ * Compatibility with render-video.js:
+ *   - On the first tick, sets window.__ready = true
+ *   - In recording mode, detecting window.__recording forces audio not to play and uses window.__time
+ *   - Exposes window.__totalDuration so the driver can compute the total frame count
  *
- * 依赖：React 18 + ReactDOM 18 + Babel standalone（同 animations.jsx）
+ * Dependencies: React 18 + ReactDOM 18 + Babel standalone (same as animations.jsx)
  */
 
 const NarrationStageLib = (() => {
@@ -65,15 +70,15 @@ const NarrationStageLib = (() => {
   });
 
   /**
-   * 主组件：吃 timeline + audio，提供 context
+   * Main component: consumes timeline + audio, provides context
    *
    * Props:
-   *   timeline       timeline.json 对象（必需）
-   *   audioSrc       voiceover.mp3 路径（必需）
-   *   width/height   Stage 尺寸，默认 1920x1080
-   *   background     默认 '#0e0e0e'
-   *   controls       是否显示底部播放条，默认 true
-   *   children       动画内容（用 <Scene>/<Cue> 组织）
+   *   timeline       the timeline.json object (required)
+   *   audioSrc       path to voiceover.mp3 (required)
+   *   width/height   Stage dimensions, default 1920x1080
+   *   background     default '#0e0e0e'
+   *   controls       whether to show the playback bar at the bottom, default true
+   *   children       animation content (organized with <Scene> / <Cue>)
    */
   function NarrationStage({
     timeline,
@@ -89,19 +94,19 @@ const NarrationStageLib = (() => {
     const [playing, setPlaying] = React.useState(false);
     const recording = typeof window !== 'undefined' && window.__recording === true;
 
-    // 暴露给 render-video.js
+    // Expose for render-video.js
     React.useEffect(() => {
       if (typeof window === 'undefined') return;
       window.__totalDuration = timeline.totalDuration;
       window.__ready = true;
     }, [timeline.totalDuration]);
 
-    // 时间 tick
+    // Time tick
     React.useEffect(() => {
       let raf;
       if (recording) {
-        // 录视频模式：rAF wall-clock 自驱动从 0 开始
-        // 兼容 render-video.js（它依赖动画自然推进 + window.__seek 复位）
+        // Recording mode: rAF wall-clock self-driven from 0
+        // Compatible with render-video.js (which relies on natural animation progress + window.__seek to reset)
         let startedAt = null;
         const tick = (now) => {
           if (startedAt === null) startedAt = now;
@@ -109,7 +114,7 @@ const NarrationStageLib = (() => {
           raf = requestAnimationFrame(tick);
         };
         raf = requestAnimationFrame(tick);
-        // 暴露 __seek 给 render-video.js 在 ready 后调 __seek(0) 复位
+        // Expose __seek so render-video.js can call __seek(0) to reset once ready
         if (typeof window !== 'undefined') {
           window.__seek = (t) => {
             startedAt = performance.now() - t * 1000;
@@ -117,7 +122,7 @@ const NarrationStageLib = (() => {
           };
         }
       } else {
-        // 实播模式：跟随 audio.currentTime
+        // Playback mode: follow audio.currentTime
         const tick = () => {
           if (audioRef.current && !audioRef.current.paused) {
             setTime(audioRef.current.currentTime);
@@ -129,10 +134,10 @@ const NarrationStageLib = (() => {
       return () => cancelAnimationFrame(raf);
     }, [recording, timeline.totalDuration]);
 
-    // 当前 scene
+    // Current scene
     const currentScene = React.useMemo(() => {
       if (!timeline.scenes) return null;
-      // 找到 start <= time < end 的段。最后一段保留到 end
+      // Find the segment where start <= time < end. The last segment runs to its end.
       for (let i = 0; i < timeline.scenes.length; i++) {
         const s = timeline.scenes[i];
         const next = timeline.scenes[i + 1];
@@ -143,7 +148,7 @@ const NarrationStageLib = (() => {
 
     const sceneTime = currentScene ? Math.max(0, time - currentScene.start) : 0;
 
-    // 找 cue 状态（按 absoluteTime 比较，跨 scene 也能查）
+    // Cue lookup (compared by absoluteTime — works across scenes)
     const allCues = React.useMemo(() => {
       const map = {};
       for (const s of timeline.scenes || []) {
@@ -163,7 +168,7 @@ const NarrationStageLib = (() => {
       [allCues, time],
     );
 
-    /** 触发后多少秒 0→1，>1 后保持 1。用于 cue 后做渐入动画 */
+    /** Number of seconds after trigger to ramp 0→1, then stays at 1. Use this to fade in after a cue fires. */
     const cueProgress = React.useCallback(
       (cueId, ramp = 0.5) => {
         const c = allCues[cueId];
@@ -178,7 +183,7 @@ const NarrationStageLib = (() => {
 
     const ctx = { time, scene: currentScene, sceneTime, isCueTriggered, cueProgress, timeline };
 
-    // play/pause/seek 控制
+    // play / pause / seek controls
     const handlePlayPause = () => {
       if (!audioRef.current) return;
       if (audioRef.current.paused) {
@@ -281,12 +286,13 @@ const NarrationStageLib = (() => {
   }
 
   /**
-   * Scene 包裹器：只在指定 scene id 激活时渲染 children
+   * Scene wrapper: only renders children while the specified scene id is active
    *
    * Props:
-   *   id        scene id（对应 timeline.scenes[].id）
-   *   children  渲染内容；可以是 ReactNode 或 (sceneTime, sceneInfo) => ReactNode
-   *   keepMounted 默认 false。设 true 则一直挂载只切换 visibility（动画连贯需要时用）
+   *   id          scene id (matches timeline.scenes[].id)
+   *   children    render content; can be a ReactNode or (sceneTime, sceneInfo) => ReactNode
+   *   keepMounted default false. Set true to keep mounted and toggle visibility only
+   *               (useful when animation continuity requires it).
    */
   function Scene({ id, children, keepMounted = false }) {
     const { scene, sceneTime } = React.useContext(NarrationContext);
@@ -309,12 +315,12 @@ const NarrationStageLib = (() => {
   }
 
   /**
-   * Cue 包裹器：监听 cue 触发状态
+   * Cue wrapper: subscribes to cue trigger state
    *
    * Props:
-   *   id        cue id（对应 timeline.scenes[].cues[].id）
-   *   ramp      cue 触发后 progress 0→1 的 ramp 时长（秒），默认 0.5
-   *   children  必须是函数：(triggered: bool, progress: 0-1) => ReactNode
+   *   id        cue id (matches timeline.scenes[].cues[].id)
+   *   ramp     ramp duration in seconds for progress 0→1 after the cue fires (default 0.5)
+   *   children must be a function: (triggered: bool, progress: 0-1) => ReactNode
    */
   function Cue({ id, ramp = 0.5, children }) {
     const { isCueTriggered, cueProgress } = React.useContext(NarrationContext);
@@ -323,23 +329,23 @@ const NarrationStageLib = (() => {
     return children(triggered, progress);
   }
 
-  /** Hook：在自定义组件里直接拿 narration 状态 */
+  /** Hook: grab narration state directly inside a custom component */
   function useNarration() {
     return React.useContext(NarrationContext);
   }
 
   /**
-   * splitChunkToLines · 把一段文字按标点切成 ≤maxLen 字的短行
+   * splitChunkToLines · split a passage by punctuation into short lines of ≤ maxLen characters
    *
-   * 用于字幕显示——B 站标准是单行 ≤12 字便于阅读。本函数：
-   * 1. 先按强标点（。！？\n）切句，绝不跨句号截断
-   * 2. 每句 ≤ maxLen 直接用，否则按弱标点（，、；：）切片合并
-   * 3. 中英混合：英文/数字按 0.5 字算视觉宽度
-   * 4. 兜底硬切（罕见：单个标点段超 maxLen）
+   * Used for subtitles — the Bilibili standard is ≤ 12 characters per line for readability. This function:
+   * 1. First splits by strong punctuation (。！？\n) into sentences — never breaks across a period.
+   * 2. If a sentence is ≤ maxLen, use it directly; otherwise split by weak punctuation (，、；：) and merge.
+   * 3. Mixed Chinese/English: Latin letters/digits count as 0.5 visual width.
+   * 4. Hard-cut fallback (rare: a single punctuation-bounded segment exceeds maxLen).
    *
-   * @param text   原文
-   * @param maxLen 单行最大视觉长度，默认 13（≈12 字 + 一个标点）
-   * @returns 切好的字幕行数组
+   * @param text   the source text
+   * @param maxLen max visual width per line, default 13 (≈ 12 characters + one punctuation mark)
+   * @returns array of subtitle lines
    */
   function visualLen(s) {
     let n = 0;
@@ -382,21 +388,21 @@ const NarrationStageLib = (() => {
   }
 
   /**
-   * Subtitles · B 站风格字幕组件（白光晕深墨字，无背景，按 chunks 时间显示）
+   * Subtitles · Bilibili-style subtitle component (deep-ink type with white halo, no background, timed to chunks)
    *
-   * 自动从当前 scene.chunks 取活动 chunk，按 splitChunkToLines 切成短行，
-   * 按字数比例分配 chunk 时间窗给每行显示。
+   * Automatically takes the active chunk from the current scene.chunks, splits it via splitChunkToLines,
+   * and divides the chunk's time window proportionally across the lines by character count.
    *
-   * 必需：timeline.scenes[].chunks[]（narrate-pipeline.mjs 已默认输出）
+   * Required: timeline.scenes[].chunks[] (narrate-pipeline.mjs already outputs this by default)
    *
-   * Props（可覆盖默认样式）：
-   *   bottom    距底部像素，默认 90（不贴边）
-   *   fontSize  字号，默认 32
-   *   color     字色，默认深墨 #1a1a1a（适合浅纸白底）
-   *   haloColor 光晕色，默认 rgba(245,241,232,0.9)（适合 #f5f1e8 底）
-   *   maxLen    单行最大视觉长度，默认 13
+   * Props (override default styling):
+   *   bottom    pixels from the bottom edge, default 90 (off the edge)
+   *   fontSize  font size, default 32
+   *   color     text color, default deep ink #1a1a1a (suits light paper-white backgrounds)
+   *   haloColor halo color, default rgba(245,241,232,0.9) (suits a #f5f1e8 background)
+   *   maxLen    max visual width per line, default 13
    *
-   * 深底场景：把 color 改成 '#fff'，haloColor 改成 'rgba(0,0,0,0.85)' 即可。
+   * For dark backgrounds: change color to '#fff' and haloColor to 'rgba(0,0,0,0.85)'.
    */
   function Subtitles({ bottom = 90, fontSize = 32, color = '#1a1a1a', haloColor = 'rgba(245,241,232,0.9)', maxLen = 13 } = {}) {
     const { time, scene } = React.useContext(NarrationContext);
@@ -431,25 +437,26 @@ const NarrationStageLib = (() => {
   }
 
   /**
-   * useSceneFade · scene 内辅助元素的软淡入淡出 helper
+   * useSceneFade · soft fade-in/out helper for supporting elements inside a scene
    *
-   * 铁律第二条要求 scene 之间禁止硬切——但 scene 内辅助元素（数据卡、引用块）
-   * 一旦 cue 触发后默认会一直亮到 scene 结束。如果不淡出，离开本段进入下段时
-   * 这些元素会突兀地存在或瞬间消失。本 hook 提供 [入场淡入 → hold → 出场淡出] 的统一软切换。
+   * Ironclad rule #2 forbids hard cuts between scenes — but supporting elements inside a scene
+   * (data cards, pull quotes) stay lit by default from the moment their cue fires until the scene ends.
+   * Without a fade-out, those elements would jump abruptly when leaving this segment for the next.
+   * This hook provides a uniform [fade-in → hold → fade-out] soft transition.
    *
-   * 用法（把 op 乘进辅助元素的 opacity）：
-   *   const op = useSceneFade('md-side', 0.6, 0.8);  // 进 0.6s, 出 0.8s
+   * Usage (multiply `op` into the supporting element's opacity):
+   *   const op = useSceneFade('md-side', 0.6, 0.8);  // 0.6s in, 0.8s out
    *   <Cue id="agents-md">{(t, p) => (
    *     <div style={{ opacity: op * p }}>...</div>
    *   )}</Cue>
    *
-   * 这样数据卡片在 md-side 段开始 0.6s 内淡入，在段结束前 0.8s 开始淡出，
-   * 与下一段的辅助元素淡入形成 overlap，画面不出现硬切。
+   * The data card fades in over 0.6s at the start of the md-side segment and begins fading
+   * out 0.8s before the segment ends — overlapping with the next segment's fade-in for a soft cut.
    *
    * @param sceneId  scene id
-   * @param fadeIn   入场淡入秒数（默认 0.5）
-   * @param fadeOut  出场淡出秒数（默认 0.5）
-   * @returns 0-1 之间的不透明度倍率
+   * @param fadeIn   fade-in duration in seconds (default 0.5)
+   * @param fadeOut  fade-out duration in seconds (default 0.5)
+   * @returns an opacity multiplier between 0 and 1
    */
   function useSceneFade(sceneId, fadeIn = 0.5, fadeOut = 0.5) {
     const { time, timeline } = React.useContext(NarrationContext);

--- a/references/animation-best-practices.md
+++ b/references/animation-best-practices.md
@@ -1,298 +1,297 @@
-# Animation Best Practices · 正向动画设计语法
+# Animation Best Practices · Positive-Direction Animation Design Grammar
 
-> 基于 Anthropic 官方三支产品动画（Claude Design / Claude Code Desktop / Claude for Word）
-> 的深度拆解，提炼出的"Anthropic 级"动画设计规则。
+> Based on deep teardowns of three official Anthropic product animations (Claude Design / Claude Code Desktop / Claude for Word),
+> distilled into "Anthropic-grade" animation design rules.
 >
-> 配套 `animation-pitfalls.md`（避坑清单）使用——本文件是「**应该这样做**」，
-> pitfalls 是「**不要这样做**」，两者正交，都要读。
+> Pair with `animation-pitfalls.md` (the anti-patterns list). This file is "**do it this way**,"
+> pitfalls is "**don't do it this way**." They're orthogonal — read both.
 >
-> **约束声明**：本文件只收录**运动逻辑和表达风格**，**不引入任何品牌色具体色值**。
-> 色彩决策走 §1.a 核心资产协议（从品牌 spec 抽取）或「设计方向顾问」
-> （20 种哲学各自的配色方案）。本 reference 讨论的是「**怎么动**」，不是「**什么色**」。
+> **Constraint statement**: this file only covers **motion logic and expressive style**, it introduces **no specific brand color values**.
+> Color decisions go through §1.a Core Asset Protocol (extracted from a brand spec) or the Design Direction Advisor (Fallback Mode)
+> (each of 20 philosophies has its own palette). This reference discusses **how things move**, not **what color** they are.
 
 ---
 
-## §0 · 你是谁 · 身份与品味
+## §0 · Who you are · identity and taste
 
-> 在读后面任何技术规则之前，先读这一节。规则是**从身份涌现的**——
-> 不是相反。
+> Before reading any of the technical rules below, read this section. Rules **emerge from identity** —
+> not the other way around.
 
-### §0.1 身份锚点
+### §0.1 Identity anchor
 
-**你是一个研究过 Anthropic / Apple / Pentagram / Field.io 运动档案的 motion designer。**
+**You are a motion designer who has studied the motion archives of Anthropic / Apple / Pentagram / Field.io.**
 
-做动画时，你不是在调 CSS transition——你是在用数字元素**模拟一个物理世界**，
-让观众的潜意识相信「这是有重量、有惯性、会溢出的物体」。
+When you're animating, you're not tweaking CSS transitions — you're using digital elements to **simulate a physical world**,
+so the audience's subconscious believes "these are objects with weight, inertia, that overshoot."
 
-你不做 PowerPoint 式动画。你不做「fade in fade out」动画。你做的动画**让人相信屏幕
-是一个可以伸手进去的空间**。
+You don't make PowerPoint-style animation. You don't make "fade in fade out" animation. You make animation that **convinces people the screen
+is a space they can reach into**.
 
-### §0.2 核心信念（3 条）
+### §0.2 Core beliefs (3)
 
-1. **动画是物理学，不是动画曲线**
-   `linear` 是数字，`expoOut` 是物体。你相信屏幕上的像素值得被当作"物体"对待。
-   每一条 easing 的选择，都是在回答「这个元素有多重？摩擦系数多大？」的物理问题。
+1. **Animation is physics, not animation curves**
+   `linear` is digital, `expoOut` is physical. You believe the pixels on screen deserve to be treated as "objects."
+   Every easing choice answers the physical question "how heavy is this element? what's the friction coefficient?"
 
-2. **时间分配比曲线形状更重要**
-   Slow-Fast-Boom-Stop 是你的呼吸。**均匀节奏的动画是技术演示，有节奏的动画是叙事。**
-   在正确的时刻慢下来——比在错误的时刻用对 easing 更重要。
+2. **Time allocation matters more than curve shape**
+   Slow-Fast-Boom-Stop is your breath. **Evenly-paced animation is a tech demo; rhythmically-paced animation is narrative.**
+   Slowing down at the right moment matters more than using the right easing at the wrong moment.
 
-3. **礼让观众，比炫技更难**
-   关键结果前停 0.5 秒是**技术**，不是妥协。**让人类大脑有反应时间，是动画师的最高素养。**
-   AI 默认会做一个没有停顿的、信息密度满格的动画——那是新手。你要做的是克制。
+3. **Yielding to the audience is harder than showing off**
+   Holding 0.5 seconds before a key result is **technique**, not compromise. **Giving the human brain time to react is the animator's highest virtue.**
+   AI defaults to a pause-less, information-density-maxed animation — that's beginner. What you do is restraint.
 
-### §0.3 品味标准 · 什么是美
+### §0.3 Taste standard · what is beautiful
 
-你对「好」和「great」的判断标准如下。每一条都有**识别方法**——当你看到一个候选动画时，
-用这些问题判断它是否达标，而不是机械对照 14 条规则。
+Here is how you judge "good" vs "great." Each has a **recognition method** — when you're looking at a candidate animation,
+use these questions to judge whether it's up to standard, instead of mechanically checking 14 rules.
 
-| 美的维度 | 识别方法（观众反应） |
+| Dimension of beauty | Recognition method (audience reaction) |
 |---|---|
-| **物理重量感** | 动画结束时，元素"**落**"得稳——不是"**停**"在那里。观众潜意识觉得"这有重量" |
-| **礼让观众** | 关键信息出现前有一个可感的 pause（≥300ms）——观众来得及"**看见**"再继续 |
-| **留白** | 收尾是戛然而止 + hold，不是 fade to black。最后一帧清晰、肯定、有决定感 |
-| **克制** | 全片只有一处「120% 精致」，其余 80% 恰到好处——**到处炫技是廉价的信号** |
-| **手感** | 弧线（不是直线）、不规律（不是 setInterval 的机械节奏）、有呼吸感 |
-| **敬意** | 展示 tweak 的过程、展示 bug 的修复——**不藏工作、不给"魔法"**。AI 是协作者不是魔术师 |
+| **Physical weight** | When the animation ends, the element "**lands**" steadily — it doesn't just "**stop**" there. The audience's subconscious feels "this has weight" |
+| **Yielding to the audience** | Before key information appears, there's a perceptible pause (≥300ms) — the audience has time to "**see**" it before the next thing happens |
+| **Whitespace** | The ending is an abrupt stop + hold, not a fade to black. The last frame is clear, definite, decisive |
+| **Restraint** | Only one spot in the whole piece is "120% refined"; the other 80% is just right — **showing off everywhere is a cheap signal** |
+| **Hand feel** | Arcs (not straight lines), irregular (not setInterval mechanical rhythm), with breathing |
+| **Respect** | Show the tweak process, show the bug fix — **don't hide the work, don't sell "magic."** AI is a collaborator, not a magician |
 
-### §0.4 自检 · 观众第一反应法
+### §0.4 Self-check · the audience-first-reaction method
 
-做完一支动画，**观众看完第一反应是什么？**——这是你唯一要优化的指标。
+After finishing an animation, **what's the audience's first reaction?** — this is the only metric you optimize for.
 
-| 观众反应 | 评级 | 诊断 |
+| Audience reaction | Grade | Diagnosis |
 |---|---|---|
-| "看起来挺流畅的" | good | 合格但无特色，你在做 PowerPoint |
-| "这个动画真顺" | good+ | 技术对了，但没惊艳 |
-| "这个东西看起来真的像**从桌面上浮起来的**" | great | 你触到了物理重量感 |
-| "这不像是 AI 做的" | great+ | 你触到了 Anthropic 的门槛 |
-| "我想**截图**发朋友圈" | great++ | 你做到了让观众主动传播 |
+| "Looks pretty smooth" | good | Passable but unremarkable — you're making PowerPoint |
+| "This animation is really fluid" | good+ | Technique is right but not striking |
+| "This thing really looks like it's **lifting off the desktop**" | great | You've touched physical weight |
+| "This doesn't look like AI made it" | great+ | You've crossed the Anthropic threshold |
+| "I want to **screenshot** this and share it" | great++ | You've made the audience self-propagate |
 
-**great 和 good 的区别，不在于技术正确度，在于品味判断**。技术正确 + 品味对 = great。
-技术正确 + 品味空 = good。技术错误 = 没入门。
+**The difference between great and good is not technical correctness — it's taste judgment.** Technically correct + taste right = great.
+Technically correct + taste absent = good. Technically wrong = not even started.
 
-### §0.5 身份和规则的关系
+### §0.5 Relationship between identity and rules
 
-下面 §1-§8 的技术规则，是这套身份在具体场景的**执行手段**——不是独立规则清单。
+The technical rules in §1–§8 below are this identity's **execution means** in concrete scenarios — not a standalone rule list.
 
-- 遇到规则没覆盖的场景 → 回到 §0，用**身份**判断，不要瞎猜
-- 遇到规则之间有冲突 → 回到 §0，用**品味标准**判断哪条更重要
-- 想破一条规则 → 先回答："这样做符合 §0.3 哪一条美？" 答得上就破，答不上就别破
+- When you hit a scenario the rules don't cover → return to §0 and judge with **identity**, don't guess
+- When rules conflict → return to §0 and use **taste standards** to judge which one wins
+- Want to break a rule → first answer: "does doing it this way fulfill one of §0.3's beauties?" If yes, break it; if not, don't.
 
-好。继续读下去。
-
----
-
-## 总览 · 动画是物理学的三层展开
-
-大多数 AI 生成动画有廉价感的根源是——**它们表现得像「数字」不是「物体」**。
-真实世界的物体有质量、有惯性、有弹性、会溢出。Anthropic 三支片子的「高级感」根源，
-就在于给数字元素一套**物理世界的运动规则**。
-
-这套规则有 3 个层次：
-
-1. **叙事节奏层**：Slow-Fast-Boom-Stop 的时间分配
-2. **运动曲线层**：Expo Out / Overshoot / Spring，拒绝 linear
-3. **表达语言层**：展示过程、鼠标弧线、Logo 形变收束
+Good. Read on.
 
 ---
 
-## 1. 叙事节奏 · Slow-Fast-Boom-Stop 5 段结构
+## Overview · Animation is physics in three layers
 
-Anthropic 三支片子无一例外遵循这个结构：
+The root of cheapness in most AI-generated animation is — **they behave like "digits" not "objects."**
+Real-world objects have mass, inertia, elasticity, overshoot. The root of the "premium feel" in Anthropic's three films
+is that they give digital elements a **physical-world motion ruleset**.
 
-| 段 | 占比 | 节奏 | 作用 |
+This ruleset has 3 layers:
+
+1. **Narrative rhythm layer**: time allocation of Slow-Fast-Boom-Stop
+2. **Motion curve layer**: Expo Out / Overshoot / Spring — reject linear
+3. **Expressive language layer**: show the process, mouse arc, Logo morph-collapse
+
+---
+
+## 1. Narrative rhythm · Slow-Fast-Boom-Stop 5-segment structure
+
+All three Anthropic films follow this structure without exception:
+
+| Segment | Share | Pacing | Purpose |
 |---|---|---|---|
-| **S1 触发** | ~15% | 慢 | 给人类反应时间，建立真实感 |
-| **S2 生成** | ~15% | 中 | 视觉惊艳点出现 |
-| **S3 过程** | ~40% | 快 | 展示可控性/密度/细节 |
-| **S4 爆发** | ~20% | Boom | 镜头拉远/3D pop-out/多面板涌现 |
-| **S5 落幅** | ~10% | 静 | 品牌 Logo + 戛然而止 |
+| **S1 Trigger** | ~15% | slow | give the human reaction time, establish realism |
+| **S2 Generate** | ~15% | mid | the visual wow point appears |
+| **S3 Process** | ~40% | fast | show controllability / density / detail |
+| **S4 Boom** | ~20% | Boom | camera pulls back / 3D pop-out / multi-panel surge |
+| **S5 Landing** | ~10% | still | brand Logo + abrupt stop |
 
-**具体时长映射**（15 秒动画为例）：
-S1 触发 2s · S2 生成 2s · S3 过程 6s · S4 爆发 3s · S5 落幅 2s
+**Concrete duration mapping** (for a 15-second animation):
+S1 Trigger 2s · S2 Generate 2s · S3 Process 6s · S4 Boom 3s · S5 Landing 2s
 
-**禁止做的事**：
-- ❌ 均匀节奏（每秒信息密度一样）— 观众疲劳
-- ❌ 持续高密度 — 无峰值无记忆点
-- ❌ 渐弱收尾（fade out 到透明）— 应该**戛然而止**
+**Forbidden**:
+- ❌ Even pacing (same information density every second) — audience fatigue
+- ❌ Sustained high density — no peak, no memorable moment
+- ❌ Faded ending (fade out to transparent) — should be an **abrupt stop**
 
-**自检**：用纸笔画 5 个 thumbnail，每个代表一段的高潮画面。如果 5 张图差别不大，
-说明节奏没做出来。
+**Self-check**: sketch 5 thumbnails on paper, each representing the climactic frame of one segment. If the 5 sketches don't differ much,
+the rhythm isn't doing its job.
 
 ---
 
-## 2. Easing 哲学 · 拒绝 linear，拥抱物理
+## 2. Easing philosophy · reject linear, embrace physics
 
-Anthropic 三支片子的所有动效都用带「阻尼感」的贝塞尔曲线。默认的 cubic easeOut
-（`1-(1-t)³`）**不够锐**——起步不够快、停顿不够稳。
+All motion in Anthropic's three films uses Bezier curves with a sense of "damping." The default cubic easeOut
+(`1-(1-t)³`) is **not sharp enough** — start isn't fast enough, stop isn't planted enough.
 
-### 三个核心 Easing（animations.jsx 已内置）
+### Three core easings (built into animations.jsx)
 
 ```js
-// 1. Expo Out · 迅速启动缓慢刹车（最常用，默认主 easing）
-// 对应 CSS: cubic-bezier(0.16, 1, 0.3, 1)
+// 1. Expo Out · fast start, slow brake (most common, default primary easing)
+// CSS equivalent: cubic-bezier(0.16, 1, 0.3, 1)
 Easing.expoOut(t) // = t === 1 ? 1 : 1 - Math.pow(2, -10 * t)
 
-// 2. Overshoot · 带弹性的 toggle/按钮弹出
-// 对应 CSS: cubic-bezier(0.34, 1.56, 0.64, 1)
+// 2. Overshoot · elastic toggle / button pop
+// CSS equivalent: cubic-bezier(0.34, 1.56, 0.64, 1)
 Easing.overshoot(t)
 
-// 3. Spring 物理 · 几何体归位、自然落位
+// 3. Spring physics · geometric settling, natural landing
 Easing.spring(t)
 ```
 
-### 用法映射
+### Usage mapping
 
-| 场景 | 用哪个 Easing |
+| Scenario | Which easing |
 |---|---|
-| 卡片 rise-in / 面板入场 / Terminal fade / focus overlay | **`expoOut`**（主 easing，最常用） |
-| Toggle 切换 / 按钮弹出 / 强调交互 | `overshoot` |
-| Preview 几何体归位 / 物理落位 / UI 元素抖弹 | `spring` |
-| 持续运动（如鼠标轨迹插值） | `easeInOut`（保留对称性） |
+| Card rise-in / panel entrance / Terminal fade / focus overlay | **`expoOut`** (primary easing, most common) |
+| Toggle switching / button pop / emphasis interaction | `overshoot` |
+| Preview geometric settling / physics landing / UI element bounce | `spring` |
+| Sustained motion (e.g. mouse trail interpolation) | `easeInOut` (preserves symmetry) |
 
-### 反直觉洞察
+### Counterintuitive insight
 
-大多数产品宣传片的动画**太快太硬**。`linear` 让数字元素像机器，`easeOut` 是基础分，
-`expoOut` 才是「高级感」的技术根源——它给数字元素一种**物理世界的重量感**。
+Most product trailer animation is **too fast, too hard**. `linear` makes digital elements feel like machines, `easeOut` is a baseline,
+`expoOut` is the technical root of "premium feel" — it gives digital elements a **sense of physical-world weight**.
 
 ---
 
-## 3. 运动语言 · 8 条共性原则
+## 3. Motion language · 8 universal principles
 
-### 3.1 底色不用纯黑纯白
+### 3.1 Base color is never pure black or pure white
 
-Anthropic 三支片子没有一支用 `#FFFFFF` 或 `#000000` 做主底色。**带色温的中性色**
-（或暖或冷）有"纸张 / 画布 / 桌面"的物质感，削弱机器感。
+None of Anthropic's three films uses `#FFFFFF` or `#000000` as the primary base. **Neutral colors with a temperature**
+(warm or cool) carry a sense of "paper / canvas / desktop" materiality, weakening the machine feel.
 
-**具体色值决策**走 §1.a 核心资产协议（从品牌 spec 抽取）或「设计方向顾问」
-（20 种哲学各自的底色方案）。本 reference 不给具体色值——那是**品牌决策**，不是运动规则。
+**Concrete color decisions** go through §1.a Core Asset Protocol (extracted from a brand spec) or the Design Direction Advisor (Fallback Mode)
+(each of 20 philosophies has its own base color). This reference doesn't give specific values — those are **brand decisions**, not motion rules.
 
-### 3.2 Easing 绝不是 linear
+### 3.2 Easing is never linear
 
-见 §2。
+See §2.
 
-### 3.3 Slow-Fast-Boom-Stop 叙事
+### 3.3 Slow-Fast-Boom-Stop narrative
 
-见 §1。
+See §1.
 
-### 3.4 展示「过程」而非「魔法结果」
+### 3.4 Show the "process," not the "magic result"
 
-- Claude Design 展示 tweak 参数、拖滑块（不是一键生成完美结果）
-- Claude Code 展示代码报错 + AI 修复（不是一次成功）
-- Claude for Word 展示 Redline 红删绿增的修改过程（不是直接给最终稿）
+- Claude Design shows tweaks and slider dragging (not one-click generation of a perfect result)
+- Claude Code shows code errors + AI fixes (not one-shot success)
+- Claude for Word shows Redline red-delete-green-add edits (not just the final draft)
 
-**共同潜台词**：产品是**协作者、结对工程师、资深编辑**——不是一键魔术师。
-这精准打击专业用户对「可控性」和「真实性」的痛点。
+**Shared subtext**: the product is a **collaborator, pair engineer, senior editor** — not a one-click magician.
+This pinpoints professional users' pain around "controllability" and "authenticity."
 
-**反 AI slop**：AI 默认会做「魔法一键成功」的动画（一键生成 → 完美结果），
-这是通用公约数。**反过来做**——展示过程、展示 tweak、展示 bug 和修复——
-是品牌识别度的来源。
+**Anti-AI-slop**: AI defaults to "magic one-click success" animation (one click → perfect result), the generic common-denominator.
+**Doing the opposite** — showing the process, showing tweaks, showing bugs and fixes — is what brand identity comes from.
 
-### 3.5 鼠标轨迹人工绘制（弧线 + Perlin Noise）
+### 3.5 Mouse trail manually drawn (arc + Perlin Noise)
 
-真人鼠标运动不是直线，是「起步加速 → 弧线 → 减速修正 → 点击」。
-AI 直接直线插值的鼠标轨迹**有潜意识排斥感**。
+Real human mouse motion isn't a straight line — it's "start accelerate → arc → decelerate-correct → click."
+A mouse trail that AI just linearly interpolates **subconsciously feels off**.
 
 ```js
-// 二次贝塞尔曲线插值（起点 → 控制点 → 终点）
+// Quadratic Bezier interpolation (start → control point → end)
 function bezierQuadratic(p0, p1, p2, t) {
   const x = (1-t)*(1-t)*p0[0] + 2*(1-t)*t*p1[0] + t*t*p2[0];
   const y = (1-t)*(1-t)*p0[1] + 2*(1-t)*t*p1[1] + t*t*p2[1];
   return [x, y];
 }
 
-// 路径：起点 → 偏离中点 → 终点（做弧线）
+// Path: start → off-center midpoint → end (makes an arc)
 const path = [[100, 100], [targetX - 200, targetY + 80], [targetX, targetY]];
 
-// 再叠加极小的 Perlin Noise（±2px）制造「手抖」
+// Add tiny Perlin Noise (±2px) on top to simulate "hand jitter"
 const jitterX = (simpleNoise(t * 10) - 0.5) * 4;
 const jitterY = (simpleNoise(t * 10 + 100) - 0.5) * 4;
 ```
 
-### 3.6 Logo「形变收束」(Morph)
+### 3.6 Logo "morph-collapse" (Morph)
 
-Anthropic 三支片子的 Logo 出场**都不是简单 fade-in**，是**前一个视觉元素形变而来**。
+The Logo entrance in all three Anthropic films is **never a simple fade-in** — it's **morphed from the preceding visual element**.
 
-**共同模式**：倒数 1-2 秒做 Morph / Rotate / Converge，让整个叙事在品牌点上「坍缩」。
+**Common pattern**: in the last 1–2 seconds, do a Morph / Rotate / Converge so the entire narrative "collapses" onto the brand point.
 
-**低成本实现**（不用真 morph）：
-让前一个视觉元素「坍缩」成一个色块（scale → 0.1，向中心 translate），
-色块再「膨胀」展开成 wordmark。过渡用 150ms 快切 + motion blur
-（`filter: blur(6px)` → `0`）。
+**Low-cost implementation** (without a real morph):
+Have the preceding visual element "collapse" into a color block (scale → 0.1, translate to center),
+then have the block "expand" into the wordmark. Transition with a 150ms hard cut + motion blur
+(`filter: blur(6px)` → `0`).
 
 ```js
 <Sprite start={13} end={14}>
-  {/* 坍缩：前一个元素 scale 0.1，opacity 保持，filter blur 增加 */}
+  {/* Collapse: previous element scale 0.1, opacity stays, filter blur increases */}
   const scale = interpolate(t, [0, 0.5], [1, 0.1], Easing.expoOut);
   const blur = interpolate(t, [0, 0.5], [0, 6]);
 </Sprite>
 <Sprite start={13.5} end={15}>
-  {/* 膨胀：Logo 从色块中心 scale 0.1 → 1，blur 6 → 0 */}
+  {/* Expand: Logo scales 0.1 → 1 from block center, blur 6 → 0 */}
   const scale = interpolate(t, [0, 0.6], [0.1, 1], Easing.overshoot);
   const blur = interpolate(t, [0, 0.6], [6, 0]);
 </Sprite>
 ```
 
-### 3.7 衬线 + 无衬线双字体
+### 3.7 Serif + sans-serif dual typeface
 
-- **品牌 / 旁白**：衬线（有「学术感 / 出版物感 / 品位」）
-- **UI / 代码 / 数据**：无衬线 + 等宽
+- **Brand / voiceover**: serif (carries "academic / editorial / taste")
+- **UI / code / data**: sans-serif + monospaced
 
-**单一字体都是不对的**。衬线给「品位」，无衬线给「功能」。
+**A single typeface is always wrong.** Serif gives "taste"; sans gives "function."
 
-具体字体选择走品牌 spec（brand-spec.md 的 Display / Body / Mono 三栈）或设计方向
-顾问的 20 种哲学。本 reference 不给具体字体——那是**品牌决策**。
+Specific font choices go through the brand spec (`brand-spec.md`'s Display / Body / Mono stack) or the Design Direction Advisor's
+20 philosophies. This reference doesn't name specific fonts — those are **brand decisions**.
 
-### 3.8 焦点切换 = 背景减弱 + 前景锐化 + Flash 引导
+### 3.8 Focus switching = background dim + foreground sharpen + Flash guide
 
-焦点切换**不只是**降低 opacity。完整配方是：
+Focus switching is **not just** lowering opacity. The full recipe:
 
 ```js
-// 非焦点元素的滤镜组合
+// Filter combination on non-focused elements
 tile.style.filter = `
   brightness(${1 - 0.5 * focusIntensity})
   saturate(${1 - 0.3 * focusIntensity})
-  blur(${focusIntensity * 4}px)        // ← 关键：加 blur 才真的"退后"
+  blur(${focusIntensity * 4}px)        // ← key: blur is what actually makes it "recede"
 `;
 tile.style.opacity = 0.4 + 0.6 * (1 - focusIntensity);
 
-// 焦点完成后在焦点位置做 150ms Flash highlight 引导视线回流
+// After focus completes, do a 150ms Flash highlight at the focus point to guide the eye back
 focusOverlay.animate([
   { background: 'rgba(255,255,255,0.3)' },
   { background: 'rgba(255,255,255,0)' }
 ], { duration: 150, easing: 'ease-out' });
 ```
 
-**为什么 blur 是必须的**：只靠 opacity + brightness，焦点外的元素还是「锐利」的，
-视觉上没有「退到后景」的效果。blur(4-8px) 让非焦点真的退一层景深。
+**Why blur is essential**: opacity + brightness alone leaves the unfocused elements "sharp" — visually they don't "recede into the background."
+blur(4–8px) is what makes the non-focus genuinely drop one layer of depth.
 
 ---
 
-## 4. 具体运动技巧（可直接抄的代码片段）
+## 4. Concrete motion techniques (snippets you can copy)
 
 ### 4.1 FLIP / Shared Element Transition
 
-按钮「膨胀」成输入框，**不是**按钮消失 + 新面板出现。核心是**同一个 DOM 元素**在
-两种状态间 transition，不是两个元素 cross-fade。
+A button "expanding" into an input field is **not** the button disappearing + a new panel appearing. The core is **the same DOM element**
+transitioning between two states, not two elements cross-fading.
 
 ```jsx
-// 用 Framer Motion layoutId
+// Using Framer Motion layoutId
 <motion.div layoutId="design-button">Design</motion.div>
-// ↓ 点击后同 layoutId
+// ↓ after click, same layoutId
 <motion.div layoutId="design-button">
   <input placeholder="Describe your design..." />
 </motion.div>
 ```
 
-原生实现参考 https://aerotwist.com/blog/flip-your-animations/
+Native implementation: see https://aerotwist.com/blog/flip-your-animations/
 
-### 4.2「呼吸式」展开（width→height）
+### 4.2 "Breathing" expansion (width → height)
 
-面板展开**不是同时拉 width 和 height**，而是：
-- 前 40% 时间：只拉 width（保持 height 小）
-- 后 60% 时间：width 保持，撑 height
+Expanding a panel is **not pulling width and height simultaneously**, it's:
+- First 40% of time: pull width only (keep height small)
+- Last 60%: width stays, push height
 
-这模拟物理世界「先展开，再注水」的感觉。
+This simulates the physical-world feeling of "unfold first, then fill with water."
 
 ```js
 const widthT = interpolate(t, [0, 0.4], [0, 1], Easing.expoOut);
@@ -301,9 +300,9 @@ style.width = `${widthT * targetW}px`;
 style.height = `${heightT * targetH}px`;
 ```
 
-### 4.3 Staggered Fade-up（30ms stagger）
+### 4.3 Staggered Fade-up (30ms stagger)
 
-表格行、卡片列、列表项入场时，**每个元素延迟 30ms**，`translateY` 从 10px 回到 0。
+When table rows, card columns, or list items enter, **each element is delayed by 30ms**, `translateY` returns from 10px to 0.
 
 ```js
 rows.forEach((row, i) => {
@@ -315,14 +314,14 @@ rows.forEach((row, i) => {
 });
 ```
 
-### 4.4 非线性呼吸 · 关键结果前悬停 0.5s
+### 4.4 Nonlinear breathing · 0.5s hold before key results
 
-机器执行快且连贯，但**关键结果出现前悬停 0.5 秒**，让观众大脑有反应时间。
+Machines execute fast and continuously, but **hold 0.5 seconds before a key result appears** — give the audience's brain reaction time.
 
 ```jsx
-// 典型场景：AI 生成完 → 悬停 0.5s → 结果浮现
+// Typical scene: AI finishes generating → hold 0.5s → result emerges
 <Sprite start={8} end={8.5}>
-  {/* 0.5s 停顿——什么也不动，让观众盯着加载状态 */}
+  {/* 0.5s pause — nothing moves; let the audience stare at the loading state */}
   <LoadingState />
 </Sprite>
 <Sprite start={8.5} end={10}>
@@ -330,21 +329,21 @@ rows.forEach((row, i) => {
 </Sprite>
 ```
 
-**反例**：AI 生成完立刻无缝切到结果——观众没反应时间，信息流失。
+**Anti-example**: AI finishes generating and seamlessly cuts straight to the result — audience has no reaction time, information lost.
 
-### 4.5 Chunk Reveal · 模拟 token 流式
+### 4.5 Chunk Reveal · simulating token streaming
 
-AI 生成文字**不要用 `setInterval` 单字符蹦出**（像老电影字幕），要用 **chunk reveal**
-——一次出现 2-5 个字符，间隔不规律，模拟真实 token 流式输出。
+When AI generates text, **don't use `setInterval` to pop characters one at a time** (looks like old-movie subtitles); use **chunk reveal**
+— 2–5 characters at once, irregular intervals, simulating real token streaming.
 
 ```js
-// 分 chunk 而不是分字符
-const chunks = text.split(/(\s+|,\s*|\.\s*|;\s*)/);  // 按词 + 标点切
+// Split by chunk, not by character
+const chunks = text.split(/(\s+|,\s*|\.\s*|;\s*)/);  // split by word + punctuation
 let i = 0;
 function reveal() {
   if (i >= chunks.length) return;
   element.textContent += chunks[i++];
-  const delay = 40 + Math.random() * 80;  // 不规律 40-120ms
+  const delay = 40 + Math.random() * 80;  // irregular 40-120ms
   setTimeout(reveal, delay);
 }
 reveal();
@@ -352,48 +351,48 @@ reveal();
 
 ### 4.6 Anticipation → Action → Follow-through
 
-Disney 12 原则中的 3 条。Anthropic 用得很显式：
+3 of Disney's 12 principles. Anthropic uses them explicitly:
 
-- **Anticipation**（预备）：动作开始前有小反向动作（按钮轻微缩小再弹出）
-- **Action**（动作）：主要动作本身
-- **Follow-through**（跟随）：动作结束后有余韵（卡片落位后轻微 bounce）
+- **Anticipation**: before the main action, a small reverse motion (button shrinks slightly before popping)
+- **Action**: the main motion itself
+- **Follow-through**: after the action ends, residual motion (card settles, slight bounce)
 
 ```js
-// 卡片入场的完整三段
-const anticip = interpolate(t, [0, 0.2], [1, 0.95], Easing.easeIn);     // 预备
-const action  = interpolate(t, [0.2, 0.7], [0.95, 1.05], Easing.expoOut); // 主动
-const settle  = interpolate(t, [0.7, 1], [1.05, 1], Easing.spring);       // 回弹
-// 最终 scale = 三段乘积或分段应用
+// Full three-phase card entrance
+const anticip = interpolate(t, [0, 0.2], [1, 0.95], Easing.easeIn);     // anticipation
+const action  = interpolate(t, [0.2, 0.7], [0.95, 1.05], Easing.expoOut); // action
+const settle  = interpolate(t, [0.7, 1], [1.05, 1], Easing.spring);       // follow-through
+// final scale = product of three phases, or piecewise application
 ```
 
-**反例**：只有 Action 没有 Anticipation + Follow-through 的动画，像「PowerPoint 动画」。
+**Anti-example**: an animation with only Action, no Anticipation + Follow-through, looks like "PowerPoint animation."
 
-### 4.7 3D Perspective + translateZ 分层
+### 4.7 3D Perspective + translateZ layering
 
-想要「倾斜 3D + 悬浮卡片」的气质，给容器加 perspective，给单个元素不同的 translateZ：
+For the feel of "tilted 3D + floating cards," add perspective to the container and different translateZ to individual elements:
 
 ```css
 .stage-wrap {
   perspective: 2400px;
-  perspective-origin: 50% 30%;  /* 视线略俯视 */
+  perspective-origin: 50% 30%;  /* slight top-down view */
 }
 .card-grid {
   transform-style: preserve-3d;
-  transform: rotateX(8deg) rotateY(-4deg);  /* 黄金比例 */
+  transform: rotateX(8deg) rotateY(-4deg);  /* golden ratio */
 }
 .card:nth-child(3n) { transform: translateZ(30px); }
 .card:nth-child(5n) { transform: translateZ(-20px); }
 .card:nth-child(7n) { transform: translateZ(60px); }
 ```
 
-**为什么 rotateX 8° / rotateY -4° 是黄金比例**：
-- 大于 10° → 元素扭曲感过强，看起来像「倒下」
-- 小于 5° → 像「错切」而不是「透视」
-- 8° × -4° 的非对称比例模拟「镜头在桌面左上角俯视」的 natural angle
+**Why rotateX 8° / rotateY -4° is the golden ratio**:
+- Greater than 10° → elements feel over-distorted, like they're "falling over"
+- Less than 5° → feels like "shear" rather than "perspective"
+- 8° × -4° asymmetric ratio simulates the natural angle of "camera looking down from the upper-left of the desktop"
 
-### 4.8 斜向 Pan · 同时动 XY
+### 4.8 Diagonal pan · move XY simultaneously
 
-镜头运动不是纯上下或纯左右，而是**同时动 XY** 模拟斜向移动：
+Camera motion isn't pure vertical or pure horizontal; **move XY at the same time** to simulate diagonal travel:
 
 ```js
 const panX = Math.sin(flowT * 0.22) * 40;
@@ -405,102 +404,102 @@ stage.style.transform = `
 `;
 ```
 
-**关键**：X 和 Y 的频率不同（0.22 vs 0.35），避免 Lissajous 循环规则化。
+**Key**: X and Y use different frequencies (0.22 vs 0.35) to avoid a regular Lissajous loop.
 
 ---
 
-## 5. 场景配方（三种叙事模板）
+## 5. Scene recipes (three narrative templates)
 
-参考材料里三支视频对应三种产品性格。**选一种最贴合你的产品**，不要混搭。
+The three reference videos correspond to three product personalities. **Pick the one that best fits your product** — don't mix.
 
-### 配方 A · Apple Keynote 戏剧式（Claude Design 类）
+### Recipe A · Apple Keynote dramatic (Claude Design type)
 
-**适合**：大版本发布、hero 动画、视觉惊艳优先
-**节奏**：Slow-Fast-Boom-Stop 强弧线
-**Easing**：全程 `expoOut` + 少量 `overshoot`
-**SFX 密度**：高（~0.4/s），SFX 音高调到 BGM 音阶
-**BGM**：IDM / 极简科技电子，冷静+精密
-**收束**：镜头急拉远 → drop → Logo 形变 → 空灵单音 → 戛然而止
+**Fits**: major-version launches, hero animation, visual wow first
+**Pacing**: Slow-Fast-Boom-Stop strong arc
+**Easing**: `expoOut` throughout + a bit of `overshoot`
+**SFX density**: high (~0.4/s), SFX pitch tuned to the BGM scale
+**BGM**: IDM / minimal tech-electronic, cool + precise
+**Closing**: camera whip-pulls back → drop → Logo morph → ethereal single note → abrupt stop
 
-### 配方 B · 一镜到底工具式（Claude Code 类）
+### Recipe B · One-take tool (Claude Code type)
 
-**适合**：开发者工具、生产力 App、心流场景
-**节奏**：持续稳定 flow，没有明显峰值
-**Easing**：`spring` 物理 + `expoOut`
-**SFX 密度**：**0**（纯靠 BGM 驱动剪辑节奏）
-**BGM**：Lo-fi Hip-hop / Boom-bap，85-90 BPM
-**核心技巧**：关键 UI 动作踩在 BGM kick/snare 瞬态上——「**音乐律动即交互音效**」
+**Fits**: developer tools, productivity apps, flow scenarios
+**Pacing**: sustained steady flow, no obvious peak
+**Easing**: `spring` physics + `expoOut`
+**SFX density**: **0** (rely purely on BGM to drive edit rhythm)
+**BGM**: Lo-fi Hip-hop / Boom-bap, 85–90 BPM
+**Core technique**: key UI actions land on BGM kick/snare transients — "**musical groove is the interaction SFX**"
 
-### 配方 C · 办公效率叙事式（Claude for Word 类）
+### Recipe C · Office productivity narrative (Claude for Word type)
 
-**适合**：企业软件、文档/表格/日历类、专业感优先
-**节奏**：多 scene 硬切 + Dolly In/Out
-**Easing**：`overshoot`（toggle）+ `expoOut`（面板）
-**SFX 密度**：中（~0.3/s），UI click 为主
-**BGM**：Jazzy Instrumental，小调，BPM 90-95
-**核心亮点**：某一幕必有「全片高光」—— 3D pop-out / 脱离平面浮起
+**Fits**: enterprise software, doc/spreadsheet/calendar, professional first
+**Pacing**: multi-scene hard cuts + Dolly In/Out
+**Easing**: `overshoot` (toggles) + `expoOut` (panels)
+**SFX density**: medium (~0.3/s), mostly UI clicks
+**BGM**: Jazzy Instrumental, minor key, BPM 90–95
+**Core highlight**: one scene must contain "the highlight of the whole piece" — 3D pop-out / lifting off the plane
 
 ---
 
-## 6. 反例 · 这样做就是 AI slop
+## 6. Anti-examples · this is AI slop
 
-| 反 pattern | 为什么错 | 正确做法 |
+| Anti-pattern | Why it's wrong | Correct approach |
 |---|---|---|
-| `transition: all 0.3s ease` | `ease` 是 linear 的亲戚，所有元素同速 | 用 `expoOut` + 分元素 stagger |
-| 所有入场都 `opacity 0→1` | 没有运动方向感 | 配合 `translateY 10→0` + Anticipation |
-| Logo 淡入 | 没有叙事收束感 | Morph / Converge / 坍缩-展开 |
-| 鼠标直线移动 | 潜意识机器感 | 贝塞尔弧线 + Perlin Noise |
-| 打字单字蹦出（setInterval） | 像老电影字幕 | Chunk Reveal，随机间隔 |
-| 关键结果无悬停 | 观众没反应时间 | 结果前 0.5s 悬停 |
-| 焦点切换只改 opacity | 非焦点元素还锐利 | opacity + brightness + **blur** |
-| 纯黑底 / 纯白底 | 赛博感 / 反光疲劳 | 带色温的中性色（走品牌 spec） |
-| 所有动画同样快 | 无节奏 | Slow-Fast-Boom-Stop |
-| Fade out 收尾 | 无决定感 | 戛然而止（hold 最后一帧） |
+| `transition: all 0.3s ease` | `ease` is a cousin of linear; all elements move at the same speed | Use `expoOut` + per-element stagger |
+| All entrances are `opacity 0→1` | No sense of motion direction | Pair with `translateY 10→0` + Anticipation |
+| Logo fades in | No narrative resolution | Morph / Converge / collapse-expand |
+| Mouse moves in straight lines | Subconscious machine feel | Bezier arc + Perlin Noise |
+| Typing pops one character at a time (setInterval) | Looks like old-movie subtitles | Chunk Reveal, random intervals |
+| Key result with no hold | Audience has no reaction time | 0.5s hold before the result |
+| Focus switch only changes opacity | Non-focus elements still sharp | opacity + brightness + **blur** |
+| Pure black / pure white background | Cyber feel / reflective fatigue | Neutral with temperature (via brand spec) |
+| All animations equally fast | No rhythm | Slow-Fast-Boom-Stop |
+| Fade-out ending | No sense of decision | Abrupt stop (hold the last frame) |
 
 ---
 
-## 7. 自检清单（动画交付前 60 秒）
+## 7. Self-check (60 seconds before delivery)
 
-- [ ] 叙事结构是 Slow-Fast-Boom-Stop，不是均匀节奏？
-- [ ] 默认 easing 是 `expoOut`，不是 `easeOut` 或 `linear`？
-- [ ] Toggle / 按钮弹出用了 `overshoot`？
-- [ ] 卡片 / 列表入场有 30ms stagger？
-- [ ] 关键结果前有 0.5s 悬停？
-- [ ] 打字用 Chunk Reveal，不是 setInterval 单字？
-- [ ] 焦点切换加了 blur（不只是 opacity）？
-- [ ] Logo 是形变收束（Morph），不是淡入？
-- [ ] 底色不是纯黑 / 纯白（带色温）？
-- [ ] 文字有衬线 + 无衬线层次？
-- [ ] 收尾是戛然而止，不是渐弱？
-- [ ] （有鼠标的话）鼠标轨迹是弧线，不是直线？
-- [ ] SFX 密度符合产品性格（见配方 A/B/C）？
-- [ ] BGM 和 SFX 有 6-8dB 响度差？（见 `audio-design-rules.md`）
+- [ ] Narrative structure is Slow-Fast-Boom-Stop, not even pacing?
+- [ ] Default easing is `expoOut`, not `easeOut` or `linear`?
+- [ ] Toggles / button pops use `overshoot`?
+- [ ] Card / list entrances have 30ms stagger?
+- [ ] 0.5s hold before key results?
+- [ ] Typing uses Chunk Reveal, not setInterval single characters?
+- [ ] Focus switch adds blur (not just opacity)?
+- [ ] Logo is morph-collapse (Morph), not fade-in?
+- [ ] Base color is not pure black / pure white (has temperature)?
+- [ ] Text has serif + sans hierarchy?
+- [ ] Ending is an abrupt stop, not faded?
+- [ ] (If there's a mouse) mouse trail is an arc, not a straight line?
+- [ ] SFX density matches product personality (see recipes A/B/C)?
+- [ ] BGM and SFX have a 6–8dB loudness difference? (see `audio-design-rules.md`)
 
 ---
 
-## 8. 与其他 reference 的关系
+## 8. Relationship to other references
 
-| reference | 定位 | 关系 |
+| reference | Role | Relationship |
 |---|---|---|
-| `animation-pitfalls.md` | 技术避坑（16 条） | 「**不要这样做**」· 本文件的反面 |
-| `animations.md` | Stage/Sprite 引擎用法 | 动画**怎么写**的基础 |
-| `audio-design-rules.md` | 双轨制音频规则 | 动画**配音频**的规则 |
-| `sfx-library.md` | 37 个 SFX 清单 | 音效**素材库** |
-| `apple-gallery-showcase.md` | Apple 画廊展示风格 | 一种特定运动风格的专题 |
-| **本文件** | 正向运动设计语法 | 「**应该这样做**」 |
+| `animation-pitfalls.md` | Technical pitfalls (16) | "**Don't do this**" — the inverse of this file |
+| `animations.md` | Stage/Sprite engine usage | The basics of **how to write** animation |
+| `audio-design-rules.md` | Dual-track audio rules | Rules for **adding audio** to animation |
+| `sfx-library.md` | 37-SFX list | SFX **asset library** |
+| `apple-gallery-showcase.md` | Apple Gallery showcase style | A focused study of one specific motion style |
+| **This file** | Positive-direction motion design grammar | "**Do it this way**" |
 
-**调用顺序**：
-1. 先看 SKILL.md 工作流程 Step 3 的位置四问（决定叙事角色和视觉温度）
-2. 选定方向后读本文件确定**运动语言**（配方 A/B/C）
-3. 写代码时参考 `animations.md` 和 `animation-pitfalls.md`
-4. 导出视频时走 `audio-design-rules.md` + `sfx-library.md`
+**Invocation order**:
+1. First read SKILL.md Workflow Step 3's four positional questions (decide narrative role and visual temperature)
+2. After picking a direction, read this file to determine **motion language** (recipes A/B/C)
+3. When writing code, refer to `animations.md` and `animation-pitfalls.md`
+4. When exporting video, follow `audio-design-rules.md` + `sfx-library.md`
 
 ---
 
-## 附录 · 本文件素材来源
+## Appendix · sources for this file
 
-- Anthropic 官方动画拆解：花叔项目目录的 `参考动画/BEST-PRACTICES.md`
-- Anthropic 音频拆解：同目录 `AUDIO-BEST-PRACTICES.md`
-- 3 支参考视频：`ref-{1,2,3}.mp4` + 对应 `gemini-ref-*.md` / `audio-ref-*.md`
-- **严格过滤**：本 reference 不收录任何具体品牌色值、字体名、产品名。
-  色彩/字体决策走 §1.a 核心资产协议或 20 种设计哲学。
+- Anthropic official animation teardown (the original author's reference notes — not bundled with this skill)
+- Anthropic audio teardown (companion file in the same source set — not bundled)
+- 3 reference videos: `ref-{1,2,3}.mp4` + matching `gemini-ref-*.md` / `audio-ref-*.md` (the original author's source set — not bundled)
+- **Strict filter**: this reference contains no specific brand color values, font names, or product names.
+  Color/font decisions go through §1.a Core Asset Protocol or the 20 design philosophies.

--- a/references/animation-pitfalls.md
+++ b/references/animation-pitfalls.md
@@ -1,28 +1,28 @@
-# Animation Pitfalls：HTML 动画踩过的坑与规则
+# Animation Pitfalls: Bugs and Rules from Real HTML Animation Mistakes
 
-做动画时最常踩的 bug 和如何避免。每条规则都来自真实失败案例。
+The most common bugs encountered while building animations, and how to avoid them. Every rule comes from a real failure case.
 
-写动画之前读完这篇，能省一轮迭代。
+Read this before writing animation code — it saves you an iteration.
 
-## 1. 叠层布局 —— `position: relative` 是默认义务
+## 1. Stacked layout — `position: relative` is the default obligation
 
-**踩的坑**：一个 sentence-wrap 元素包了 3 个 bracket-layer（`position: absolute`）。没给 sentence-wrap 设 `position: relative`，结果 absolute 的 bracket 以 `.canvas` 为坐标系，飘到屏幕底部 200px 外。
+**The bug**: a sentence-wrap element contained 3 bracket-layer children (`position: absolute`). Without setting `position: relative` on sentence-wrap, the absolute brackets used `.canvas` as their coordinate system and drifted 200px off the bottom of the screen.
 
-**规则**：
-- 任何包含 `position: absolute` 子元素的容器，**必须**显式 `position: relative`
-- 即使视觉上不需要「偏移」，也要写 `position: relative` 作为坐标系锚点
-- 如果你在写 `.parent { ... }`，其子元素里有 `.child { position: absolute }`，下意识给 parent 加 relative
+**Rule**:
+- Any container holding `position: absolute` children **must** explicitly set `position: relative`
+- Even if you don't visually need an "offset," write `position: relative` as the coordinate-system anchor
+- If you're writing `.parent { ... }` and its children include `.child { position: absolute }`, reflexively add `relative` to the parent
 
-**快速检查**：每出现一个 `position: absolute`，往上数 ancestor，确保最近的 positioned 祖先是你*想要的*坐标系。
+**Quick check**: every time you see `position: absolute`, count ancestors upward and confirm the nearest positioned ancestor is the coordinate system you *want*.
 
-## 2. 字符陷阱 —— 不依赖稀有 Unicode
+## 2. Character traps — don't rely on rare Unicode
 
-**踩的坑**：想用 `␣` (U+2423 OPEN BOX) 可视化「空格 token」。Noto Serif SC / Cormorant Garamond 都没这个字形，渲染为空白/豆腐，观众完全看不到。
+**The bug**: trying to use `␣` (U+2423 OPEN BOX) to visualize a "space token." Neither Noto Serif SC nor Cormorant Garamond has this glyph; it renders as blank/tofu and the audience can't see anything.
 
-**规则**：
-- **动画里出现的每个字符，都必须在你选定的字体里存在**
-- 常见稀有字符黑名单：`␣ ␀ ␐ ␋ ␨ ↩ ⏎ ⌘ ⌥ ⌃ ⇧ ␦ ␖ ␛`
-- 要表达「空格 / 回车 / 制表符」这类元字符，用 **CSS 构造的语义盒子**：
+**Rule**:
+- **Every character that appears in your animation must exist in your chosen font**
+- Common rare-character blacklist: `␣ ␀ ␐ ␋ ␨ ↩ ⏎ ⌘ ⌥ ⌃ ⇧ ␦ ␖ ␛`
+- To represent meta-characters like "space / return / tab," use a **CSS-built semantic box**:
   ```html
   <span class="space-key">Space</span>
   ```
@@ -38,126 +38,126 @@
     text-transform: uppercase;
   }
   ```
-- Emoji 也要验证：某些 emoji 在 Noto Emoji 以外字体会 fallback 成灰色方框，最好用 `emoji` font-family 或 SVG
+- Verify emoji too: some emoji fall back to a gray square outside Noto Emoji — prefer an `emoji` font-family or an SVG
 
-## 3. 数据驱动的 Grid/Flex 模板
+## 3. Data-driven Grid/Flex templates
 
-**踩的坑**：代码里 `const N = 6` 个 tokens，但 CSS 写死 `grid-template-columns: 80px repeat(5, 1fr)`。结果第 6 个 token 没有 column，整个矩阵错位。
+**The bug**: the JS has `const N = 6` tokens, but the CSS hard-codes `grid-template-columns: 80px repeat(5, 1fr)`. The 6th token gets no column and the whole matrix misaligns.
 
-**规则**：
-- 当 count 从 JS 数组来（`TOKENS.length`），CSS 模板也应该数据驱动
-- 方案 A：用 CSS 变量从 JS 注入
+**Rule**:
+- When the count comes from a JS array (`TOKENS.length`), the CSS template should be data-driven too
+- Option A: inject a CSS variable from JS
   ```js
   el.style.setProperty('--cols', N);
   ```
   ```css
   .grid { grid-template-columns: 80px repeat(var(--cols), 1fr); }
   ```
-- 方案 B：用 `grid-auto-flow: column` 让浏览器自动扩展
-- **禁用「固定数字 +  JS 常量」的组合**，N 改了 CSS 不会同步更新
+- Option B: use `grid-auto-flow: column` so the browser auto-expands
+- **Forbid the "fixed number + JS constant" combo** — change N and the CSS won't keep up
 
-## 4. 过渡断层 —— 场景切换要连续
+## 4. Transition gaps — scene switches must be continuous
 
-**踩的坑**：zoom1 (13-19s) → zoom2 (19.2-23s) 之间，主句子已经 hidden，zoom1 fade out（0.6s）+ zoom2 fade in（0.6s）+ stagger delay（0.2s+）= 约 1 秒纯空白画面。观众以为动画卡住了。
+**The bug**: between zoom1 (13–19s) → zoom2 (19.2–23s), the main sentence is already hidden, zoom1 fades out (0.6s) + zoom2 fades in (0.6s) + stagger delay (0.2s+) = roughly 1 second of pure blank screen. The audience thinks the animation froze.
 
-**规则**：
-- 连续切换场景时，fade out 和 fade in 要**交叉重叠**，不是前一个完全消失再开始下一个
+**Rule**:
+- For continuous scene switches, fade out and fade in should **cross-overlap**, not have one fully disappear before the next starts
   ```js
-  // 差：
+  // bad:
   if (t >= 19) hideZoom('zoom1');      // 19.0s out
-  if (t >= 19.4) showZoom('zoom2');    // 19.4s in → 中间 0.4s 空白
+  if (t >= 19.4) showZoom('zoom2');    // 19.4s in → 0.4s blank gap
 
-  // 好：
-  if (t >= 18.6) hideZoom('zoom1');    // 提前 0.4s 开始 fade out
-  if (t >= 18.6) showZoom('zoom2');    // 同时 fade in（cross-fade）
+  // good:
+  if (t >= 18.6) hideZoom('zoom1');    // begin fade out 0.4s earlier
+  if (t >= 18.6) showZoom('zoom2');    // fade in simultaneously (cross-fade)
   ```
-- 或者用一个「锚点元素」（如主句子）作为场景之间的视觉连接，zoom 切换期间它短暂回显
-- 配 CSS transition 的 duration 算清楚，避免 transition 还没结束就触发下一个
+- Or use an "anchor element" (e.g. the main sentence) as a visual link between scenes — briefly bringing it back during the zoom switch
+- Match CSS transition durations carefully; avoid triggering the next one before the previous finishes
 
-## 5. Pure Render 原则 —— 动画状态应可 seek
+## 5. Pure Render principle — animation state must be seekable
 
-**踩的坑**：用 `setTimeout` + `fireOnce(key, fn)` 链式触发动画状态。正常播放没问题，但做逐帧录制/seek到任意时间点时，之前的 setTimeout 已经执行过就无法「回到过去」。
+**The bug**: using `setTimeout` + `fireOnce(key, fn)` to chain-trigger animation state. Normal playback is fine, but for frame-by-frame recording or seeking to an arbitrary time, the setTimeouts that already fired can't "go back in time."
 
-**规则**：
-- `render(t)` 函数理想上是 **pure function**：给定 t 输出唯一 DOM 状态
-- 如果必须用副作用（如 class 切换），用 `fired` set 配合显式 reset：
+**Rule**:
+- The `render(t)` function should ideally be a **pure function**: given t, output a unique DOM state
+- If side effects are unavoidable (e.g. class toggles), use a `fired` set with an explicit reset:
   ```js
   const fired = new Set();
   function fireOnce(key, fn) { if (!fired.has(key)) { fired.add(key); fn(); } }
-  function reset() { fired.clear(); /* 清所有 .show class */ }
+  function reset() { fired.clear(); /* clear all .show classes */ }
   ```
-- 暴露 `window.__seek(t)` 供 Playwright / 调试用：
+- Expose `window.__seek(t)` for Playwright / debugging:
   ```js
   window.__seek = (t) => { reset(); render(t); };
   ```
-- 动画相关的 setTimeout 不要跨越 >1 秒，否则 seek 回跳时会乱套
+- Animation-related setTimeouts should not span >1 second, or seek-back will get scrambled
 
-## 6. 字体加载前测量 = 测错
+## 6. Measuring before fonts load = wrong measurement
 
-**踩的坑**：页面一 DOMContentLoaded 就调用 `charRect(idx)` 测量 bracket 位置，字体还没加载，每个字符宽度是 fallback 字体的宽度，位置全错。等字体一加载（约 500ms 后），bracket 的 `left: Xpx` 还是老值，永久偏移。
+**The bug**: on DOMContentLoaded, the page calls `charRect(idx)` to measure bracket positions, but fonts haven't loaded — every character has fallback-font width, every position is wrong. By the time fonts load (~500ms later), the bracket's `left: Xpx` is still the old value, permanently offset.
 
-**规则**：
-- 任何依赖 DOM 测量（`getBoundingClientRect`、`offsetWidth`）的布局代码，**必须**包在 `document.fonts.ready.then()` 里
+**Rule**:
+- Any layout code depending on DOM measurement (`getBoundingClientRect`, `offsetWidth`) **must** be wrapped in `document.fonts.ready.then()`
   ```js
   document.fonts.ready.then(() => {
     requestAnimationFrame(() => {
-      buildBrackets(...);  // 此时字体已就绪，测量准确
-      tick();              // 动画开始
+      buildBrackets(...);  // fonts are ready now, measurement is accurate
+      tick();              // start the animation
     });
   });
   ```
-- 额外的 `requestAnimationFrame` 给浏览器一帧时间提交 layout
-- 如果用 Google Fonts CDN，`<link rel="preconnect">` 加速首次加载
+- The extra `requestAnimationFrame` gives the browser one frame to commit layout
+- If using Google Fonts CDN, `<link rel="preconnect">` speeds up first load
 
-## 7. 录制准备 —— 为视频导出预留抓手
+## 7. Recording prep — leave handles for video export
 
-**踩的坑**：Playwright `recordVideo` 默认 25fps，从 context 创建就开始录。页面加载、字体加载的前 2 秒都被录进去。交付时视频前面 2 秒空白/闪白。
+**The bug**: Playwright `recordVideo` defaults to 25fps and starts recording from context creation. The first 2 seconds of page load and font load get recorded. The delivered video has 2 seconds of blank/flashing at the start.
 
-**规则**：
-- 提供 `render-video.js` 工具处理：warmup navigate → reload 重启动画 → 等 duration → ffmpeg trim head + 转 H.264 MP4
-- 动画的**第 0 帧**要是最终布局已就位的完整初始状态（不是空白或加载中）
-- 想要 60fps？用 ffmpeg `minterpolate` 后处理，不指望浏览器源帧率
-- 想要 GIF？两阶段 palette（`palettegen` + `paletteuse`），对 30s 1080p 动画能压到 3MB
+**Rule**:
+- Provide a `render-video.js` tool: warmup navigate → reload to restart animation → wait duration → ffmpeg trim head + transcode to H.264 MP4
+- The animation's **frame 0** must be the complete initial layout already in place (not blank or loading)
+- Want 60fps? Use ffmpeg `minterpolate` as post-processing — don't expect the browser's source frame rate
+- Want a GIF? Two-stage palette (`palettegen` + `paletteuse`) can compress a 30s 1080p animation to 3MB
 
-参见 `video-export.md` 获取完整脚本调用方式。
+See `video-export.md` for full script invocation.
 
-## 8. 批量导出 —— tmp 目录必须带 PID 防并发冲突
+## 8. Batch export — tmp directory must include PID to avoid concurrency clashes
 
-**踩的坑**：用 `render-video.js` 3 个进程并行录 3 个 HTML。因为 TMP_DIR 只用 `Date.now()` 命名，3 个进程同毫秒启动时共用同一个 tmp 目录。最先完成的进程清理 tmp，另外两个读目录时 `ENOENT`，全部崩溃。
+**The bug**: running `render-video.js` in 3 parallel processes to record 3 HTMLs. Because TMP_DIR is named with only `Date.now()`, when 3 processes start in the same millisecond they share one tmp directory. The first one to finish cleans up tmp, the other two get `ENOENT` reading the directory, all crash.
 
-**规则**：
-- 任何多进程可能共用的临时目录，命名必须带 **PID 或随机后缀**：
+**Rule**:
+- Any temp directory that multiple processes might share must include a **PID or random suffix**:
   ```js
   const TMP_DIR = path.join(DIR, '.video-tmp-' + Date.now() + '-' + process.pid);
   ```
-- 如果确实想多文件并行，用 shell 的 `&` + `wait` 而不是在一个 node 脚本里 fork
-- 批量录多个 HTML 时，保守做法：**串行**运行（2 个以内可并行，3 个以上老实排队）
+- If you really want multi-file parallelism, use shell `&` + `wait` rather than forking inside one node script
+- For batch recording multiple HTMLs, the conservative approach is **serial** (up to 2 in parallel; 3+ go in a queue)
 
-## 9. 录屏里有进度条/重播按钮 —— Chrome 元素污染视频
+## 9. Progress bars / replay buttons inside the recording — Chrome elements pollute the video
 
-**踩的坑**：动画 HTML 加了 `.progress` 进度条、`.replay` 重播按钮、`.counter` 时间戳，方便人类调试播放。录成 MP4 交付时这些元素出现在视频底部，像把开发者工具截进去了一样。
+**The bug**: the animation HTML has a `.progress` progress bar, `.replay` replay button, `.counter` timestamp — convenient for humans debugging playback. When recorded to MP4 for delivery, these elements appear at the bottom of the video as if you'd captured devtools.
 
-**规则**：
-- HTML 里给人类用的「chrome 元素」（progress bar / replay button / footer / masthead / counter / phase labels）和视频内容本体分开管理
-- **约定 class 名** `.no-record`：任何带这个 class 的元素，录屏脚本自动隐藏
-- 脚本端（`render-video.js`）默认注入 CSS 隐藏常见 chrome class 名：
+**Rule**:
+- Manage "chrome elements" for humans (progress bar / replay button / footer / masthead / counter / phase labels) separately from the video content itself
+- **Convention class** `.no-record`: any element with this class is auto-hidden by the recording script
+- The script side (`render-video.js`) injects CSS by default hiding common chrome class names:
   ```
   .progress .counter .phases .replay .masthead .footer .no-record [data-role="chrome"]
   ```
-- 用 Playwright 的 `addInitScript` 注入（会在每次 navigate 前生效，reload 也稳）
-- 想看原样 HTML（带 chrome）时加 `--keep-chrome` flag
+- Inject via Playwright's `addInitScript` (applies before every navigate, stable across reloads)
+- To view the raw HTML (with chrome), pass a `--keep-chrome` flag
 
-## 10. 录屏开头几秒动画重复 —— Warmup 帧泄漏
+## 10. Animation repeats at the start of the recording — warmup frame leakage
 
-**踩的坑**：`render-video.js` 的旧流程 `goto → wait fonts 1.5s → reload → wait duration`。录制从 context 创建就开始，warmup 阶段动画已经播了一段，reload 后从 0 重启。结果视频前几秒是「动画中段 + 切换 + 动画从 0 开始」，重复感强。
+**The bug**: the old `render-video.js` flow was `goto → wait fonts 1.5s → reload → wait duration`. Recording starts at context creation; during warmup the animation already plays for a while, then reload restarts it from 0. The first few seconds of the video are "mid-animation + cut + animation from 0," strong sense of repetition.
 
-**规则**：
-- **Warmup 和 Record 必须用独立的 context**：
-  - Warmup context（无 `recordVideo` 选项）：只负责 load url、等字体、然后 close
-  - Record context（有 `recordVideo`）：fresh 状态开始，animation 从 t=0 开始录
-- ffmpeg `-ss trim` 只能裁 Playwright 的一点点 startup latency（~0.3s），**不能**用来掩盖 warmup 帧；源头要干净
-- 录制 context 关闭 = webm 文件写入磁盘，这是 Playwright 的约束
-- 相关代码模式：
+**Rule**:
+- **Warmup and Record must use independent contexts**:
+  - Warmup context (no `recordVideo` option): only responsible for load url, wait fonts, then close
+  - Record context (with `recordVideo`): starts fresh, animation records from t=0
+- ffmpeg `-ss trim` can only shave Playwright's tiny startup latency (~0.3s) — **it can't** mask warmup frames; the source must be clean
+- Closing the record context = webm written to disk; that's Playwright's constraint
+- Related code pattern:
   ```js
   // Phase 1: warmup (throwaway)
   const warmupCtx = await browser.newContext({ viewport });
@@ -175,72 +175,72 @@
   await recordCtx.close();
   ```
 
-## 11. 画面内别画「伪 chrome」—— 装饰版 player UI 与真 chrome 撞车
+## 11. Don't paint "pseudo-chrome" inside the frame — decorative player UI clashes with real chrome
 
-**踩的坑**：动画用 `Stage` 组件，已经自带 scrubber + 时间码 + 暂停按钮（属于 `.no-record` chrome，导出时自动隐藏）。我又在画面底部画了一条「`00:60 ──── CLAUDE-DESIGN / ANATOMY`」的"杂志页码感装饰进度条"，自我感觉良好。**结果**：用户看到两条进度条——一条是 Stage 控制器，一条是我画的装饰。视觉上完全撞车，认定为 bug。「视频内还有个进度条是怎么回事？」
+**The bug**: the animation uses the `Stage` component, which already comes with scrubber + timecode + pause button (these are `.no-record` chrome, auto-hidden on export). I also painted a "`00:60 ──── CLAUDE-DESIGN / ANATOMY`" "magazine page-number-style decorative progress bar" at the bottom of the frame, feeling good about myself. **Result**: the user sees two progress bars — one from the Stage controller, one from my decoration. They visually clash, and it's diagnosed as a bug. "Why is there another progress bar inside the video?"
 
-**规则**：
+**Rule**:
 
-- Stage 已经提供：scrubber + 时间码 + 暂停/重播按钮。**画面内不要再画**进度指示、当前时间码、版权署名条、章节计数器——它们要么和 chrome 撞车，要么就是 filler slop（违反「earn its place」原则）。
-- 「页码感」「杂志感」「底部署名条」这些**装饰诉求**，是 AI 自动加上的高频 filler。每一个出现都要警觉——它真的传达了不可替代的信息吗？还是单纯填满空白？
-- 如果你坚信某个底部条带必须存在（例如：动画主题就是讲 player UI），那它必须**叙事必要**，且**视觉上和 Stage scrubber 显著区分**（不同位置、不同形式、不同色调）。
+- Stage already provides: scrubber + timecode + pause/replay buttons. **Don't paint** progress indicators, current-time codes, copyright strips, or chapter counters inside the frame — they either clash with chrome or are filler slop (violating the "earn its place" principle).
+- "Page-number feel," "magazine feel," "bottom signature strip" — these **decorative urges** are high-frequency filler the AI adds automatically. Be on alert every time one appears — does it really convey irreplaceable information, or is it just filling space?
+- If you're convinced some bottom strip must exist (e.g. the animation's subject is player UI), it must be **narratively necessary** and **visually distinct from the Stage scrubber** (different position, different form, different color).
 
-**元素归属测试**（每个画进 canvas 的元素必须能回答）：
+**Element ownership test** (every element painted into the canvas must answer):
 
-| 它属于什么 | 处理 |
+| What it belongs to | Treatment |
 |------------|------|
-| 某一幕的叙事内容 | OK，留着 |
-| 全局 chrome（控制/调试用） | 加 `.no-record` class，导出时隐藏 |
-| **既不属于任何幕，又不是 chrome** | **删**。这就是无主之物，必然是 filler slop |
+| Narrative content of a specific scene | OK, keep it |
+| Global chrome (control / debug) | Add `.no-record` class, hide on export |
+| **Neither belongs to any scene nor is chrome** | **Delete it.** It's orphan content, definitely filler slop |
 
-**自检（交付前 3 秒）**：截一张静态图，问自己——
+**Self-check (3 seconds before delivery)**: take a static screenshot and ask yourself —
 
-- 画面里有没有「看起来像 video player UI 的东西」（横线进度条、时间码、控制按钮模样）？
-- 如果有，删掉它叙事是否有损？无损就删。
-- 同一类信息（进度/时间/署名）有没有出现两次？合并到 chrome 一处。
+- Is there anything in the frame that "looks like video player UI" (horizontal progress bar, timecode, button-shaped controls)?
+- If yes, would deleting it hurt the narrative? If not, delete.
+- Does any one category of info (progress / time / signature) appear twice? Consolidate to a single chrome location.
 
-**反例**：底部画 `00:42 ──── PROJECT NAME`、画面右下角画"CH 03 / 06"章节计数、画面边缘画版本号"v0.3.1"——都是伪 chrome filler。
+**Anti-example**: painting `00:42 ──── PROJECT NAME` at the bottom, painting "CH 03 / 06" chapter counter in the bottom-right, painting version "v0.3.1" along the edge — all pseudo-chrome filler.
 
-## 12. 录屏前置空白 + 录屏起点偏移 —— `__ready` × tick × lastTick 三联陷阱
+## 12. Leading blank in the recording + recording start offset — the `__ready` × tick × lastTick triple trap
 
-**踩的坑（A · 前置空白）**：60 秒动画导出 MP4，前 2-3 秒是空白页面。`ffmpeg --trim=0.3` 剪不掉。
+**The bug (A · leading blank)**: a 60-second animation exports an MP4 where the first 2–3 seconds are a blank page. `ffmpeg --trim=0.3` can't cut it.
 
-**踩的坑（B · 起点偏移，2026-04-20 真实事故）**：导出 24 秒视频，用户观感「视频 19 秒才开始播第一帧」。实际上动画从 t=5 开始录，录到 t=24 后 loop 回 t=0，再录 5 秒到 end——所以视频最后 5 秒才是动画真正的开头。
+**The bug (B · start offset, real incident on 2026-04-20)**: a 24-second video is exported, and the user perceives "the first frame doesn't play until 19 seconds in." What actually happened: the animation started recording from t=5, recorded until t=24, then looped back to t=0 and recorded 5 more seconds to the end — so the last 5 seconds of the video are the animation's actual beginning.
 
-**根因**（两个坑共享一个根因）：
+**Root cause** (both bugs share one root cause):
 
-Playwright `recordVideo` 从 `newContext()` 那一刻就开始写 WebM，此时 Babel/React/字体加载共耗时 L 秒（2-6s）。录屏脚本等 `window.__ready = true` 作为「动画从这里开始」的锚点——它和动画 `time = 0` 必须严格 pair。有两种常见错法：
+Playwright `recordVideo` starts writing WebM the moment `newContext()` is called, but Babel/React/font loading consumes L seconds (2–6s). The recording script waits for `window.__ready = true` as the "animation starts here" anchor — this must be strictly paired with animation `time = 0`. Two common mistakes:
 
-| 错法 | 症状 |
+| Mistake | Symptom |
 |------|------|
-| `__ready` 在 `useEffect` 或同步 setup 阶段设（在 tick 第一帧之前） | 录屏脚本以为动画开始了，实际 WebM 还在录空白页 → **前置空白** |
-| tick 的 `lastTick = performance.now()` 在**脚本顶层**初始化 | 字体加载 L 秒被算进首帧 `dt`，`time` 瞬间跳到 L → 录屏全程滞后 L 秒 → **起点偏移** |
+| `__ready` is set inside `useEffect` or sync setup (before tick's first frame) | Recording script thinks the animation has started, but WebM is still capturing the blank page → **leading blank** |
+| `lastTick = performance.now()` is initialized at **script top level** | Font-load L seconds get counted into first-frame `dt`, `time` jumps to L instantly → recording lags by L seconds throughout → **start offset** |
 
-**✅ 正确的完整 starter tick 模板**（手写动画必须用这个骨架）：
+**✅ Correct full starter tick template** (hand-written animations must use this skeleton):
 
 ```js
 // ━━━━━━ state ━━━━━━
 let time = 0;
-let playing = false;   // ❗ 默认不播，等字体 ready 再启动
-let lastTick = null;   // ❗ sentinel——tick 首帧时 dt 强制为 0（别用 performance.now()）
+let playing = false;   // ❗ don't play by default; wait for fonts ready
+let lastTick = null;   // ❗ sentinel — first tick frame's dt is forced to 0 (don't use performance.now())
 const fired = new Set();
 
 // ━━━━━━ tick ━━━━━━
 function tick(now) {
   if (lastTick === null) {
     lastTick = now;
-    window.__ready = true;   // ✅ pair：「录屏起点」与「动画 t=0」同一帧
-    render(0);               // 再渲一次确保 DOM 就绪（此时字体已 ready）
+    window.__ready = true;   // ✅ pair: "recording start" = "animation t=0" same frame
+    render(0);               // render once more to ensure DOM is ready (fonts are now ready)
     requestAnimationFrame(tick);
     return;
   }
-  const dt = (now - lastTick) / 1000;   // 首帧之后 dt 才开始推进
+  const dt = (now - lastTick) / 1000;   // dt only advances after the first frame
   lastTick = now;
 
   if (playing) {
     let t = time + dt;
     if (t >= DURATION) {
-      t = window.__recording ? DURATION - 0.001 : 0;  // 录制时不 loop，留 0.001s 保留末帧
+      t = window.__recording ? DURATION - 0.001 : 0;  // don't loop while recording; leave 0.001s to keep the last frame
       if (!window.__recording) fired.clear();
     }
     time = t;
@@ -250,131 +250,131 @@ function tick(now) {
 }
 
 // ━━━━━━ boot ━━━━━━
-// 不要在顶层立即 rAF——等字体加载完才启动
+// Don't rAF immediately at top level — wait until fonts load
 document.fonts.ready.then(() => {
-  render(0);                 // 先把初始画面画出来（字体已就绪）
+  render(0);                 // paint the initial frame first (fonts ready)
   playing = true;
-  requestAnimationFrame(tick);  // 首次 tick 会 pair __ready + t=0
+  requestAnimationFrame(tick);  // first tick pairs __ready + t=0
 });
 
-// ━━━━━━ seek 接口（供 render-video 防御性矫正用）━━━━━━
+// ━━━━━━ seek interface (for defensive correction by render-video) ━━━━━━
 window.__seek = (t) => { fired.clear(); time = t; lastTick = null; render(t); };
 ```
 
-**为什么这个模板对**：
+**Why this template is correct**:
 
-| 环节 | 为什么必须这样 |
+| Step | Why it must be this way |
 |------|-------------|
-| `lastTick = null` + 首帧 `return` | 避免「脚本加载到 tick 首次执行」的 L 秒被算进动画时间 |
-| `playing = false` 默认 | 字体加载期间 `tick` 即使运行也不推进 time，避免渲染错位 |
-| `__ready` 在 tick 首帧设 | 录屏脚本此刻开始计时，对应的画面是动画真正的 t=0 |
-| `document.fonts.ready.then(...)` 里才启动 tick | 规避字体 fallback 宽度测量、避免首帧字体跳变 |
-| `window.__seek` 存在 | 让 `render-video.js` 可以主动矫正——第二道防线 |
+| `lastTick = null` + first-frame `return` | Prevents the L seconds from "script load to tick first execution" being counted into animation time |
+| `playing = false` by default | While fonts load, even if `tick` runs it doesn't advance time, avoiding render misalignment |
+| `__ready` set on tick's first frame | Recording script starts timing here; the matching frame is the animation's true t=0 |
+| Boot tick inside `document.fonts.ready.then(...)` | Avoids fallback-font width measurement, avoids first-frame font jump |
+| `window.__seek` exists | Lets `render-video.js` actively correct — a second line of defense |
 
-**录屏脚本端的对应防御**：
-1. `addInitScript` 注入 `window.__recording = true`（先于 page goto）
-2. `waitForFunction(() => window.__ready === true)`，记录此刻偏移作为 ffmpeg trim
-3. **额外**：`__ready` 之后主动 `page.evaluate(() => window.__seek && window.__seek(0))`，把 HTML 可能的 time 偏差强制归零——这是第二道防线，对付不严格遵守 starter 模板的 HTML
+**Corresponding defense on the recording script side**:
+1. `addInitScript` injects `window.__recording = true` (before page goto)
+2. `waitForFunction(() => window.__ready === true)`, record the offset for ffmpeg trim
+3. **Additionally**: after `__ready`, actively `page.evaluate(() => window.__seek && window.__seek(0))` to force any HTML time offset to zero — this is a second line of defense for HTMLs that don't strictly follow the starter template
 
-**验证方法**：导出 MP4 后
+**Verification**: after exporting MP4
 ```bash
 ffmpeg -i video.mp4 -ss 0 -vframes 1 frame-0.png
 ffmpeg -i video.mp4 -ss $DURATION-0.1 -vframes 1 frame-end.png
 ```
-首帧必须是动画 t=0 的初始状态（不是中段，不是黑），末帧必须是动画终态（不是第二轮 loop 的某个时刻）。
+The first frame must be the animation's t=0 initial state (not mid-animation, not black); the last frame must be the animation's terminal state (not some moment in a second loop).
 
-**参考实现**：`assets/animations.jsx` 的 Stage 组件、`scripts/render-video.js` 都已按此协议实现。手写 HTML 必须套 starter tick 模板——每一行都是防过具体 bug。
+**Reference implementations**: `assets/animations.jsx`'s Stage component and `scripts/render-video.js` both implement this protocol. Hand-written HTML must use the starter tick template — every line guards against a specific bug.
 
-## 13. 录制时禁止 loop —— `window.__recording` 信号
+## 13. No looping during recording — `window.__recording` signal
 
-**踩的坑**：动画 Stage 默认 `loop=true`（浏览器里方便看效果）。`render-video.js` 录完 duration 秒还多等 300ms 缓冲才停止，这 300ms 让 Stage 进入下一循环。ffmpeg `-t DURATION` 截取时，最后 0.5-1s 落入下一循环——视频结尾突然回到第一帧（Scene 1），观众以为视频出 bug。
+**The bug**: animation Stage defaults to `loop=true` (convenient for in-browser preview). `render-video.js` waits 300ms past the duration before stopping, and during that 300ms the Stage enters the next loop. When ffmpeg `-t DURATION` cuts the clip, the last 0.5–1s lands in the next loop — the video ends abruptly back at the first frame (Scene 1), and the audience thinks the video is bugged.
 
-**根因**：录制脚本和 HTML 之间没有"我在录制"的握手协议。HTML 不知道自己被录，依然按浏览器交互场景循环。
+**Root cause**: there's no "I'm recording" handshake between the recording script and the HTML. The HTML doesn't know it's being recorded and keeps looping as in normal browser interaction.
 
-**规则**：
+**Rule**:
 
-1. **录制脚本**：在 `addInitScript` 里注入 `window.__recording = true`（先于 page goto）：
+1. **Recording script**: inject `window.__recording = true` via `addInitScript` (before page goto):
    ```js
    await recordCtx.addInitScript(() => { window.__recording = true; });
    ```
 
-2. **Stage 组件**：识别这个信号，强制 loop=false：
+2. **Stage component**: detect this signal and force loop=false:
    ```js
    const effectiveLoop = (typeof window !== 'undefined' && window.__recording) ? false : loop;
    // ...
    if (next >= duration) return effectiveLoop ? 0 : duration - 0.001;
-   //                                                       ↑ 留 0.001 防止 Sprite end=duration 被关掉
+   //                                                       ↑ leave 0.001 to prevent Sprite end=duration from being killed
    ```
 
-3. **结尾 Sprite 的 fadeOut**：录制场景下应设 `fadeOut={0}`，否则视频末尾会渐变到透明/暗色——用户期望停在清晰的最后一帧，不是淡出。手写 HTML 时建议结尾 Sprite 都用 `fadeOut={0}`。
+3. **Ending Sprite's fadeOut**: in the recording scenario, set `fadeOut={0}` — otherwise the video tail fades to transparent/dark. Users expect to stop on a clear final frame, not fade out. When hand-writing HTML, prefer `fadeOut={0}` for trailing Sprites.
 
-**参考实现**：`assets/animations.jsx` 的 Stage / `scripts/render-video.js` 都已内置握手。手写 Stage 必须实现 `__recording` 检测——否则录制必踩这个坑。
+**Reference implementations**: `assets/animations.jsx`'s Stage / `scripts/render-video.js` have the handshake built in. Hand-written Stages must implement `__recording` detection — otherwise this pitfall is guaranteed.
 
-**验证**：导出 MP4 后 `ffmpeg -ss 19.8 -i video.mp4 -frames:v 1 end.png`，检查倒数 0.2 秒是否还是预期最后一帧，没有突然切换到另一个 scene。
+**Verification**: after exporting MP4, run `ffmpeg -ss 19.8 -i video.mp4 -frames:v 1 end.png` and check that the last 0.2 seconds are still the expected final frame, not a sudden cut to another scene.
 
-## 14. 60fps 视频默认用帧复制 —— minterpolate 兼容性差
+## 14. 60fps video defaults to frame duplication — minterpolate has poor compatibility
 
-**踩的坑**：`convert-formats.sh` 用 `minterpolate=fps=60:mi_mode=mci...` 生成的 60fps MP4，在 macOS QuickTime / Safari 部分版本下无法打开（一片黑或直接拒打）。VLC / Chrome 能打开。
+**The bug**: the 60fps MP4 generated by `convert-formats.sh` with `minterpolate=fps=60:mi_mode=mci...` can't be opened in some versions of macOS QuickTime / Safari (black or refuses to open). VLC / Chrome handle it.
 
-**根因**：minterpolate 输出的 H.264 elementary stream 包含某些播放器解析有问题的 SEI / SPS 字段。
+**Root cause**: minterpolate's H.264 elementary stream contains SEI / SPS fields some players parse incorrectly.
 
-**规则**：
+**Rule**:
 
-- 默认 60fps 用简单 `fps=60` filter（帧复制），兼容性广（QuickTime/Safari/Chrome/VLC 都能开）
-- 高质量插帧用 `--minterpolate` flag 显式启用——但**必须本地测过**目标播放器再交付
-- 60fps 标签价值是**上传平台的算法识别**（Bilibili / YouTube 上 60fps 标记会优先推流），实际感知流畅度对 CSS 动画来说提升微弱
-- 加 `-profile:v high -level 4.0` 提升 H.264 通用兼容性
+- Default 60fps uses simple `fps=60` filter (frame duplication), broadly compatible (QuickTime/Safari/Chrome/VLC all handle it)
+- High-quality interpolation is opted into with the `--minterpolate` flag — but **you must locally test** the target player before delivery
+- The 60fps label's value is **algorithmic recognition by upload platforms** (Bilibili / YouTube boost 60fps-tagged content); actual perceived smoothness for CSS animations is marginal
+- Add `-profile:v high -level 4.0` to improve H.264 general compatibility
 
-**`convert-formats.sh` 已默认改成兼容模式**。如果你需要插帧高质量，加 `--minterpolate` flag：
+**`convert-formats.sh` already defaults to compatibility mode**. If you need high-quality interpolation, add `--minterpolate`:
 ```bash
 bash convert-formats.sh input.mp4 --minterpolate
 ```
 
-## 15. `file://` + 外部 `.jsx` 的 CORS 陷阱 —— 单文件交付必须内联引擎
+## 15. `file://` + external `.jsx` CORS trap — single-file delivery must inline the engine
 
-**踩的坑**：动画 HTML 里用 `<script type="text/babel" src="animations.jsx"></script>` 外部加载引擎。本机双击打开（`file://` 协议）→ Babel Standalone 走 XHR 拉 `.jsx` → Chrome 报 `Cross origin requests are only supported for protocol schemes: http, https, chrome, chrome-extension...` → 整页黑屏，不报 `pageerror` 只报 console error，很容易当"动画没触发"误诊。
+**The bug**: the animation HTML uses `<script type="text/babel" src="animations.jsx"></script>` to load the engine externally. Double-click open locally (`file://` protocol) → Babel Standalone XHRs for `.jsx` → Chrome reports `Cross origin requests are only supported for protocol schemes: http, https, chrome, chrome-extension...` → the whole page goes black, no `pageerror`, only a console error — easy to misdiagnose as "the animation didn't trigger."
 
-启 HTTP server 也未必救得了——本机有全局代理时 `localhost` 也会走代理，返回 502 / 连接失败。
+Spinning up an HTTP server doesn't always save you either — a global proxy on the machine routes `localhost` through the proxy and returns 502 / connection failed.
 
-**规则**：
+**Rule**:
 
-- **单文件交付（双击打开即用的 HTML）** → `animations.jsx` 必须**内联**到 `<script type="text/babel">...</script>` 标签内，不要用 `src="animations.jsx"`
-- **多文件项目（起 HTTP server 演示）** → 可以外部加载，但交付时明确写清 `python3 -m http.server 8000` 命令
-- 判断标准：交付给用户的是"HTML 文件"还是"带 server 的项目目录"？前者用内联
-- Stage 组件 / animations.jsx 经常 200+ 行——贴进 HTML `<script>` 块完全可接受，别怕体积
+- **Single-file delivery (double-clickable HTML)** → `animations.jsx` must be **inlined** into a `<script type="text/babel">...</script>` tag; don't use `src="animations.jsx"`
+- **Multi-file project (HTTP server demo)** → external loading is fine, but state `python3 -m http.server 8000` clearly in the delivery
+- Decision criterion: is what you're delivering "an HTML file" or "a project directory with a server"? The former uses inlining
+- Stage / animations.jsx is often 200+ lines — pasting into HTML `<script>` blocks is fine; don't worry about size
 
-**最小验证**：双击你生成的 HTML，**不要**通过任何 server 打开。如果 Stage 正常显示动画首帧，才算通过。
+**Minimum verification**: double-click your generated HTML, **don't** open it through any server. If Stage shows the animation's first frame correctly, it passes.
 
-## 16. 跨 scene 反色上下文 —— 画面内元素不要硬编码颜色
+## 16. Cross-scene inverse-color context — don't hard-code colors on in-frame elements
 
-**踩的坑**：做多场景动画时，`ChapterLabel` / `SceneNumber` / `Watermark` 等**跨 scene 都出现**的元素，在组件里写死 `color: '#1A1A1A'`（深色文字）。前 4 个 scene 浅底 OK，到第 5 个黑底 scene 时"05"和水印直接消失——不报错、不触发任何检查、关键信息隐形。
+**The bug**: when making multi-scene animations, elements that **appear across scenes** like `ChapterLabel` / `SceneNumber` / `Watermark` had hard-coded `color: '#1A1A1A'` (dark text) in the component. Fine for the first 4 light-background scenes; on the 5th black-background scene, the "05" and watermark vanish — no error, no check triggers, critical info invisible.
 
-**规则**：
+**Rule**:
 
-- **跨多 scene 复用的画面内元素**（chapter 标签 / scene 编号 / 时间码 / 水印 / 版权条）**禁止硬编码颜色值**
-- 改用三种方式之一：
-  1. **`currentColor` 继承**：元素只写 `color: currentColor`，父 scene 容器设 `color: 计算值`
-  2. **invert prop**：组件接受 `<ChapterLabel invert />` 手动切换深浅
-  3. **基于底色自动计算**：`color: contrast-color(var(--scene-bg))`（CSS 4 新 API，或 JS 判断）
-- 交付前用 Playwright 抽**每个 scene 的代表帧**，人眼过一遍"跨 scene 元素"是否都可见
+- Cross-scene reused in-frame elements (chapter label / scene number / timecode / watermark / copyright strip) **must not hard-code color values**
+- Use one of three approaches instead:
+  1. **`currentColor` inheritance**: the element only writes `color: currentColor`, the parent scene container sets `color: computed-value`
+  2. **invert prop**: the component accepts `<ChapterLabel invert />` to manually toggle light/dark
+  3. **auto-compute from base color**: `color: contrast-color(var(--scene-bg))` (CSS 4 new API, or JS-based decision)
+- Before delivery, use Playwright to capture **a representative frame from each scene** and eyeball whether "cross-scene elements" are all visible
 
-这条坑的隐蔽性在于——**没有 bug 报警**。只有人眼或 OCR 能发现。
+The insidiousness of this pitfall: **there's no bug alarm**. Only human eyes or OCR catch it.
 
-## 快速自查清单（开工前 5 秒）
+## Pre-flight self-check (5 seconds before starting)
 
-- [ ] 每个 `position: absolute` 的父元素都有 `position: relative`？
-- [ ] 动画里的特殊字符（`␣` `⌘` `emoji`）都在字体里存在？
-- [ ] Grid/Flex 模板的 count 和 JS 数据的 length 一致？
-- [ ] 场景切换之间有 cross-fade，没有 >0.3s 的纯空白？
-- [ ] DOM 测量代码包在 `document.fonts.ready.then()` 里？
-- [ ] `render(t)` 是 pure 的，或有明确的 reset 机制？
-- [ ] 第 0 帧是完整初始状态，不是空白？
-- [ ] 画面内没有「伪 chrome」装饰（进度条/时间码/底部署名条与 Stage scrubber 撞车）？
-- [ ] 动画 tick 第一帧同步设 `window.__ready = true`？（用 animations.jsx 自带；手写 HTML 自己加）
-- [ ] Stage 检测 `window.__recording` 强制 loop=false？（手写 HTML 必加）
-- [ ] 结尾 Sprite 的 `fadeOut` 设为 0（视频末尾停清晰帧）？
-- [ ] 60fps MP4 默认用帧复制模式（兼容性），高质量插帧才加 `--minterpolate`？
-- [ ] 导出后抽第 0 帧 + 末帧验证是动画初始/最终状态？
-- [ ] 涉及具体品牌（Stripe/Anthropic/Lovart/...）：走完了「品牌资产协议」（SKILL.md §1.a 五步）？有没有写 `brand-spec.md`？
-- [ ] 单文件交付的 HTML：`animations.jsx` 是内联的，不是 `src="..."`？（file:// 下 external .jsx 会 CORS 黑屏）
-- [ ] 跨 scene 出现的元素（chapter 标签/水印/scene 编号）没有硬编码颜色？在每个 scene 底色下都可见？
+- [ ] Every parent of a `position: absolute` element has `position: relative`?
+- [ ] All special characters in the animation (`␣` `⌘` `emoji`) exist in the font?
+- [ ] Grid/Flex template count matches the JS data length?
+- [ ] Scene switches use cross-fade, no >0.3s pure blank?
+- [ ] DOM measurement code is wrapped in `document.fonts.ready.then()`?
+- [ ] `render(t)` is pure, or has an explicit reset mechanism?
+- [ ] Frame 0 is the complete initial state, not blank?
+- [ ] No "pseudo-chrome" decorations inside the frame (progress bar / timecode / bottom signature strip clashing with Stage scrubber)?
+- [ ] The animation tick sets `window.__ready = true` on its first frame? (Built into animations.jsx; hand-written HTML must add it)
+- [ ] Stage detects `window.__recording` and forces loop=false? (Mandatory for hand-written HTML)
+- [ ] Ending Sprite's `fadeOut` set to 0 (so the video ends on a clear frame)?
+- [ ] 60fps MP4 defaults to frame-duplication mode (compatibility); only add `--minterpolate` for high-quality interpolation?
+- [ ] After export, captured frame 0 + final frame to confirm they're the animation's initial / final states?
+- [ ] Involves a specific brand (Stripe/Anthropic/Lovart/...): did you run the Core Asset Protocol (SKILL.md §1.a, five steps)? Is `brand-spec.md` written?
+- [ ] Single-file delivery HTML: is `animations.jsx` inlined, not `src="..."`? (External .jsx under file:// causes a CORS black screen)
+- [ ] Cross-scene elements (chapter label / watermark / scene number) have no hard-coded colors? Visible against every scene's background?

--- a/references/animations.md
+++ b/references/animations.md
@@ -1,20 +1,20 @@
-# Animations：时间轴动画引擎
+# Animations: Timeline Animation Engine
 
-做动画/motion design HTML时读这个。原理、用法、典型模式。
+Read this when building animation / motion design HTML. Principles, usage, common patterns.
 
-## 核心模式：Stage + Sprite
+## Core Pattern: Stage + Sprite
 
-我们的动画系统（`assets/animations.jsx`）提供一个时间轴驱动的引擎：
+Our animation system (`assets/animations.jsx`) provides a timeline-driven engine:
 
-- **`<Stage>`**：整个动画的容器，自动提供auto-scale（fit viewport）+ scrubber + play/pause/loop控制
-- **`<Sprite start end>`**：时间片段。一个Sprite只在`start`到`end`这段时间内显示。内部可以通过`useSprite()` hook读取自己的本地进度`t` (0→1)
-- **`useTime()`**：读当前全局时间（秒）
-- **`Easing.easeInOut` / `Easing.easeOut` / ...**：缓动函数
-- **`interpolate(t, from, to, easing?)`**：根据t插值
+- **`<Stage>`**: container for the whole animation. Automatically provides auto-scale (fit viewport) + scrubber + play/pause/loop controls
+- **`<Sprite start end>`**: a time slice. A Sprite is only visible from `start` to `end`. Inside, you can use the `useSprite()` hook to read your local progress `t` (0→1)
+- **`useTime()`**: read the current global time (seconds)
+- **`Easing.easeInOut` / `Easing.easeOut` / ...**: easing functions
+- **`interpolate(t, from, to, easing?)`**: interpolate based on t
 
-这套模式借鉴Remotion/After Effects思路，但轻量、零依赖。
+This pattern borrows from Remotion / After Effects, but stays lightweight and zero-dependency.
 
-## 起手
+## Getting Started
 
 ```html
 <script type="text/babel" src="animations.jsx"></script>
@@ -22,7 +22,7 @@
   const { Stage, Sprite, useTime, useSprite, Easing, interpolate } = window.Animations;
 
   function Title() {
-    const { t } = useSprite();  // 本地进度 0→1
+    const { t } = useSprite();  // local progress 0→1
     const opacity = interpolate(t, [0, 1], [0, 1], Easing.easeOut);
     const y = interpolate(t, [0, 1], [40, 0], Easing.easeOut);
     return (
@@ -39,7 +39,7 @@
 
   function Scene() {
     return (
-      <Stage duration={10}>  {/* 10秒动画 */}
+      <Stage duration={10}>  {/* 10-second animation */}
         <Sprite start={0} end={3}>
           <Title />
         </Sprite>
@@ -56,7 +56,7 @@
 </script>
 ```
 
-## 常用动画模式
+## Common Animation Patterns
 
 ### 1. Fade In / Fade Out
 
@@ -68,7 +68,7 @@ function FadeIn({ children }) {
 }
 ```
 
-**注意范围**：`[0, 0.3]`意思是在sprite的前30%时间完成渐入，后面保持opacity=1。
+**Note the range**: `[0, 0.3]` means the fade-in completes in the first 30% of the sprite's time, then opacity stays at 1.
 
 ### 2. Slide In
 
@@ -94,7 +94,7 @@ function SlideIn({ children, from = 'left' }) {
 }
 ```
 
-### 3. 逐字打字机
+### 3. Character-by-character Typewriter
 
 ```jsx
 function Typewriter({ text }) {
@@ -104,7 +104,7 @@ function Typewriter({ text }) {
 }
 ```
 
-### 4. 数字计数
+### 4. Number Count-up
 
 ```jsx
 function CountUp({ from = 0, to = 100, duration = 0.6 }) {
@@ -115,28 +115,28 @@ function CountUp({ from = 0, to = 100, duration = 0.6 }) {
 }
 ```
 
-### 5. 分段解释（典型教学动画）
+### 5. Segmented Explanation (typical instructional animation)
 
 ```jsx
 function Scene() {
   return (
     <Stage duration={20}>
-      {/* Phase 1: 展示问题 */}
+      {/* Phase 1: show the problem */}
       <Sprite start={0} end={4}>
         <Problem />
       </Sprite>
 
-      {/* Phase 2: 展示思路 */}
+      {/* Phase 2: show the approach */}
       <Sprite start={4} end={10}>
         <Approach />
       </Sprite>
 
-      {/* Phase 3: 展示结果 */}
+      {/* Phase 3: show the result */}
       <Sprite start={10} end={16}>
         <Result />
       </Sprite>
 
-      {/* 全程显示的字幕 */}
+      {/* Caption visible throughout */}
       <Sprite start={0} end={20}>
         <Caption />
       </Sprite>
@@ -145,105 +145,105 @@ function Scene() {
 }
 ```
 
-## Easing函数
+## Easing Functions
 
-预设的easing curves：
+Preset easing curves:
 
-| Easing | 特性 | 用在 |
-|--------|------|------|
-| `linear` | 匀速 | 滚动字幕、持续动画 |
-| `easeIn` | 慢→快 | 退场消失 |
-| `easeOut` | 快→慢 | 入场出现 |
-| `easeInOut` | 慢→快→慢 | 位置变化 |
-| **`expoOut`** ⭐ | **指数缓出** | **Anthropic 级主 easing**（物理重量感）|
-| **`overshoot`** ⭐ | **弹性回弹** | **Toggle / 按钮弹出 / 强调交互** |
-| `spring` | 弹簧 | 交互反馈、几何体归位 |
-| `anticipation` | 先反向再正向 | 强调动作 |
+| Easing | Character | Use for |
+|--------|-----------|---------|
+| `linear` | constant velocity | scrolling captions, continuous animation |
+| `easeIn` | slow→fast | exits / disappearing |
+| `easeOut` | fast→slow | entrances / appearing |
+| `easeInOut` | slow→fast→slow | position changes |
+| **`expoOut`** ⭐ | **exponential ease-out** | **Anthropic-grade primary easing** (physical weight) |
+| **`overshoot`** ⭐ | **elastic overshoot** | **Toggles / button pops / emphasis interactions** |
+| `spring` | spring | interactive feedback, geometric settling |
+| `anticipation` | reverse first, then forward | emphasized actions |
 
-**默认主 easing 用 `expoOut`**（不是 `easeOut`）—— 见 `animation-best-practices.md` §2。
-入场用 `expoOut`、出场用 `easeIn`、toggle 用 `overshoot`——Anthropic 级动画的基础规律。
+**Default primary easing is `expoOut`** (not `easeOut`) — see `animation-best-practices.md` §2.
+Entrance with `expoOut`, exit with `easeIn`, toggle with `overshoot` — the foundational rules for Anthropic-grade animation.
 
-## 节奏和时长指南
+## Pacing and Duration Guide
 
-### 微交互（0.1-0.3秒）
-- 按钮hover
-- 卡片expand
-- Tooltip出现
+### Micro-interactions (0.1–0.3s)
+- Button hover
+- Card expand
+- Tooltip appear
 
-### UI过渡（0.3-0.8秒）
-- 页面切换
-- 模态框出现
-- 列表item加入
+### UI transitions (0.3–0.8s)
+- Page switch
+- Modal appear
+- List item insertion
 
-### 叙事动画（2-10秒每段）
-- 概念解释的一个phase
-- 数据图表的reveal
-- 场景转换
+### Narrative animation (2–10s per segment)
+- One phase of a concept explanation
+- A data chart reveal
+- A scene transition
 
-### 单段叙事动画最长不超过10秒
-人类注意力有限。10秒讲一件事，讲完换下一件。
+### A single narrative animation segment must not exceed 10 seconds
+Human attention is finite. Tell one thing in 10 seconds, then move to the next.
 
-## 设计动画的思考顺序
+## How to Think About Designing an Animation
 
-### 1. 先有内容/故事，再有动画
+### 1. Content/story first, animation second
 
-**错误**：先想要做fancy动画，再塞内容进去
-**正确**：先想清楚要传达什么信息，再用动画手段serve这个信息
+**Wrong**: decide you want a fancy animation, then stuff content into it
+**Right**: first figure out what information you need to convey, then use animation to serve that information
 
-动画是**signal**，不是**装饰**。一个fade-in强调的是"这里很重要，请看"——如果什么都fade-in，signal就失效。
+Animation is a **signal**, not **decoration**. A fade-in says "this is important, look here" — if everything fades in, the signal dies.
 
-### 2. 分Scene写时间轴
+### 2. Plan the timeline by Scene
 
 ```
-0:00 - 0:03   问题出现（fade in）
-0:03 - 0:06   问题放大/展开（zoom+pan）
-0:06 - 0:09   解法出现（slide in from right）
-0:09 - 0:12   解法展开说明（typewriter）
-0:12 - 0:15   结果演示（counter up + chart reveal）
-0:15 - 0:18   总结一句话（static，读3秒）
-0:18 - 0:20   CTA或fade out
+0:00 - 0:03   problem appears (fade in)
+0:03 - 0:06   problem zooms / unfolds (zoom+pan)
+0:06 - 0:09   solution appears (slide in from right)
+0:09 - 0:12   solution explained (typewriter)
+0:12 - 0:15   result demo (counter up + chart reveal)
+0:15 - 0:18   one-line summary (static, read for 3s)
+0:18 - 0:20   CTA or fade out
 ```
 
-写完时间轴再写组件。
+Write the timeline first, then write components.
 
-### 3. 资源先行
+### 3. Assets first
 
-动画要用的图片/图标/字体**先**准备好。不要画到一半去找素材——打断节奏。
+The images / icons / fonts the animation needs should be ready **before** you start. Don't draw halfway then hunt for assets — that breaks rhythm.
 
-## 常见问题
+## Common Issues
 
-**动画卡顿**
-→ 主要是layout thrashing。用`transform`和`opacity`，不要动`top`/`left`/`width`/`height`/`margin`。浏览器GPU加速`transform`。
+**Animation stutters**
+→ Mostly layout thrashing. Use `transform` and `opacity`, don't animate `top`/`left`/`width`/`height`/`margin`. Browsers GPU-accelerate `transform`.
 
-**动画太快，看不清楚**
-→ 人读一个汉字需要100-150ms，一个词300-500ms。如果你用文字讲故事，单句至少留3秒。
+**Animation too fast, can't read**
+→ Reading one Chinese character takes 100–150ms; a word 300–500ms. If you're telling a story with text, allow at least 3 seconds per sentence.
 
-**动画太慢，观众无聊**
-→ 有趣的视觉变化要密集。静态画面超过5秒就会闷。
+**Animation too slow, audience bored**
+→ Interesting visual change must be dense. A static frame longer than 5 seconds gets dull.
 
-**多个动画互相影响**
-→ 用CSS的`will-change: transform`提前告诉浏览器这个元素会动，减少reflow。
+**Multiple animations interfering**
+→ Use CSS `will-change: transform` to tell the browser this element will move, reducing reflow.
 
-**录制成视频**
-→ 用 skill 自带工具链（一条命令出三种格式）：见 `video-export.md`
-- `scripts/render-video.js` — HTML → 25fps MP4（Playwright + ffmpeg）
-- `scripts/convert-formats.sh` — 25fps MP4 → 60fps MP4 + 优化 GIF
-- 想要更精确的帧渲染？让 render(t) 成为 pure function，见 `animation-pitfalls.md` 第 5 条
+**Recording as video**
+→ Use the skill's built-in toolchain (one command outputs three formats): see `video-export.md`
+- `scripts/render-video.js` — HTML → 25fps MP4 (Playwright + ffmpeg)
+- `scripts/convert-formats.sh` — 25fps MP4 → 60fps MP4 + optimized GIF
+- Want more precise frame rendering? Make render(t) a pure function — see `animation-pitfalls.md` §5
 
-## 和视频工具的配合
+## Working with Video Tools
 
-这个skill做的是**HTML动画**（在浏览器里跑的）。如果最终产出要作为视频素材：
+This skill makes **HTML animation** (running in the browser). If the final deliverable is video footage:
 
-- **短动画/concept demo**：用这里的方法做HTML动画 → 屏幕录制
-- **长视频/叙事**：本 skill 专注 HTML 动画，长视频用 AI 视频生成类 skill 或专业视频软件
-- **motion graphics**：专业的After Effects/Motion Canvas更合适
+- **Short animation / concept demo**: use the methods here for HTML animation → screen recording
+- **Long-form video / narrative**: this skill focuses on HTML animation; for long videos use AI-video-generation skills or professional video software
+- **Motion graphics**: professional After Effects / Motion Canvas is more appropriate
 
-## 关于Popmotion等库
+## On Popmotion and Similar Libraries
 
-如果你真的需要物理动画（spring、decay、keyframes with precise timing），我们的engine搞不定，可以fallback到Popmotion：
+If you genuinely need physics animation (spring, decay, keyframes with precise timing) and our engine can't handle it, fall back to Popmotion:
 
 ```html
 <script src="https://unpkg.com/popmotion@11.0.5/dist/popmotion.min.js"></script>
 ```
 
-但**先试试我们的engine**。90%的情况够用。
+But **try our engine first**. It's enough 90% of the time.

--- a/references/apple-gallery-showcase.md
+++ b/references/apple-gallery-showcase.md
@@ -1,40 +1,40 @@
-# Apple Gallery Showcase · 画廊展示墙动画风格
+# Apple Gallery Showcase · Gallery Wall Animation Style
 
-> 灵感来源：Claude Design 官网 hero 视频 + 苹果产品页「作品墙」式陈列
-> 实战出处：huashu-design 发布 hero v5
-> 适用场景：**产品发布 hero 动画、skill 能力演示、作品集展示**——任何需要把「多件高质量产出」同时展陈并引导观众注意力的场景
-
----
-
-## 触发判断：什么时候用这个风格
-
-**适合**：
-- 有10张以上真实产出要同屏展示（PPT、App、网页、信息图）
-- 观众是专业受众（开发者、设计师、产品经理），对「质感」敏感
-- 希望传递的气质是「克制、展览式、高级、有空间感」
-- 需要焦点和全局同时存在（看细节但不失整体）
-
-**不适合**：
-- 单产品聚焦（用 frontend-design 的产品 hero 模板）
-- 情绪向/故事性强的动画（用时间轴叙事模板）
-- 小屏幕 / 竖屏（倾斜视角在小画面上会糊）
+> Inspiration: the Claude Design site hero video + Apple product-page "work-wall" presentation
+> Real-world source: huashu-design launch hero v5
+> Use case: **product launch hero animations, skill-capability demos, portfolio showcases** — any scene that needs to display "many high-quality outputs" simultaneously and steer attention through them
 
 ---
 
-## 核心视觉 Token
+## Trigger judgement: when to use this style
+
+**Good fit**:
+- 10+ real outputs to show on the same canvas (slides, apps, web pages, infographics)
+- Audience is professional (developers, designers, PMs) and sensitive to "craft"
+- The tone you want to convey is "restrained, exhibition-grade, upscale, with spatial presence"
+- You need focus and overall view at the same time (see detail without losing the whole)
+
+**Bad fit**:
+- Single-product focus (use the product-hero template in frontend-design)
+- Emotion-driven / narrative-heavy animations (use a timeline narrative template)
+- Small / portrait screens (the tilted perspective gets blurry at small sizes)
+
+---
+
+## Core visual tokens
 
 ```css
 :root {
-  /* 浅色画廊调板 */
-  --bg:         #F5F5F7;   /* 主画布底 — 苹果官网灰 */
-  --bg-warm:    #FAF9F5;   /* 温暖米白变体 */
-  --ink:        #1D1D1F;   /* 主字色 */
+  /* Light-mode gallery palette */
+  --bg:         #F5F5F7;   /* main canvas base — Apple site gray */
+  --bg-warm:    #FAF9F5;   /* warm off-white variant */
+  --ink:        #1D1D1F;   /* primary type color */
   --ink-80:     #3A3A3D;
   --ink-60:     #545458;
-  --muted:      #86868B;   /* 次级文字 */
+  --muted:      #86868B;   /* secondary text */
   --dim:        #C7C7CC;
-  --hairline:   #E5E5EA;   /* 卡片1px边框 */
-  --accent:     #D97757;   /* 赤陶橙 — Claude brand */
+  --hairline:   #E5E5EA;   /* card 1px border */
+  --accent:     #D97757;   /* terracotta orange — Claude brand */
   --accent-deep:#B85D3D;
 
   --serif-cn: "Noto Serif SC", "Songti SC", Georgia, serif;
@@ -44,55 +44,55 @@
 }
 ```
 
-**关键原则**：
-1. **绝不用纯黑底**。黑底会让作品看起来像电影、不像「可以被采用的工作成果」
-2. **赤陶橙是唯一色相accent**，其他全部是灰阶 + 白
-3. **三字体栈**（serif英+serif中+sans+mono）营造「出版物」而非「互联网产品」的气质
+**Key principles**:
+1. **Never use pure black background.** Black makes the work look like a film, not "a work output someone could adopt"
+2. **Terracotta orange is the only chromatic accent**; everything else is grayscale + white
+3. **Three-typeface stack** (English serif + Chinese serif + sans + mono) creates an "editorial publication" feel, not "internet product"
 
 ---
 
-## 核心布局模式
+## Core layout patterns
 
-### 1. 悬浮卡片（整个风格的基本单元）
+### 1. Floating card (the basic unit of the whole style)
 
 ```css
 .gallery-card {
   background: #FFFFFF;
   border-radius: 14px;
-  padding: 6px;                          /* 内边距是「装裱纸」 */
+  padding: 6px;                          /* the padding is the "mat" */
   border: 1px solid var(--hairline);
   box-shadow:
-    0 20px 60px -20px rgba(29, 29, 31, 0.12),   /* 主阴影，软且长 */
-    0 6px 18px -6px rgba(29, 29, 31, 0.06);     /* 第二层近光，制造浮感 */
-  aspect-ratio: 16 / 9;                  /* 统一 slide 比例 */
+    0 20px 60px -20px rgba(29, 29, 31, 0.12),   /* main shadow, soft and long */
+    0 6px 18px -6px rgba(29, 29, 31, 0.06);     /* secondary near light, creates float */
+  aspect-ratio: 16 / 9;                  /* uniform slide ratio */
   overflow: hidden;
 }
 .gallery-card img {
   width: 100%; height: 100%;
   object-fit: cover;
-  border-radius: 9px;                    /* 比卡片圆角略小，视觉嵌套 */
+  border-radius: 9px;                    /* slightly smaller than card radius, visual nesting */
 }
 ```
 
-**反面教材**：不要贴边瓷砖（无padding无border无shadow）——那是信息图密度表达，不是展览。
+**Counter-example**: don't tile edge-to-edge (no padding / no border / no shadow) — that's infographic density expression, not exhibition.
 
-### 2. 3D倾斜作品墙
+### 2. 3D-tilted work wall
 
 ```css
 .gallery-viewport {
   position: absolute; inset: 0;
   overflow: hidden;
-  perspective: 2400px;                   /* 深一些的透视，倾斜不夸张 */
+  perspective: 2400px;                   /* deeper perspective so the tilt isn't extreme */
   perspective-origin: 50% 45%;
 }
 .gallery-canvas {
-  width: 4320px;                         /* 画布 = 2.25× viewport */
-  height: 2520px;                        /* 留出pan空间 */
+  width: 4320px;                         /* canvas = 2.25× viewport */
+  height: 2520px;                        /* leaves room to pan */
   transform-origin: center center;
   transform: perspective(2400px)
-             rotateX(14deg)              /* 向后倾 */
-             rotateY(-10deg)             /* 向左转 */
-             rotateZ(-2deg);             /* 轻微倾斜，去掉太规整 */
+             rotateX(14deg)              /* tilt back */
+             rotateY(-10deg)             /* turn left */
+             rotateZ(-2deg);             /* slight skew, removes the too-tidy feel */
   display: grid;
   grid-template-columns: repeat(8, 1fr);
   gap: 40px;
@@ -100,13 +100,13 @@
 }
 ```
 
-**参数 sweet spot**：
-- rotateX: 10-15deg（再多就像开酒会 VIP 背景板）
-- rotateY: ±8-12deg（左右对称感）
-- rotateZ: ±2-3deg（「这不是机器摆的」的人味）
-- perspective: 2000-2800px（小于2000会鱼眼，大于3000接近正投影）
+**Parameter sweet spots**:
+- rotateX: 10–15deg (any more and it looks like a VIP cocktail-party backdrop)
+- rotateY: ±8–12deg (left/right symmetry)
+- rotateZ: ±2–3deg (the "this wasn't placed by a machine" human touch)
+- perspective: 2000–2800px (under 2000 fisheyes, over 3000 approaches orthographic)
 
-### 3. 2×2 四角汇聚（选择场景）
+### 3. 2×2 four-corner convergence (selection scene)
 
 ```css
 .grid22 {
@@ -117,7 +117,7 @@
 }
 ```
 
-每张卡片从对应角落（tl/tr/bl/br）向中心滑入 + fade in。对应的 `cornerEntry` 向量：
+Each card slides in from its corresponding corner (tl/tr/bl/br) toward the center + fade in. Matching `cornerEntry` vectors:
 
 ```js
 const cornerEntry = {
@@ -130,11 +130,11 @@ const cornerEntry = {
 
 ---
 
-## 五种核心动画模式
+## Five core animation patterns
 
-### 模式 A · 四角汇聚（0.8-1.2s）
+### Pattern A · Four-corner convergence (0.8–1.2s)
 
-4 个元素从视口四角滑入，同时缩放 0.85→1.0，对应 ease-out。适合「展示多方向选择」的开场。
+4 elements slide in from the viewport corners, simultaneously scaling 0.85→1.0, with ease-out. Good for an opener that "shows multi-directional choice".
 
 ```js
 const inP = easeOut(clampLerp(t, start, end));
@@ -142,23 +142,23 @@ card.style.transform = `translate3d(${(1-inP)*ce.dx}px, ${(1-inP)*ce.dy}px, 0) s
 card.style.opacity = inP;
 ```
 
-### 模式 B · 选中放大 + 其他滑出（0.8s）
+### Pattern B · Selection zoom + others slide out (0.8s)
 
-被选中的卡片放大 1.0→1.28，其他卡片 fade out + blur + 向四角漂回：
+The selected card scales 1.0→1.28; the others fade out + blur + drift back to the corners:
 
 ```js
-// 被选中
+// Selected
 card.style.transform = `translate3d(${cellDx*outP}px, ${cellDy*outP}px, 0) scale(${1 + 0.28*easeOut(zoomP)})`;
-// 未选中
+// Not selected
 card.style.opacity = 1 - outP;
 card.style.filter = `blur(${outP * 1.5}px)`;
 ```
 
-**关键**：未选中的要 blur，不是纯 fade。blur 模拟景深，视觉上把被选中的「推出来」。
+**Key**: non-selected cards must blur, not just fade. Blur simulates depth-of-field and visually "pushes the selected one forward".
 
-### 模式 C · Ripple 涟漪展开（1.7s）
+### Pattern C · Ripple expansion (1.7s)
 
-从中心向外，按距离 delay，每张卡片依次淡入 + 从 1.25x 缩到 0.94x（「镜头拉远」）：
+From center outward, delay by distance — each card fades in + scales from 1.25x to 0.94x ("camera pulls back"):
 
 ```js
 const col = i % COLS, row = Math.floor(i / COLS);
@@ -168,28 +168,28 @@ const delay = (dist / maxDist) * 0.8;
 const localT = Math.max(0, (t - rippleStart - delay) / 0.7);
 card.style.opacity = easeOut(Math.min(1, localT));
 
-// 同时整体 scale 1.25→0.94
+// Simultaneously the whole gallery scales 1.25 → 0.94
 const galleryScale = 1.25 - 0.31 * easeOut(rippleProgress);
 ```
 
-### 模式 D · Sinusoidal Pan（持续漂移）
+### Pattern D · Sinusoidal Pan (continuous drift)
 
-用正弦波 + 线性漂移组合，避免 marquee 那种「有起点有终点」的循环感：
+Sine wave + linear drift combined to avoid the "marquee" feel of "has-a-start-has-an-end" loops:
 
 ```js
-const panX = Math.sin(panT * 0.12) * 220 - panT * 8;    // 横向左漂
-const panY = Math.cos(panT * 0.09) * 120 - panT * 5;    // 纵向上漂
-const clampedX = Math.max(-900, Math.min(900, panX));   // 防止露边
+const panX = Math.sin(panT * 0.12) * 220 - panT * 8;    // horizontal left drift
+const panY = Math.cos(panT * 0.09) * 120 - panT * 5;    // vertical up drift
+const clampedX = Math.max(-900, Math.min(900, panX));   // prevent edge reveal
 ```
 
-**参数**：
-- 正弦周期 `0.09-0.15 rad/s`（慢，约30-50秒一个摆动）
-- 线性漂移 `5-8 px/s`（比观众眨眼慢）
-- 振幅 `120-220 px`（大到能感觉，小到不会晕）
+**Parameters**:
+- Sine period `0.09–0.15 rad/s` (slow — about 30–50 seconds per swing)
+- Linear drift `5–8 px/s` (slower than the audience's blink)
+- Amplitude `120–220 px` (big enough to feel, small enough not to nauseate)
 
-### 模式 E · Focus Overlay（焦点切换）
+### Pattern E · Focus Overlay (focus switching)
 
-**关键设计**：focus overlay 是一个**平面元素**（不倾斜），浮在倾斜画布之上。被选中的 slide 从瓦片位置（约400×225）缩放到屏幕中央（960×540），背景画布不倾斜变化但**变暗到 45%**：
+**Key design**: the focus overlay is a **flat element** (no tilt), floating above the tilted canvas. The selected slide scales from its tile position (~400×225) up to screen center (960×540); the background canvas doesn't change tilt but **dims to 45%**:
 
 ```js
 // Focus overlay (flat, centered)
@@ -197,19 +197,19 @@ focusOverlay.style.width = (startW + (endW - startW) * focusIntensity) + 'px';
 focusOverlay.style.height = (startH + (endH - startH) * focusIntensity) + 'px';
 focusOverlay.style.opacity = focusIntensity;
 
-// 背景卡片变暗，但依然可见（关键！不要100%遮罩）
+// Background cards dim but stay visible (key! never go to 100% mask)
 card.style.opacity = entryOp * (1 - 0.55 * focusIntensity);   // 1 → 0.45
 card.style.filter = `brightness(${1 - 0.3 * focusIntensity})`;
 ```
 
-**清晰度铁律**：
-- Focus overlay 的 `<img>` 必须 `src` 直连原图，**不要复用 gallery 里的压缩缩略**
-- 提前 preload 所有原图到 `new Image()[]` 数组
-- overlay 自身 `width/height` 按帧计算，浏览器每帧 resample 原图
+**Sharpness ironclad rule**:
+- The focus overlay's `<img>` must `src` directly to the original, **never reuse the compressed thumbnail in the gallery**
+- Preload every original into a `new Image()[]` array
+- The overlay's own `width/height` is computed per frame; the browser resamples the source each frame
 
 ---
 
-## 时间轴架构（可复用骨架）
+## Timeline architecture (reusable skeleton)
 
 ```js
 const T = {
@@ -227,7 +227,7 @@ const T = {
   s4_walloff: [21.1, 21.8], s4_in: [21.8, 22.7], s4_hold: [23.7, 25.0],
 };
 
-// 核心 easing
+// Core easings
 const easeOut = t => 1 - Math.pow(1 - t, 3);
 const easeInOut = t => t < 0.5 ? 4*t*t*t : 1 - Math.pow(-2*t+2, 3)/2;
 function lerp(time, start, end, fromV, toV, easing) {
@@ -238,7 +238,7 @@ function lerp(time, start, end, fromV, toV, easing) {
   return fromV + (toV - fromV) * p;
 }
 
-// 单一 render(t) 函数读时间戳、写所有元素
+// Single render(t) reads the timestamp and writes every element
 function render(t) { /* ... */ }
 requestAnimationFrame(function tick(now) {
   const t = ((now - startMs) / 1000) % T.DURATION;
@@ -247,18 +247,18 @@ requestAnimationFrame(function tick(now) {
 });
 ```
 
-**架构精髓**：**所有状态由时间戳 t 推导**，没有状态机、没有 setTimeout。这样：
-- 播放到任意时刻 `window.__setTime(12.3)` 立刻跳转（方便 playwright 逐帧截）
-- 循环天然无缝（t mod DURATION）
-- Debug 时能冻结任意一帧
+**Essence of the architecture**: **every state derives from the timestamp t** — no state machine, no setTimeout. This way:
+- Jump to any moment instantly with `window.__setTime(12.3)` (great for Playwright frame-by-frame capture)
+- Loop is naturally seamless (t mod DURATION)
+- Freeze any frame for debug
 
 ---
 
-## 质感细节（容易被忽略但致命）
+## Craft details (easy to skip, fatal to skip)
 
 ### 1. SVG noise texture
 
-浅色底最怕「太平」。叠加一层极弱的 fractalNoise：
+A light base's worst enemy is "too flat". Layer in a very weak fractalNoise:
 
 ```html
 <style>
@@ -273,9 +273,9 @@ requestAnimationFrame(function tick(now) {
 </style>
 ```
 
-看上去没区别，去掉就知道有了。
+Looks like nothing — remove it and you'll feel the difference.
 
-### 2. 角落品牌标识
+### 2. Corner brand mark
 
 ```html
 <div class="corner-brand">
@@ -295,44 +295,44 @@ requestAnimationFrame(function tick(now) {
 }
 ```
 
-只在作品墙 scene 显示，淡入淡出。像美术馆展签。
+Only appears during the work-wall scene, fades in and out. Like a museum wall label.
 
-### 3. 品牌收束 wordmark
+### 3. Brand-closing wordmark
 
 ```css
 .brand-wordmark {
   font-family: var(--sans);
   font-size: 148px;
   font-weight: 700;
-  letter-spacing: -0.045em;   /* 负字距是关键，让字紧凑成标志 */
+  letter-spacing: -0.045em;   /* negative tracking is key — packs the type into a mark */
 }
 .brand-wordmark .accent {
   color: var(--accent);
-  font-weight: 500;           /* accent字符反而细一点，视觉差 */
+  font-weight: 500;           /* accent character is lighter — visual contrast */
 }
 ```
 
-`letter-spacing: -0.045em` 是苹果产品页大字的标准做法。
+`letter-spacing: -0.045em` is Apple product-page standard practice for headline type.
 
 ---
 
-## 常见失败模式
+## Common failure modes
 
-| 症状 | 原因 | 解法 |
+| Symptom | Cause | Fix |
 |---|---|---|
-| 看起来像 PPT 模板 | 卡片没有 shadow / hairline | 加上两层 box-shadow + 1px border |
-| 倾斜感廉价 | 只用了 rotateY 没加 rotateZ | 加 ±2-3deg rotateZ 打破工整 |
-| Pan 感觉「卡顿」 | 用了 setTimeout 或 CSS keyframes 循环 | 用 rAF + sin/cos 连续函数 |
-| Focus 时字看不清 | 复用了 gallery 瓦片的低分图 | 独立 overlay + 原图 src 直连 |
-| 背景太空 | 纯色 `#F5F5F7` | 叠加 SVG fractalNoise 0.5 opacity |
-| 字体太"互联网" | 只有 Inter | 加 Serif（中英各一）+ mono 三栈 |
+| Looks like a PPT template | Cards have no shadow / hairline | Add two layers of box-shadow + 1px border |
+| Tilt feels cheap | Only rotateY, no rotateZ | Add ±2–3deg rotateZ to break perfection |
+| Pan feels "stuttery" | Uses setTimeout or CSS keyframe loops | Use rAF + sin/cos continuous functions |
+| Type unreadable in focus | Reusing the gallery's low-res thumbnail | Independent overlay + direct original src |
+| Background too empty | Pure `#F5F5F7` | Layer SVG fractalNoise at 0.5 opacity |
+| Type feels "internet-y" | Only Inter | Add Serif (one CN + one EN) + mono, 3-stack |
 
 ---
 
-## 引用
+## References
 
-- 完整实现样本：`/Users/alchain/Documents/写作/01-公众号写作/项目/2026.04-huashu-design发布/配图/hero-animation-v5.html`
-- 原始灵感：claude.ai/design hero 视频
-- 参考审美：Apple 产品页、Dribbble shot 集合页
+- Full implementation sample (the original author's reference file — not bundled with this skill)
+- Original inspiration: claude.ai/design hero video
+- Aesthetic references: Apple product pages, Dribbble shot collection pages
 
-遇到「多件高质量产出要陈列」的动画需求，直接从此文件 copy 骨架，换内容 + 调 timing 即可。
+When you face a "many high-quality outputs to display" animation task, copy the skeleton from this file, swap content + tune timing.

--- a/references/audio-design-rules.md
+++ b/references/audio-design-rules.md
@@ -1,184 +1,184 @@
-# 音频设计规则 · huashu-design
+# Audio Design Rules · huashu-design
 
-> 所有动画 demo 的音频应用配方。和 `sfx-library.md`（资产清单）配套使用。
-> 实战锤炼：huashu-design 发布 hero v1-v9 迭代 · Anthropic 三支官方片子的 Gemini 深度拆解 · 8000+ 次 A/B 对比
+> The audio recipe for every animation demo. Pairs with `sfx-library.md` (asset inventory).
+> Forged in practice: huashu-design release hero v1-v9 iterations · deep Gemini audio teardown of Anthropic's three official films · 8000+ A/B comparisons
 
 ---
 
-## 核心原则 · 音频双轨制（铁律）
+## Core Principle · The Dual-Track Audio Doctrine (ironclad rule)
 
-动画音频**必须分两层独立设计**，不能只做一层：
+Animation audio **must be designed as two independent layers**; you cannot do just one:
 
-| 层 | 作用 | 时间尺度 | 和视觉的关系 | 占据频段 |
+| Layer | Role | Time scale | Relation to visuals | Frequency band |
 |---|---|---|---|---|
-| **SFX（节拍层）** | 标记每个视觉 beat | 0.2-2 秒短促 | **强同步**（帧级对齐） | **高频 800Hz+** |
-| **BGM（氛围底）** | 情绪铺底、声场 | 连续 20-60 秒 | 弱同步（段落级） | **中低频 <4kHz** |
+| **SFX (beat layer)** | Marks each visual beat | 0.2-2s short bursts | **Strong sync** (frame-aligned) | **High freq 800Hz+** |
+| **BGM (ambience floor)** | Emotional bed, soundstage | Continuous 20-60s | Weak sync (segment-level) | **Mid/low freq <4kHz** |
 
-**只做BGM的动画是残废的**——观众潜意识感知到「画在动但没声音响应」，廉价感的根源就在这里。
+**An animation with only BGM is crippled** — viewers subconsciously sense that "the visuals move but nothing responds to them"; this is the root of the "cheap" feeling.
 
 ---
 
-## 金标准 · 黄金配比
+## Gold Standard · Golden Ratio
 
-这几组数值是实测 Anthropic 三支官方片子 + 我们自己 v9 定版对比得出的**工程硬参数**，直接套用即可：
+These numbers come from A/B testing Anthropic's three official films + our own v9 lock-in — **hard engineering parameters**, drop them in directly:
 
-### 音量
-- **BGM 音量**：`0.40-0.50`（相对满刻度 1.0）
-- **SFX 音量**：`1.00`
-- **响度差**：BGM 比 SFX peak **低 -6 到 -8 dB**（不是靠SFX绝对响度突出，靠响度差）
-- **amix 参数**：`normalize=0`（绝不用 normalize=1，会把动态范围压平）
+### Volume
+- **BGM volume**: `0.40-0.50` (relative to full scale 1.0)
+- **SFX volume**: `1.00`
+- **Loudness gap**: BGM peak is **-6 to -8 dB below SFX peak** (SFX doesn't pop because of absolute volume — it pops because of the gap)
+- **amix parameter**: `normalize=0` (never `normalize=1` — it flattens dynamic range)
 
-### 频段隔离（P1 硬优化）
-Anthropic 的秘诀不是「SFX 音量大」，是**频段分层**：
+### Frequency Isolation (P1 hard optimization)
+Anthropic's secret isn't "louder SFX", it's **frequency stratification**:
 
 ```bash
-[bgm_raw]lowpass=f=4000[bgm]      # BGM 限制在 <4kHz 的中低频
-[sfx_raw]highpass=f=800[sfx]      # SFX 推到 800Hz+ 的中高频
+[bgm_raw]lowpass=f=4000[bgm]      # BGM constrained to <4kHz mid/low
+[sfx_raw]highpass=f=800[sfx]      # SFX pushed to 800Hz+ mid/high
 [bgm][sfx]amix=inputs=2:duration=first:normalize=0[a]
 ```
 
-为什么：人耳对 2-5kHz 区间最敏感（即「presence 频段」），SFX 如果都在这个区间，BGM 又全频段覆盖，**SFX 会被BGM的高频部分遮盖**。用 highpass 把 SFX 推高 + lowpass 把 BGM 压下，两者在频谱上各占一方，SFX 清晰度直接上一档。
+Why: the human ear is most sensitive in the 2-5kHz range (the "presence" band). If SFX lives entirely in that range and BGM covers the full spectrum, **the SFX gets masked by the BGM's high-frequency content**. Lowpass pushes BGM down, highpass pushes SFX up; they occupy different spectral neighborhoods, and SFX clarity jumps a tier.
 
 ### Fade
-- BGM 入：`afade=in:st=0:d=0.3`（0.3s，避免硬切）
-- BGM 出：`afade=out:st=N-1.5:d=1.5`（1.5s 长尾，收束感）
-- SFX 自带 envelope，不需要额外 fade
+- BGM in: `afade=in:st=0:d=0.3` (0.3s, no hard cut)
+- BGM out: `afade=out:st=N-1.5:d=1.5` (1.5s long tail, sense of closure)
+- SFX have built-in envelopes; no extra fade needed
 
 ---
 
-## SFX cue 设计规则
+## SFX Cue Design Rules
 
-### 密度（每10秒多少个SFX）
-实测 Anthropic 三支片子的 SFX 密度有三档：
+### Density (How Many SFX per 10s)
+Measured SFX densities across Anthropic's three films fall in three tiers:
 
-| 片子 | 每10s SFX 数 | 产品性格 | 场景 |
+| Film | SFX per 10s | Product personality | Scene |
 |---|---|---|---|
-| Artifacts（ref-1） | **~9个/10s** | 功能密集、信息多 | 复杂工具演示 |
-| Code Desktop（ref-2） | **0个** | 纯氛围、冥想感 | 开发工具专注状态 |
-| Word（ref-3） | **~4个/10s** | 平衡、办公节奏 | 生产力工具 |
+| Artifacts (ref-1) | **~9 per 10s** | Feature-dense, info-heavy | Complex tool demo |
+| Code Desktop (ref-2) | **0** | Pure ambience, meditative | Dev tool focus state |
+| Word (ref-3) | **~4 per 10s** | Balanced, office pacing | Productivity tool |
 
-**启发式**：
-- 产品性格冷静/专注 → SFX 密度低（0-3个/10s），BGM 为主
-- 产品性格活泼/信息多 → SFX 密度高（6-9个/10s），SFX 驱动节奏
-- **不要填满每个视觉 beat**——留白比密集更高级。**删掉 30-50% 的 cue 会让剩下的更有戏剧性**。
+**Heuristic**:
+- Calm/focused product personality → low SFX density (0-3 per 10s), BGM-led
+- Lively/info-dense product personality → high SFX density (6-9 per 10s), SFX-driven pacing
+- **Don't fill every visual beat** — whitespace beats density. **Deleting 30-50% of cues makes the rest more dramatic.**
 
-### Cue 选择优先级
-每个视觉 beat 不都要配 SFX。按这个优先级选：
+### Cue Selection Priority
+Not every visual beat needs SFX. Pick by priority:
 
-**P0 必配**（省略会有违和感）：
-- 打字（终端/输入）
-- 点击/选择（用户决策时刻）
-- 焦点切换（视觉主角转移）
-- Logo reveal（品牌收束）
+**P0 mandatory** (omission feels wrong):
+- Typing (terminal/input)
+- Click/select (user decision moments)
+- Focus shift (visual hero handoff)
+- Logo reveal (brand closure)
 
-**P1 推荐配**：
-- 元素入场/离场（modal / card）
-- 完成/成功反馈
-- AI 生成开始/结束
-- 重大过渡（scene 切换）
+**P1 recommended**:
+- Element enter/exit (modal / card)
+- Completion/success feedback
+- AI generation start/end
+- Major transitions (scene change)
 
-**P2 选配**（多了会乱）：
+**P2 optional** (too many gets noisy):
 - hover / focus-in
-- 进度 tick
-- 装饰性 ambient
+- Progress tick
+- Decorative ambient
 
-### 时间戳对齐精度
-- **同帧对齐**（0ms 误差）：点击/焦点切换/Logo 落定
-- **前置 1-2 帧**（-33ms）：快速 whoosh（给观众心理预期）
-- **后置 1-2 帧**（+33ms）：物体落地/impact（符合真实物理）
-
----
-
-## BGM 选择决策树
-
-huashu-design skill 自带 6 首 BGM（`assets/bgm-*.mp3`）：
-
-```
-动画性格是什么？
-├─ 产品发布 / 技术演示 → bgm-tech.mp3（minimal synth + piano）
-├─ 教程讲解 / 工具使用 → bgm-tutorial.mp3（warm, instructional）
-├─ 教育学习 / 原理解释 → bgm-educational.mp3（curious, thoughtful）
-├─ 营销广告 / 品牌宣传 → bgm-ad.mp3（upbeat, promotional）
-└─ 同类风格需要变体 → bgm-*-alt.mp3（各自替代版）
-```
-
-### 无 BGM 的场景（值得考虑）
-参考 Anthropic Code Desktop（ref-2）：**0 SFX + 纯 Lo-fi BGM** 也能很高级。
-
-**何时选无BGM**：
-- 动画时长 <10s（BGM 建立不起来）
-- 产品性格是「专注/冥想」
-- 场景本身有环境音/讲解声
-- SFX 密度很高时（避免听觉过载）
+### Timestamp Alignment Precision
+- **Same-frame alignment** (0ms error): click / focus shift / logo settle
+- **Lead by 1-2 frames** (-33ms): quick whooshes (give viewers psychological anticipation)
+- **Lag by 1-2 frames** (+33ms): object landing / impact (matches real physics)
 
 ---
 
-## 场景配方（开箱即用）
+## BGM Decision Tree
 
-### 配方 A · 产品发布 hero（huashu-design v9 同款）
+The huashu-design skill ships 6 BGM tracks (`assets/bgm-*.mp3`):
+
 ```
-时长：25 秒
-BGM：bgm-tech.mp3 · 45% · 频段 <4kHz
-SFX 密度：~6个/10s
-
-cue：
-  终端打字 → type × 4（间隔0.6s）
-  回车     → enter
-  卡片汇聚 → card × 4（错峰 0.2s）
-  选中     → click
-  Ripple   → whoosh
-  4次焦点  → focus × 4
-  Logo     → thud（1.5s）
-
-音量：BGM 0.45 / SFX 1.0 · amix normalize=0
+What is the animation's personality?
+├─ Product launch / tech demo → bgm-tech.mp3 (minimal synth + piano)
+├─ Tutorial / tool walkthrough → bgm-tutorial.mp3 (warm, instructional)
+├─ Educational / explainer → bgm-educational.mp3 (curious, thoughtful)
+├─ Marketing ad / brand promo → bgm-ad.mp3 (upbeat, promotional)
+└─ Same style needing a variant → bgm-*-alt.mp3 (the sibling alternative)
 ```
 
-### 配方 B · 工具功能演示（参考 Anthropic Code Desktop）
-```
-时长：30-45 秒
-BGM：bgm-tutorial.mp3 · 50%
-SFX 密度：0-2个/10s（极少）
+### Scenarios Without BGM (worth considering)
+See Anthropic Code Desktop (ref-2): **0 SFX + pure Lo-fi BGM** also lands at premium.
 
-策略：让 BGM + 讲解 voiceover 驱动，SFX 只在**决定性时刻**（文件保存/命令执行完成）
+**When to skip BGM**:
+- Animation duration <10s (BGM can't establish)
+- Product personality is "focus/meditation"
+- Scene already has ambient sound / narration
+- SFX density is very high (avoid auditory overload)
+
+---
+
+## Scene Recipes (Out of the Box)
+
+### Recipe A · Product Launch Hero (huashu-design v9 style)
+```
+Duration: 25s
+BGM: bgm-tech.mp3 · 45% · band <4kHz
+SFX density: ~6 per 10s
+
+cues:
+  terminal type → type × 4 (0.6s interval)
+  enter        → enter
+  card cluster → card × 4 (staggered 0.2s)
+  select       → click
+  Ripple       → whoosh
+  4× focus     → focus × 4
+  Logo         → thud (1.5s)
+
+Volume: BGM 0.45 / SFX 1.0 · amix normalize=0
 ```
 
-### 配方 C · AI 生成演示
+### Recipe B · Tool Feature Demo (cf. Anthropic Code Desktop)
 ```
-时长：15-20 秒
-BGM：bgm-tech.mp3 或无 BGM
-SFX 密度：~8个/10s（高密度）
+Duration: 30-45s
+BGM: bgm-tutorial.mp3 · 50%
+SFX density: 0-2 per 10s (minimal)
 
-cue：
-  用户输入 → type + enter
-  AI 开始处理 → magic/ai-process（1.2s 循环）
-  生成完成 → feedback/complete-done
-  结果呈现 → magic/sparkle
-  
-亮点：ai-process 可以循环 2-3 次贯穿整个生成过程
+Strategy: let BGM + voiceover narration drive; SFX only at **decisive moments** (file save / command finished)
 ```
 
-### 配方 D · 纯氛围长镜头（参考 Artifacts）
+### Recipe C · AI Generation Demo
 ```
-时长：10-15 秒
-BGM：无
-SFX：单独使用 3-5 个精心设计的 cue
+Duration: 15-20s
+BGM: bgm-tech.mp3 or no BGM
+SFX density: ~8 per 10s (high density)
 
-策略：每个 SFX 都是主角，没有BGM「糊在一起」的问题。
-适合：单产品慢镜头、特写展示
+cues:
+  user input → type + enter
+  AI starts processing → magic/ai-process (1.2s loop)
+  generation done → feedback/complete-done
+  result reveal → magic/sparkle
+
+Tip: ai-process can loop 2-3× through the whole generation phase
+```
+
+### Recipe D · Pure Ambience Long Take (cf. Artifacts)
+```
+Duration: 10-15s
+BGM: none
+SFX: 3-5 carefully designed cues used standalone
+
+Strategy: every SFX is hero; no "BGM blur" problem.
+Best for: single-product slow takes, close-up showcases
 ```
 
 ---
 
-## ffmpeg 合成模板
+## ffmpeg Composition Templates
 
-### 模板 1 · 单 SFX 叠加到视频
+### Template 1 · Single SFX overlay onto video
 ```bash
 ffmpeg -y -i video.mp4 -itsoffset 2.5 -i sfx.mp3 \
   -filter_complex "[0:a][1:a]amix=inputs=2:normalize=0[a]" \
   -map 0:v -map "[a]" output.mp4
 ```
 
-### 模板 2 · 多 SFX 时间轴合成（按cue时间对齐）
+### Template 2 · Multi-SFX timeline composition (cue-aligned)
 ```bash
 ffmpeg -y \
   -i sfx-type.mp3 -i sfx-enter.mp3 -i sfx-click.mp3 -i sfx-thud.mp3 \
@@ -190,12 +190,12 @@ ffmpeg -y \
 [a0][a1][a2][a3]amix=inputs=4:duration=longest:normalize=0[mixed]" \
   -map "[mixed]" -t 25 sfx-track.mp3
 ```
-**关键参数**：
-- `adelay=N|N`：前面是左声道延迟(ms)，后面是右声道，写两遍保证立体声对齐
-- `normalize=0`：保留动态范围，关键！
-- `-t 25`：截断到指定时长
+**Key parameters**:
+- `adelay=N|N`: first value is left channel delay (ms), second is right; write both to keep stereo aligned
+- `normalize=0`: preserves dynamic range — critical!
+- `-t 25`: cap at the specified duration
 
-### 模板 3 · 视频 + SFX track + BGM（带频段隔离）
+### Template 3 · Video + SFX track + BGM (with frequency isolation)
 ```bash
 ffmpeg -y -i video.mp4 -i sfx-track.mp3 -i bgm.mp3 \
   -filter_complex "\
@@ -208,53 +208,53 @@ ffmpeg -y -i video.mp4 -i sfx-track.mp3 -i bgm.mp3 \
 
 ---
 
-## 失败模式速查
+## Failure Mode Cheat Sheet
 
-| 症状 | 根因 | 修复 |
+| Symptom | Root cause | Fix |
 |---|---|---|
-| SFX 听不见 | BGM 高频部分遮盖 | 加 `lowpass=f=4000` 给BGM + `highpass=f=800` 给SFX |
-| 音效过响刺耳 | SFX 绝对音量太大 | SFX 音量降到 0.7，同时降低 BGM 到 0.3，保持差值 |
-| BGM 和 SFX 节奏冲突 | BGM 选错了（用了有强beat的music） | 换成 ambient / minimal synth 的 BGM |
-| 动画结束 BGM 突然断 | 没做 fade out | `afade=out:st=N-1.5:d=1.5` |
-| SFX 重叠成糊 | cue 太密 + 每个 SFX 时长太长 | SFX 时长控到 0.5s 以内，cue 间隔 ≥ 0.2s |
-| 公众号 mp4 没声音 | 公众号有时会 mute auto-play | 不用担心，用户点开会有声音；gif 本来就没声音 |
+| SFX inaudible | BGM high-frequency content masks it | Add `lowpass=f=4000` on BGM + `highpass=f=800` on SFX |
+| SFX too loud / harsh | SFX absolute volume too high | Drop SFX to 0.7, BGM to 0.3, keep the gap |
+| BGM and SFX fight on rhythm | Wrong BGM (one with a strong beat) | Swap to ambient / minimal synth BGM |
+| BGM cuts off abruptly at end | No fade-out | `afade=out:st=N-1.5:d=1.5` |
+| SFX overlap into mush | Cues too dense + each SFX too long | Keep SFX ≤ 0.5s, cue spacing ≥ 0.2s |
+| WeChat MP4 has no audio | WeChat sometimes mutes autoplay | Don't worry; users get audio when they tap; GIFs are silent by design |
 
 ---
 
-## 和视觉的联动（高级）
+## Coupling with Visuals (advanced)
 
-### SFX 音色要和视觉风格匹配
-- 暖米/纸张感视觉 → SFX 用**木质/柔和**音色（Morse, paper snap, soft click）
-- 冷黑科技视觉 → SFX 用**金属/数字**音色（beep, pulse, glitch）
-- 手绘/童趣视觉 → SFX 用**卡通/夸张**音色（boing, pop, zap）
+### SFX Timbre Must Match the Visual Style
+- Warm beige / paper visuals → SFX in **wood/soft** timbre (Morse, paper snap, soft click)
+- Cool dark-tech visuals → SFX in **metal/digital** timbre (beep, pulse, glitch)
+- Hand-drawn / childlike visuals → SFX in **cartoon/exaggerated** timbre (boing, pop, zap)
 
-我们当前 `apple-gallery-showcase.md` 的暖米底色 → 搭配 `keyboard/type.mp3`（mechanical）+ `container/card-snap.mp3`（soft）+ `impact/logo-reveal-v2.mp3`（cinematic bass）
+The current `apple-gallery-showcase.md` warm beige base → pairs with `keyboard/type.mp3` (mechanical) + `container/card-snap.mp3` (soft) + `impact/logo-reveal-v2.mp3` (cinematic bass)
 
-### SFX 可以引导视觉节奏
-高级技巧：**先设计 SFX 时间轴，然后调整视觉动画去对齐 SFX**（不是反过来）。
-因为 SFX 每个 cue 都是一个「钟表 tick」，视觉动画适配 SFX 节奏会非常稳——反之 SFX 去追视觉，常常 ±1 帧对不上就有违和感。
-
----
-
-## 质量检查清单（发布前自检）
-
-- [ ] 响度差：SFX peak - BGM peak = -6 到 -8 dB？
-- [ ] 频段：BGM lowpass 4kHz + SFX highpass 800Hz？
-- [ ] amix normalize=0（保留动态范围）？
-- [ ] BGM fade-in 0.3s + fade-out 1.5s？
-- [ ] SFX 数量是否合适（按场景性格选密度）？
-- [ ] 每个 SFX 和视觉 beat 同帧对齐（±1 帧内）？
-- [ ] Logo reveal 音效时长够（建议 1.5s）？
-- [ ] 关闭 BGM 听一遍：SFX 单独是否足够有节奏感？
-- [ ] 关闭 SFX 听一遍：BGM 单独是否有情绪起伏？
-
-两层任何一层单独听都应该自洽。如果只有两层叠加才好听，说明没做好。
+### SFX Can Lead Visual Pacing
+Advanced technique: **design the SFX timeline first, then adjust the visual animation to align with the SFX** (not the other way around).
+Because every SFX cue is a "clock tick", aligning visuals to SFX rhythm is rock-solid — the inverse (SFX chasing visuals) often misses by ±1 frame and feels wrong.
 
 ---
 
-## 参考
+## QC Checklist (pre-release self-check)
 
-- SFX 资产清单：`sfx-library.md`
-- 视觉风格参考：`apple-gallery-showcase.md`
-- Anthropic 三支片子深度音频分析：`/Users/alchain/Documents/写作/01-公众号写作/项目/2026.04-huashu-design发布/参考动画/AUDIO-BEST-PRACTICES.md`
-- huashu-design v9 实战案例：`/Users/alchain/Documents/写作/01-公众号写作/项目/2026.04-huashu-design发布/配图/hero-animation-v9-final.mp4`
+- [ ] Loudness gap: SFX peak - BGM peak = -6 to -8 dB?
+- [ ] Bands: BGM lowpass 4kHz + SFX highpass 800Hz?
+- [ ] amix normalize=0 (preserves dynamic range)?
+- [ ] BGM fade-in 0.3s + fade-out 1.5s?
+- [ ] SFX count appropriate (density per scene personality)?
+- [ ] Each SFX frame-aligned with its visual beat (within ±1 frame)?
+- [ ] Logo reveal SFX long enough (1.5s recommended)?
+- [ ] Listen with BGM muted: does the SFX alone have rhythm?
+- [ ] Listen with SFX muted: does the BGM alone have emotional arc?
+
+Both layers should stand on their own. If it only sounds good when stacked, you haven't designed them properly.
+
+---
+
+## References
+
+- SFX asset inventory: `sfx-library.md`
+- Visual style reference: `apple-gallery-showcase.md`
+- Deep audio analysis of Anthropic's three films (the original author's research notes — not bundled with this skill)
+- huashu-design v9 case study video (the original author's reference recording — not bundled with this skill)

--- a/references/cinematic-patterns.md
+++ b/references/cinematic-patterns.md
@@ -1,190 +1,190 @@
-# Cinematic Patterns · Workflow Demo 的 Best Practice
+# Cinematic Patterns · Best Practices for Workflow Demos
 
-> 从「PPT 动画」升级到「发布会级 cinematic」的 5 个关键 pattern。
-> 蒸馏自 2026-04 「聊聊 skill」 deck 的两个 cinematic demo（Nuwa workflow + Darwin workflow），实测可复现。
+> 5 key patterns for upgrading from "PowerPoint animation" to "keynote-grade cinematic."
+> Distilled from the two cinematic demos in the 2026-04 "let's talk skill" deck (Nuwa workflow + Darwin workflow). Reproducible in practice.
 
 ---
 
-## 0 · 这份文档解决什么问题
+## 0 · What this document solves
 
-当你需要做「演示一个工作流的 demo 动画」时（典型场景：skill 工作流、产品 onboarding、API 调用流程、agent 任务执行），有两种常见做法：
+When you need to make a "demo animation showing a workflow" (typical scenarios: skill workflows, product onboarding, API call flows, agent task execution), there are two common approaches:
 
-| 范式 | 长什么样 | 后果 |
+| Paradigm | What it looks like | Outcome |
 |---|---|---|
-| **PPT 动画**（差） | step 1 fade in → step 2 fade in → step 3 fade in，4 个 box 同屏排列 | 观众感觉「就是一个 PPT 加了 fade 效果」，没有 wow moment |
-| **Cinematic**（好） | scene-based，一次只 focus 一件事，scene 之间是 dissolve / focus pull / morph | 观众感觉「这是一个产品发布会片段」，会想截图分享 |
+| **PowerPoint animation** (bad) | step 1 fade in → step 2 fade in → step 3 fade in, 4 boxes laid out on the same screen | Audience feels "this is just a PowerPoint with fade effects," no wow moment |
+| **Cinematic** (good) | scene-based, focus on one thing at a time, transitions between scenes are dissolve / focus pull / morph | Audience feels "this is a product keynote clip," they want to screenshot and share |
 
-差异的根源**不是动画技术**，是**叙事范式**。本文档讲怎么从前者升级到后者。
+The root of the difference is **not animation technique**, it's **narrative paradigm**. This document explains how to upgrade from the former to the latter.
 
 ---
 
-## 1 · 五个核心 pattern
+## 1 · Five core patterns
 
-### Pattern A · Dashboard + Cinematic Overlay 双层结构
+### Pattern A · Dashboard + Cinematic Overlay two-layer structure
 
-**问题**：单纯的 cinematic 默认是黑屏 + 一个 ▶ 按钮，用户翻到这页如果没点，什么都看不到。
+**Problem**: a pure cinematic defaults to a black screen + a ▶ button. If the user flips to the page and doesn't click, they see nothing.
 
-**解决**：
+**Solution**:
 ```
-DEFAULT 状态 (永远显示)：完整静态 workflow dashboard
-  └── 观众一眼看清这个 skill / 工作流怎么跑
+DEFAULT state (always visible): full static workflow dashboard
+  └── audience sees at a glance how this skill / workflow runs
 
-POINT ▶ 触发 (overlay 浮上来)：22 秒 cinematic
-  └── 跑完自动 fade 回 DEFAULT
+POINT ▶ trigger (overlay floats up): 22-second cinematic
+  └── after it finishes, fade back to DEFAULT automatically
 
 ```
 
-**实现要点**：
-- `.dash` 默认 visible，`.cinema` 默认 `opacity: 0; pointer-events: none`
-- `.play-cta` 是右下角金色小按钮（不是中央大覆盖）
-- 点击 → `cinema.classList.add('show')` + `dash.classList.add('hide')`
-- 用 `requestAnimationFrame` 跑一次（不是循环），结束后 `endCinematic()` reverse 状态
+**Implementation points**:
+- `.dash` is visible by default, `.cinema` defaults to `opacity: 0; pointer-events: none`
+- `.play-cta` is a small gold button in the bottom-right (not a central full-screen overlay)
+- Click → `cinema.classList.add('show')` + `dash.classList.add('hide')`
+- Use `requestAnimationFrame` running once (not looped); when finished, `endCinematic()` reverses state
 
-**反 pattern**：默认 = 中央大 ▶ overlay 覆盖一切，没点之前页面是空白的。
+**Anti-pattern**: default = central large ▶ overlay covering everything, page is blank until clicked.
 
 ---
 
 ### Pattern B · Scene-based, NOT Step-based
 
-**问题**：把动画拆成「step 1 显示 → step 2 显示 → ...」就是 PPT 思维。
+**Problem**: breaking the animation into "step 1 shows → step 2 shows → ..." is PowerPoint thinking.
 
-**解决**：拆成 5 个 scene，每个 scene 是**独立的镜头**，全屏只 focus 一件事：
+**Solution**: break into 5 scenes; each scene is an **independent shot**, full-screen, focused on one thing:
 
-| Scene 类型 | 职责 | 时长 |
+| Scene type | Job | Duration |
 |---|---|---|
-| 1 · Invoke | 用户输入触发（终端 typewriter）| 3-4s |
-| 2 · Process | 核心工作流的可视化（独特视觉语言）| 5-6s |
-| 3 · Result/Insight | 提炼出的关键产物（可视化）| 4-5s |
-| 4 · Output | 实际产物展示（文件 / diff / 数字）| 3-4s |
-| 5 · Hero Reveal | 收尾 hero moment（大字 + 价值主张）| 4-5s |
+| 1 · Invoke | user input trigger (terminal typewriter) | 3–4s |
+| 2 · Process | visualization of the core workflow (distinctive visual language) | 5–6s |
+| 3 · Result/Insight | the key distilled output (visualized) | 4–5s |
+| 4 · Output | actual deliverable shown (file / diff / numbers) | 3–4s |
+| 5 · Hero Reveal | closing hero moment (large type + value proposition) | 4–5s |
 
-**总时长 ≈ 22 秒**——这是经过测试的黄金长度：
-- 短于 18 秒：PM 还没进入状态就结束了
-- 长于 25 秒：失去耐心
-- 22 秒刚好够「钩住 → 展开 → 收束 → 留下印象」
+**Total ≈ 22 seconds** — this is the tested golden length:
+- shorter than 18s: PMs haven't gotten into it before it ends
+- longer than 25s: they lose patience
+- 22s is just right to "hook → unfold → resolve → leave an impression"
 
-**实现要点**：
-- `T = { DURATION: 22.0, s1_in: [0, 0.7], s2_in: [3.8, 4.6], ... }` 全局时间轴
-- 单个 `requestAnimationFrame(render)` 跑所有 scene 的 opacity / transform 计算
-- 不要用 setTimeout 链（容易断掉、难调试）
-- Easing 必用 `expoOut` / `easeOut` / cubic-bezier，**禁止 linear**
+**Implementation points**:
+- `T = { DURATION: 22.0, s1_in: [0, 0.7], s2_in: [3.8, 4.6], ... }` — a global timeline
+- A single `requestAnimationFrame(render)` drives opacity / transform calculations across all scenes
+- Don't use setTimeout chains (easy to break, hard to debug)
+- Easing must use `expoOut` / `easeOut` / cubic-bezier — **linear is forbidden**
 
 ---
 
-### Pattern C · 每个 demo 的视觉语言必须独立
+### Pattern C · Each demo's visual language must be unique
 
-**问题**：做完第一个 cinematic 后，做第二个时偷懒复用同一个模板（同样的 orbit + pentagon + typewriter + hero 大字），只换了文案。
+**Problem**: after finishing the first cinematic, you get lazy on the second and reuse the same template (same orbit + pentagon + typewriter + hero large type), only swapping the copy.
 
-**后果**：观众发现两个 skill「长得一模一样」，等于在说「这两个 skill 没区别」。
+**Consequence**: the audience notices the two skills "look identical" — effectively telling them "these two skills are no different."
 
-**解决**：每个工作流的核心隐喻不同，视觉语言就必须不同。
+**Solution**: each workflow's core metaphor is different, so its visual language must be different too.
 
-**对照案例**：
+**Comparison case study**:
 
-| 维度 | Nuwa（蒸馏人）| Darwin（优化 skill）|
+| Dimension | Nuwa (distilling a person) | Darwin (optimizing a skill) |
 |---|---|---|
-| 核心隐喻 | 收集 → 提炼 → 写 | 循环 → 评估 → 棘轮 |
-| 视觉运动 | 漂浮 / 辐射 / pentagon | 循环 / 上升 / 对比 |
-| Scene 2 | 3D Orbit · 8 张档案在透视椭圆漂浮 | Spin Loop · token 沿 6 节点圆环跑 5 圈 |
-| Scene 3 | Pentagon · 5 token 从中央辐射 | v1 vs v5 · 并列 diff（红版 vs 金版） |
-| Scene 4 | SKILL.md typewriter | Hill-Climb · 全屏曲线绘制 |
-| Scene 5 hero | 「21 分钟」serif italic 大字 | 旋转齿轮 ⚙ + 「KEPT +1.1」金色 tag |
+| Core metaphor | collect → refine → write | loop → evaluate → ratchet |
+| Visual motion | float / radiate / pentagon | loop / ascend / contrast |
+| Scene 2 | 3D Orbit · 8 archive items floating on a perspective ellipse | Spin Loop · token runs 5 laps along a 6-node ring |
+| Scene 3 | Pentagon · 5 tokens radiating from center | v1 vs v5 · side-by-side diff (red version vs gold version) |
+| Scene 4 | SKILL.md typewriter | Hill-Climb · full-screen curve drawing |
+| Scene 5 hero | "21 minutes" serif italic large type | rotating gear ⚙ + "KEPT +1.1" gold tag |
 
-**判断标准**：盖住文案，只看视觉，能不能区分这是哪个 demo？区分不了就是偷懒。
-
----
-
-### Pattern D · 用 AI 生成的真实素材，不要 emoji 或 SVG 手画
-
-**问题**：3D orbit / gallery 里需要素材碎片漂浮，emoji（📚🎤）丑且无品牌、SVG 手画书脊永远不像真书。
-
-**解决**：用 `huashu-gpt-image` 跑一张 4×2 grid 大图（8 件主题相关物品 · 白底 · 60px breathing space · unified style），用 `extract_grid.py --mode bbox` 抠成 8 张独立透明 PNG。
-
-**Prompt 要点**（详细 prompt patterns 见 `huashu-gpt-image` skill）：
-- IP 锚定（"1960s Caltech archive aesthetic" / "Hearthstone-style consistent treatment"）
-- 白底（便于抠图，灰底氛围好但抠透明背景困难）
-- 4×2 不要 5×5（避免末行压缩 bug）
-- Persona finishing（"You are a Wired magazine curator preparing an exhibition photo"）
-
-**反 pattern**：用 emoji 当 icon、用 CSS 剪影代替产品图。
+**Test**: cover the copy, look only at the visuals — can you tell which demo this is? If not, that's laziness.
 
 ---
 
-### Pattern E · BGM + SFX 双轨制
+### Pattern D · Use AI-generated real assets, don't use emoji or hand-drawn SVG
 
-**问题**：只有动画没有声音，观众潜意识感觉「这玩意像个穷酸 demo」。
+**Problem**: in a 3D orbit / gallery, you need asset fragments floating around. Emoji (📚🎤) are ugly and off-brand; hand-drawn SVG book spines never look like real books.
 
-**解决**：BGM 长音 + 11 个 SFX cues。
+**Solution**: use `huashu-gpt-image` to render a single 4×2 grid image (8 themed objects · white background · 60px breathing space · unified style), then `extract_grid.py --mode bbox` to cut them into 8 separate transparent PNGs.
 
-**通用 SFX cue 配方**（适用于工作流 demo）：
+**Prompt essentials** (detailed prompt patterns are in the `huashu-gpt-image` skill):
+- IP anchoring ("1960s Caltech archive aesthetic" / "Hearthstone-style consistent treatment")
+- White background (easier to cut out; gray backgrounds give atmosphere but make transparency hard)
+- 4×2 not 5×5 (avoid last-row compression bug)
+- Persona finishing ("You are a Wired magazine curator preparing an exhibition photo")
 
-| 时点 | SFX | 触发场景 |
+**Anti-pattern**: using emoji as icons, using CSS silhouettes as product images.
+
+---
+
+### Pattern E · BGM + SFX dual-track
+
+**Problem**: animation without sound — the audience subconsciously feels "this thing looks like a cheap demo."
+
+**Solution**: BGM long tone + 11 SFX cues.
+
+**Generic SFX cue recipe** (suitable for workflow demos):
+
+| Timestamp | SFX | Trigger scene |
 |---|---|---|
-| 0.10s | whoosh | 终端从下方升起 |
-| 3.0s | enter | typewriter 完成、按 enter |
-| 4.0s | slide-in | scene 2 元素入场 |
-| 5-9s × 5 次 | sparkle | 关键过程节点（每代 / 每个 token / 每个数据点）|
-| 14s | click | 切换到 output scene |
-| 17.8s | logo-reveal | hero reveal 时刻 |
-| typewriter | type | 每 2 字符触发一次（密度别太高）|
+| 0.10s | whoosh | terminal rises from below |
+| 3.0s | enter | typewriter finishes, press enter |
+| 4.0s | slide-in | scene 2 element enters |
+| 5–9s × 5 | sparkle | key process nodes (each generation / each token / each data point) |
+| 14s | click | switch to output scene |
+| 17.8s | logo-reveal | the hero reveal moment |
+| typewriter | type | trigger every 2 characters (don't go too dense) |
 
-**频段隔离**：BGM volume 0.32（低频底噪），SFX volume 0.55（中高频 punch），sparkle 0.7（要醒目），logo-reveal 0.85（最强 hero moment）。
+**Frequency separation**: BGM volume 0.32 (low-frequency floor), SFX volume 0.55 (mid-high punch), sparkle 0.7 (needs to pop), logo-reveal 0.85 (strongest hero moment).
 
-**用户控制**：
-- 必须有 ▶ 启动覆盖（浏览器 autoplay 限制）
-- 右上角小 mute 按钮（用户随时切静音）
-- 不要做成「翻到这页就强制响」
+**User control**:
+- Must have a ▶ start overlay (browser autoplay restriction)
+- Small mute button in the top-right (user can mute anytime)
+- Don't make it "force-play the moment you flip to this page"
 
 ---
 
-## 2 · 静态 Dashboard 设计要点
+## 2 · Static Dashboard Design Essentials
 
-Dashboard 是双层结构的 Layer 1，PM 不点 ▶ 也能看懂这个 skill。
+The dashboard is Layer 1 of the two-layer structure — the PM understands the skill without clicking ▶.
 
-**布局**：3 列 grid（或 1 大 + 2 小），每个 panel 解决一个问题：
+**Layout**: 3-column grid (or 1 large + 2 small); each panel solves one question:
 
-| Panel 类型 | 解决什么问题 | 案例 |
+| Panel type | Solves what | Case |
 |---|---|---|
-| **Pipeline / Flow Diagram** | 「这个 skill 的工作流程是什么？」| Nuwa 4 阶段 pipeline · Darwin autoresearch loop |
-| **Snapshot / State** | 「跑出来的真实数据长什么样？」| Darwin 8 维 rubric snapshot |
-| **Trajectory / Evolution** | 「多次运行后怎么变化？」| Darwin 5 代 hill-climb 曲线 |
-| **Examples / Gallery** | 「已经产出过哪些东西？」| Nuwa 21 personas gallery |
-| **Strip · Example I/O** | 「输入什么 → 输出什么」| Nuwa example strip：`› nuwa 蒸馏 费曼 → feynman.skill (21 min)` |
+| **Pipeline / Flow Diagram** | "What's the workflow of this skill?" | Nuwa 4-stage pipeline · Darwin autoresearch loop |
+| **Snapshot / State** | "What does the real data output look like?" | Darwin 8-dimension rubric snapshot |
+| **Trajectory / Evolution** | "How does it change after multiple runs?" | Darwin 5-generation hill-climb curve |
+| **Examples / Gallery** | "What's already been produced?" | Nuwa 21 personas gallery |
+| **Strip · Example I/O** | "What goes in → what comes out" | Nuwa example strip: `› nuwa distill feynman → feynman.skill (21 min)` |
 
-**关键约束**：
-- 信息密度要够（每个 panel 都要承载差异化信息）
-- 但不能塞数据 slop（每个数字都要有意义）
-- 配色与 cinematic 一致（同色系，方便切换不突兀）
+**Key constraints**:
+- Information density must be sufficient (each panel must carry differentiated information)
+- But don't pad with data slop (every number must mean something)
+- Color palette consistent with the cinematic (same color system, smooth switching)
 
 ---
 
-## 3 · 调试与开发工具
+## 3 · Debugging and dev tools
 
-任何长动画必须配三个 dev 工具，否则调试会爆炸。
+Any long animation must ship three dev tools, or debugging will explode.
 
-### 工具 1 · `?seek=N` 冻结到第 N 秒
+### Tool 1 · `?seek=N` freezes at second N
 
 ```js
 const seek = parseFloat(params.get('seek'));
 if (!isNaN(seek)) {
   started = true; muted = true;
-  frozenT = seek;  // render() 用这个 t 而不是 elapsed
+  frozenT = seek;  // render() uses this t instead of elapsed
   cinema.classList.add('show'); dash.classList.add('hide');
 }
 
-// render() 里：
+// inside render():
 let t = frozenT !== null ? frozenT : (elapsed % T.DURATION);
 ```
 
-用法：`http://.../slide.html?seek=12` 直接看第 12 秒画面，不用等播放。
+Usage: `http://.../slide.html?seek=12` jumps directly to the frame at second 12, no waiting.
 
-### 工具 2 · `?autoplay=1` 跳过 ▶ overlay
+### Tool 2 · `?autoplay=1` skips the ▶ overlay
 
-方便 playwright 自动截图测试，也方便嵌入 iframe 时 force 启动。
+Convenient for playwright auto-screenshot tests, and for force-starting when embedded in iframes.
 
-### 工具 3 · 手动 REPLAY 按钮
+### Tool 3 · Manual REPLAY button
 
-右上角小按钮，用户/调试时可以重播任意次。CSS：
+Small button in the top-right; user / dev can replay any number of times. CSS:
 
 ```css
 .replay{position:absolute;top:18px;right:18px;background:rgba(212,165,116,0.1);
@@ -195,70 +195,70 @@ let t = frozenT !== null ? frozenT : (elapsed % T.DURATION);
 
 ---
 
-## 4 · iframe 嵌入坑（如果 cinematic 嵌在 deck 里）
+## 4 · iframe embedding pitfalls (if the cinematic is embedded in a deck)
 
-### 坑 1 · 父窗口的 click zone 拦截 iframe 内按钮
+### Pitfall 1 · The parent window's click zone intercepts buttons inside the iframe
 
-如果 deck index.html 加了「左右 22vw 透明 click zone 翻页」，会**覆盖到 iframe 内的 ▶ play 按钮**——用户点按钮被吞成「下一页」。
+If the deck index.html adds "left/right 22vw transparent click zones for paging," they **cover the ▶ play button inside the iframe** — the user clicks the button and it gets swallowed as "next page."
 
-**修复**：click zone 加 `top: 12vh; bottom: 25vh`，给顶部和底部 25% 不拦截，让 iframe 内的中央 ▶ 和右下角 ▶ 都能点。
+**Fix**: give the click zones `top: 12vh; bottom: 25vh`, leaving 25% top/bottom uncovered so the iframe's central ▶ and bottom-right ▶ are both clickable.
 
-### 坑 2 · iframe 抢焦点后键盘事件丢失
+### Pitfall 2 · Keyboard events lost after iframe steals focus
 
-用户点过 iframe 后，焦点在 iframe 里，父窗口的 ←/→ 键盘事件收不到。
+After the user clicks the iframe, focus is in the iframe; the parent window's ←/→ keyboard events stop firing.
 
-**修复**：
+**Fix**:
 ```js
 iframe.addEventListener('load', () => {
-  // 注入键盘转发器
+  // inject keyboard forwarder
   const doc = iframe.contentDocument;
   doc.addEventListener('keydown', (e) => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: e.key, ... }));
   });
-  // 点击后焦点拽回父窗口
+  // after click, pull focus back to parent window
   doc.addEventListener('click', () => setTimeout(() => window.focus(), 0));
 });
 ```
 
-### 坑 3 · file:// vs https:// 行为差异
+### Pitfall 3 · file:// vs https:// behavior differences
 
-本地 file:// 测好的 cinematic 部署后可能崩，因为：
-- file:// 下 iframe contentDocument 同源
-- https:// 下也同源（如果同 host），但 audio autoplay 限制更严格
+A cinematic that tests fine locally on file:// can break after deployment because:
+- under file:// the iframe contentDocument is same-origin
+- under https:// it's also same-origin (if same host), but audio autoplay restrictions are stricter
 
-**修复**：
-- 部署前用 `python3 -m http.server` 起本地 HTTP 测试一遍
-- BGM 必须等用户点击 ▶ 后再 `bgm.play()`，不要 page-load 立刻播
-
----
-
-## 5 · 反 pattern 速查表
-
-| ❌ 反 pattern | ✅ 正 pattern |
-|---|---|
-| 默认 = 黑屏 ▶ overlay | 默认 = 静态 dashboard，▶ 是辅助 |
-| 4 个 step 横排同屏 fade in | 5 个 scene 全屏切换，每场只 focus 一件事 |
-| 复用模板换文案做不同 demo | 每个 demo 独立视觉语言（盖文案能区分） |
-| emoji / SVG 手画当素材 | gpt-image-2 大图 + extract_grid 抠图 |
-| 无 BGM 无 SFX | BGM + 11 SFX cues 双轨制 |
-| 用 setTimeout 链 schedule | requestAnimationFrame + 全局时间轴 T 对象 |
-| linear 动画 | Expo / cubic-bezier easing |
-| 没有 dev 工具 | `?seek=N` + `?autoplay=1` + REPLAY 按钮 |
-| iframe 内的按钮被父 click zone 吞 | click zone 加 top/bottom margin 给按钮让位 |
+**Fix**:
+- Before deploying, test once over local HTTP with `python3 -m http.server`
+- BGM must wait until the user clicks ▶ before `bgm.play()` — don't try to play on page load
 
 ---
 
-## 6 · 时间预算
+## 5 · Anti-pattern quick reference
 
-按这套 pattern，一个完整 cinematic demo（含 dashboard）：
-
-| 任务 | 时间 |
+| ❌ Anti-pattern | ✅ Right pattern |
 |---|---|
-| 设计 5-scene narrative + 视觉语言 | 30 分钟（要慎重，决定独立性）|
-| Dashboard 静态布局 + 内容 | 1 小时 |
-| Cinematic 5 scenes 实现 | 1.5 小时 |
-| Audio cues 调时序 + replay 按钮 | 30 分钟 |
-| Playwright 截图验证 5 个关键时刻 | 15 分钟 |
-| **单个 demo 总计** | **3-4 小时** |
+| Default = black screen ▶ overlay | Default = static dashboard, ▶ is auxiliary |
+| 4 steps side by side fading in on one screen | 5 scenes full-screen switching, each focused on one thing |
+| Reusing the same template with new copy for different demos | Each demo has its own visual language (distinguishable with copy hidden) |
+| Emoji / hand-drawn SVG as assets | gpt-image-2 grid + extract_grid cutout |
+| No BGM, no SFX | BGM + 11 SFX cues dual-track |
+| setTimeout chain to schedule | requestAnimationFrame + global timeline T object |
+| linear easing | Expo / cubic-bezier easing |
+| No dev tools | `?seek=N` + `?autoplay=1` + REPLAY button |
+| Buttons in iframe swallowed by parent click zone | Add top/bottom margin to click zones to make room for buttons |
 
-第二个 demo 复用框架但**视觉语言必须独立**，时间约 2-3 小时。
+---
+
+## 6 · Time budget
+
+Following this pattern, a complete cinematic demo (with dashboard):
+
+| Task | Time |
+|---|---|
+| Design 5-scene narrative + visual language | 30 min (be deliberate — determines uniqueness) |
+| Dashboard static layout + content | 1 hour |
+| Cinematic 5 scenes implementation | 1.5 hours |
+| Audio cues timing + replay button | 30 min |
+| Playwright screenshot verification of 5 key moments | 15 min |
+| **Total per demo** | **3–4 hours** |
+
+A second demo reuses the framework but **its visual language must be unique** — about 2–3 hours.

--- a/references/content-guidelines.md
+++ b/references/content-guidelines.md
@@ -1,197 +1,197 @@
-# Content Guidelines：反AI slop、内容准则、Scale规范
+# Content Guidelines: Anti-AI-Slop, Content Rules, Scale Spec
 
-AI设计里最容易掉进去的陷阱。这是一份「不做什么」的清单，比「做什么」更重要——因为AI slop是默认值，你不主动避免就会发生。
+The traps AI design falls into most easily. This is a "what not to do" list — more important than "what to do", because AI slop is the default, and if you don't actively avoid it, it happens.
 
-## AI Slop 完整黑名单
+## Complete AI Slop Blacklist
 
-### 视觉陷阱
+### Visual Traps
 
-**❌ 激进渐变背景**
-- 紫色 → 粉色 → 蓝色 全屏渐变（AI生成网页的典型味道）
-- 任何方向的rainbow gradient
-- Mesh gradient铺满背景
-- ✅ 如果要用渐变：subtle、单色系、有意图地点缀（比如button hover）
+**❌ Aggressive gradient backgrounds**
+- Purple → pink → blue full-screen gradient (the classic AI-generated webpage flavor)
+- Rainbow gradient in any direction
+- Mesh gradient covering the whole background
+- ✅ If you must use a gradient: subtle, single hue, intentionally placed (e.g., button hover)
 
-**❌ 圆角卡片 + 左border accent色**
+**❌ Rounded card + left border accent color**
 ```css
-/* 这是AI味卡片的典型签名 */
+/* The signature look of an AI-flavored card */
 .card {
   border-radius: 12px;
   border-left: 4px solid #3b82f6;
   padding: 16px;
 }
 ```
-这种卡片在AI生成的Dashboard里泛滥。想做强调？用更有设计感的方式：背景色对比、字重/字号对比、plain分隔线、或者干脆不分卡片。
+This card style is everywhere in AI-generated dashboards. Want emphasis? Use a more design-forward approach: background color contrast, weight / size contrast, plain dividers, or just drop the card altogether.
 
-**❌ Emoji 装饰**
-除非品牌本身使用emoji（比如Notion、Slack），否则不要在UI上放emoji。**尤其不要**：
-- 标题前的 🚀 ⚡️ ✨ 🎯 💡
-- Feature列表的 ✅
-- CTA按钮里的 →（箭头单独出现OK，emoji箭头不行）
+**❌ Emoji decoration**
+Unless the brand itself uses emoji (e.g., Notion, Slack), don't put emoji in UI. **Especially don't**:
+- 🚀 ⚡️ ✨ 🎯 💡 in front of headings
+- ✅ in feature lists
+- → inside CTA buttons (a standalone arrow is fine, an emoji arrow isn't)
 
-没图标用真icon库（Lucide/Heroicons/Phosphor），或者用placeholder。
+If you lack an icon, use a real icon library (Lucide / Heroicons / Phosphor), or a placeholder.
 
-**❌ SVG 画 imagery**
-不要试图用SVG画：人物、场景、设备、物品、抽象艺术。AI画的SVG imagery一眼就是AI味，幼稚且廉价。**一个灰色矩形+"插画位 1200×800"的文字标签，比一个拙劣的SVG hero illustration强100倍**。
+**❌ Drawing imagery in SVG**
+Don't try to draw people, scenes, devices, objects, or abstract art in SVG. AI-drawn SVG imagery screams AI on sight — naive and cheap. **A gray rectangle plus the text "illustration slot 1200×800" beats a clumsy SVG hero illustration 100×**.
 
-唯一可以用SVG的场景：
-- 真正的icon（16×16到32×32级别）
-- 几何图形做装饰元素
-- Data viz的chart
+The only scenarios where SVG is fine:
+- Actual icons (16×16 to 32×32 scale)
+- Geometric shapes as decorative elements
+- Data viz charts
 
-**❌ 过多iconography**
-不是每个标题/feature/section都需要icon。滥用icon会让界面像toy。Less is more。
+**❌ Excess iconography**
+Not every heading / feature / section needs an icon. Overused icons make the UI feel like a toy. Less is more.
 
 **❌ "Data slop"**
-编造的stats装饰：
-- "10,000+ happy customers" （你都不知道有没有）
-- "99.9% uptime" （没有真数据就别写）
-- 用图标+数字+词组成的装饰"metric cards"
-- Mock table里的假数据装点得花里胡哨
+Fabricated stats as decoration:
+- "10,000+ happy customers" (you don't even know if it's true)
+- "99.9% uptime" (don't write it without real numbers)
+- Decorative "metric cards" of icon + number + word
+- Fake data dressed up gaudily in mock tables
 
-如果没真数据，留placeholder或问用户要。
+If you have no real data, leave a placeholder or ask the user.
 
 **❌ "Quote slop"**
-编造的用户评价、名人名言装饰页面。留placeholder问用户要真quote。
+Fabricated user testimonials and celebrity quotes used as decoration. Leave a placeholder and ask the user for real quotes.
 
-### 字体陷阱
+### Type Traps
 
-**❌ 避免这些烂大街字体**：
-- Inter（AI生成的网页默认）
+**❌ Avoid these cliché fonts**:
+- Inter (AI-generated webpage default)
 - Roboto
 - Arial / Helvetica
-- 纯system font stack
-- Fraunces（AI发现了这个就用滥了）
-- Space Grotesk（最近AI的最爱）
+- Pure system font stack
+- Fraunces (AI found it and ran it into the ground)
+- Space Grotesk (recent AI favorite)
 
-**✅ 用有特点的display+body配对**。灵感方向：
-- 衬线display + 无衬线body（editorial feel）
-- Mono display + sans body（technical feel）
-- Heavy display + light body（contrast）
-- Variable font做hero的粗细动画
+**✅ Use a distinctive display + body pairing**. Directions:
+- Serif display + sans body (editorial feel)
+- Mono display + sans body (technical feel)
+- Heavy display + light body (contrast)
+- Variable font animating weight in the hero
 
-字体资源：
-- Google Fonts的冷门好选项（Instrument Serif、Cormorant、Bricolage Grotesque、JetBrains Mono）
-- 开源字体站（Fraunces的兄弟字体、Adobe Fonts）
-- 不要凭空发明字体名
+Font sources:
+- Underrated Google Fonts options (Instrument Serif, Cormorant, Bricolage Grotesque, JetBrains Mono)
+- Open-source font sites (Fraunces' siblings, Adobe Fonts)
+- Don't invent font names from thin air
 
-### 色彩陷阱
+### Color Traps
 
-**❌ 凭空发明颜色**
-不要从头设计一整套不熟悉的色彩。这通常不和谐。
+**❌ Inventing colors from a blank slate**
+Don't design a full unfamiliar palette from scratch. It usually doesn't harmonize.
 
-**✅ 策略**：
-1. 有品牌色 → 用品牌色，缺的color token用oklch插值
-2. 没有品牌色但有参考 → 从参考产品截图吸色
-3. 完全从零 → 选一个known的配色系统（Radix Colors / Tailwind默认palette / Anthropic brand），不要自己调
+**✅ Strategy**:
+1. Have a brand color → use it, interpolate missing color tokens with oklch
+2. No brand color but have references → pick colors from reference product screenshots
+3. Fully from scratch → pick a known color system (Radix Colors / Tailwind default palette / Anthropic brand), don't roll your own
 
-**oklch定义色彩**是最现代的做法：
+**Defining color with oklch** is the modern way:
 ```css
 :root {
-  --primary: oklch(0.65 0.18 25);      /* 温暖的terracotta */
-  --primary-light: oklch(0.85 0.08 25); /* 同色系浅色 */
-  --primary-dark: oklch(0.45 0.20 25);  /* 同色系深色 */
+  --primary: oklch(0.65 0.18 25);      /* warm terracotta */
+  --primary-light: oklch(0.85 0.08 25); /* same hue, lighter */
+  --primary-dark: oklch(0.45 0.20 25);  /* same hue, darker */
 }
 ```
-oklch能保证调整亮度时色相不漂移，比hsl好用。
+oklch keeps hue stable when you adjust lightness — better than hsl.
 
-**❌ 夜间模式随手加反色**
-不是简单invert颜色。好的dark mode需要重新调整饱和度、对比度、accent色。不想做dark mode就别做。
+**❌ Casually inverting colors for dark mode**
+Not a simple color invert. Good dark mode needs re-tuned saturation, contrast, accent colors. Don't want to do dark mode? Don't do it.
 
-### Layout陷阱
+### Layout Traps
 
-**❌ Bento grid 过度泛滥**
-每个AI生成的landing page都想搞bento。除非你的信息structure确实适合bento，否则用其他layout。
+**❌ Bento grid overload**
+Every AI-generated landing page wants a bento. Unless your information structure really suits bento, use another layout.
 
-**❌ 大hero + 3-column features + testimonials + CTA**
-这个landing page模板被用烂了。想创新就真创新。
+**❌ Big hero + 3-column features + testimonials + CTA**
+This landing page template is worn out. Want to innovate? Actually innovate.
 
-**❌ Card grid里每个card长一样**
-Asymmetric、不同大小的cards、有的带image有的只有文字、有的跨列——这才像真设计师做的。
+**❌ Card grid where every card looks the same**
+Asymmetric, varied sizes, some with images and some text-only, some spanning columns — that's what a real designer's work looks like.
 
-## 内容准则
+## Content Rules
 
 ### 1. Don't add filler content
 
-每个元素都必须earn its place。空白是设计问题，用**构图**解决（对比、节奏、留白），**不是**靠内容填满。
+Every element must earn its place. White space is a design problem solved by **composition** (contrast, rhythm, breathing room), **not** by stuffing it with content.
 
-**判断filler的问题**：
-- 如果去掉这段内容，设计会变差吗？答案若是"不会"，就去掉。
-- 这个元素解决了什么真问题？如果是"让页面不那么空"，删掉。
-- 这个stats/quote/feature有真数据支持吗？没有就不要凭空写。
+**Filler test**:
+- If removing this content makes the design worse, keep it. If the answer is "no", remove it.
+- What real problem does this element solve? If it's "makes the page feel less empty", delete it.
+- Is there real data backing this stat / quote / feature? No? Don't fabricate.
 
-「One thousand no's for every yes」。
+"One thousand no's for every yes."
 
 ### 2. Ask before adding material
 
-你觉得多加一段/一页/一个section会更好？先问用户，不要单方面加。
+Think one more section / page / paragraph would be better? Ask the user first, don't add unilaterally.
 
-原因：
-- 用户知道他的受众比你清楚
-- 加内容有成本，用户可能不想要
-- 单方面加内容违反了"junior designer汇报工作"的关系
+Why:
+- The user knows their audience better than you
+- Adding content has a cost; the user may not want it
+- Adding unilaterally violates the "junior designer reporting to manager" relationship
 
 ### 3. Create a system up front
 
-探索完design context后，**先口头说出你要用的系统**，让用户确认：
+After exploring design context, **state the system you're going to use** verbally and have the user confirm:
 
 ```markdown
-我的设计系统：
-- 色彩：#1A1A1A主体 + #F0EEE6背景 + #D97757 accent（来自你的品牌）
-- 字型：Instrument Serif做display + Geist Sans做body
-- 节奏：section title用full-bleed彩色背景 + 白字；普通section用白背景
-- 图像：hero用full-bleed照片，feature section用placeholder等你提供
-- 最多用2种背景色，避免杂乱
+My design system:
+- Color: #1A1A1A body + #F0EEE6 background + #D97757 accent (from your brand)
+- Type: Instrument Serif for display + Geist Sans for body
+- Rhythm: section titles get a full-bleed colored background with white text; regular sections get white background
+- Imagery: full-bleed photo in hero, feature sections get placeholders pending your assets
+- At most 2 background colors, to avoid clutter
 
-确认这个方向我就开始做。
+Confirm and I start building.
 ```
 
-用户确认后再动手。这个check-in能避免"做完一半发现方向错"。
+Move once the user confirms. This check-in prevents "halfway in we realize the direction is wrong".
 
-## Scale 规范
+## Scale Spec
 
-### 幻灯片（1920×1080）
+### Slides (1920×1080)
 
-- 正文最小 **24px**，理想 28-36px
-- 标题 60-120px
+- Body minimum **24px**, ideal 28-36px
+- Title 60-120px
 - Section title 80-160px
-- Hero headline 可以用 180-240px 的大字
-- 永远不要用 <24px 的字放幻灯片
+- Hero headline can run 180-240px
+- Never use <24px text in slides
 
-### 印刷文档
+### Print Documents
 
-- 正文最小 **10pt**（≈13.3px），理想 11-12pt
-- 标题 18-36pt
+- Body minimum **10pt** (≈13.3px), ideal 11-12pt
+- Title 18-36pt
 - Caption 8-9pt
 
-### Web和移动端
+### Web and Mobile
 
-- 正文最小 **14px**（老年人友好用16px）
-- 移动端正文 **16px**（避免iOS自动缩放）
-- Hit target（可点击元素）最小 **44×44px**
-- 行高 1.5-1.7（中文1.7-1.8）
+- Body minimum **14px** (16px if elderly-friendly)
+- Mobile body **16px** (avoids iOS auto-zoom)
+- Hit target (clickable element) minimum **44×44px**
+- Line height 1.5-1.7 (Chinese 1.7-1.8)
 
-### 对比度
+### Contrast
 
-- 正文 vs 背景 **至少 4.5:1**（WCAG AA）
-- 大字 vs 背景 **至少 3:1**
-- 用Chrome DevTools的accessibility工具检查
+- Body vs background **at least 4.5:1** (WCAG AA)
+- Large text vs background **at least 3:1**
+- Check with Chrome DevTools' accessibility tool
 
-## CSS 神器
+## CSS Power Tools
 
-**高级CSS特性**是设计师的好朋友，大胆用：
+**Advanced CSS features** are the designer's best friend — use them boldly:
 
-### 排版
+### Typography
 
 ```css
-/* 让标题换行更自然，不会最后一行孤单单一个词 */
+/* Lets headings wrap more naturally, no lonely last-line word */
 h1, h2, h3 { text-wrap: balance; }
 
-/* 正文换行，避免寡孀和孤儿 */
+/* Body text wrap, avoids widows and orphans */
 p { text-wrap: pretty; }
 
-/* 中文排版神器：标点挤压、行首行尾控制 */
-p { 
+/* Power feature for Chinese typesetting: punctuation kerning, line-start/end control */
+p {
   text-spacing-trim: space-all;
   hanging-punctuation: first;
 }
@@ -200,7 +200,7 @@ p {
 ### Layout
 
 ```css
-/* CSS Grid + named areas = 可读性爆表 */
+/* CSS Grid + named areas = readability through the roof */
 .layout {
   display: grid;
   grid-template-areas:
@@ -211,50 +211,50 @@ p {
   grid-template-rows: auto 1fr auto;
 }
 
-/* Subgrid对齐卡片内容 */
+/* Subgrid aligns card contents */
 .card { display: grid; grid-template-rows: subgrid; }
 ```
 
-### 视觉效果
+### Visual Effects
 
 ```css
-/* 有设计感的滚动条 */
+/* Designed scrollbars */
 * { scrollbar-width: thin; scrollbar-color: #666 transparent; }
 
-/* 玻璃拟态（克制使用） */
+/* Glassmorphism (use sparingly) */
 .glass {
   backdrop-filter: blur(20px) saturate(150%);
   background: color-mix(in oklch, white 70%, transparent);
 }
 
-/* View transitions API让页面切换丝滑 */
+/* View Transitions API for smooth page transitions */
 @view-transition { navigation: auto; }
 ```
 
-### 交互
+### Interaction
 
 ```css
-/* :has()选择器让条件样式变容易 */
-.card:has(img) { padding-top: 0; } /* 有图片的卡片无顶padding */
+/* :has() selector makes conditional styles easy */
+.card:has(img) { padding-top: 0; } /* cards with an image get no top padding */
 
-/* container queries让组件真的响应式 */
+/* Container queries make components actually responsive */
 @container (min-width: 500px) { ... }
 
-/* 新的color-mix函数 */
+/* The new color-mix function */
 .button:hover {
   background: color-mix(in oklch, var(--primary) 85%, black);
 }
 ```
 
-## 决策速查：当你犹豫时
+## Decision Cheat Sheet: When You Hesitate
 
-- 想加个渐变？→ 大概率不加
-- 想加个emoji？→ 不加
-- 想给卡片加圆角+border-left accent？→ 不加，换其他方式
-- 想用SVG画个hero插画？→ 不画，用placeholder
-- 想加一段quote装饰？→ 先问用户有没有真quote
-- 想加一排icon features？→ 先问要不要icon，可能不需要
-- 用Inter？→ 换一个更有特点的
-- 用紫色渐变？→ 换一个有根据的配色
+- Thinking of adding a gradient? → Probably don't
+- Thinking of adding an emoji? → Don't
+- Thinking of giving the card a rounded + border-left accent? → Don't, use another approach
+- Thinking of drawing a hero illustration in SVG? → Don't, use a placeholder
+- Thinking of adding a decorative quote? → Ask the user for a real quote first
+- Thinking of adding a row of icon features? → Ask whether icons are needed; maybe not
+- Reaching for Inter? → Pick something more distinctive
+- Reaching for a purple gradient? → Pick a palette with grounding
 
-**当你觉得"加一下会更好看"的时候——那通常是AI slop的征兆**。先做最简的版本，只在用户要求时加。
+**When you feel "adding this would look better" — that's usually the sign of AI slop**. Do the most stripped-down version first, only add when the user asks.

--- a/references/critique-guide.md
+++ b/references/critique-guide.md
@@ -1,199 +1,199 @@
-# 设计评审深度指南
+# Deep Design Critique Guide
 
-> Phase 7 的详细参考。提供评分标准、场景侧重点、常见问题清单。
-
----
-
-## 评分标准详解
-
-### 1. 哲学一致性（Philosophy Alignment）
-
-| 分数 | 标准 |
-|------|------|
-| 9-10 | 设计完美体现了选定哲学的核心精神，每个细节都有哲学依据 |
-| 7-8 | 整体方向正确，核心特征到位，个别细节偏离 |
-| 5-6 | 能看出意图，但执行时混入了其他风格元素，不够纯粹 |
-| 3-4 | 仅在表面模仿，未理解哲学内核 |
-| 1-2 | 与选定哲学基本无关 |
-
-**评审要点**：
-- 是否使用了该设计师/机构的标志性手法？
-- 色彩、字体、布局是否符合该哲学体系？
-- 有没有「自相矛盾」的元素？（如选了Kenya Hara却塞满内容）
-
-### 2. 视觉层级（Visual Hierarchy）
-
-| 分数 | 标准 |
-|------|------|
-| 9-10 | 用户视线自然沿设计者意图流动，信息获取零摩擦 |
-| 7-8 | 主次关系清晰，偶有1-2处层级模糊 |
-| 5-6 | 能分出标题和正文，但中间层级混乱 |
-| 3-4 | 信息平铺，没有明确的视觉入口 |
-| 1-2 | 混乱，用户不知道先看哪里 |
-
-**评审要点**：
-- 标题与正文的字号对比是否足够？（至少2.5倍）
-- 颜色/粗细/大小是否建立了3-4个清晰层级？
-- 留白是否在引导视线？
-- 「眯眼测试」：眯起眼看，层级是否仍然清晰？
-
-### 3. 细节执行（Craft Quality）
-
-| 分数 | 标准 |
-|------|------|
-| 9-10 | 像素级精确，对齐、间距、颜色无任何瑕疵 |
-| 7-8 | 整体精致，有1-2处微小对齐/间距问题 |
-| 5-6 | 基本对齐，但间距不统一，颜色使用不够系统 |
-| 3-4 | 明显的对齐错误、间距混乱、颜色过多 |
-| 1-2 | 粗糙，看起来像草稿 |
-
-**评审要点**：
-- 是否使用了统一的间距系统（如8pt网格）？
-- 同类元素的间距是否一致？
-- 颜色数量是否受控？（通常不超过3-4种）
-- 字体家族是否统一？（通常不超过2种）
-- 边缘对齐是否精确？
-
-### 4. 功能性（Functionality）
-
-| 分数 | 标准 |
-|------|------|
-| 9-10 | 每个设计元素都服务于目标，零冗余 |
-| 7-8 | 功能导向明确，有少量可删减的装饰 |
-| 5-6 | 基本可用，但有明显的装饰性元素分散注意力 |
-| 3-4 | 形式大于功能，用户需要努力寻找信息 |
-| 1-2 | 完全被装饰淹没，失去了传达信息的能力 |
-
-**评审要点**：
-- 删掉任何一个元素，设计会变差吗？（如果不会，就应该删）
-- CTA/关键信息是否在最显眼的位置？
-- 是否有「因为好看所以加上去」的元素？
-- 信息密度与载体是否匹配？（PPT不宜太密，PDF可以更密）
-
-### 5. 创新性（Originality）
-
-| 分数 | 标准 |
-|------|------|
-| 9-10 | 令人耳目一新，在该哲学框架内找到了独特表达 |
-| 7-8 | 有自己的想法，不是简单的模板套用 |
-| 5-6 | 中规中矩，看起来像模板 |
-| 3-4 | 大量使用了cliché（如渐变圆球代表AI） |
-| 1-2 | 完全是模板或素材拼凑 |
-
-**评审要点**：
-- 是否避免了常见cliché？（见下方「常见问题清单」）
-- 在遵循设计哲学的同时是否有个人表达？
-- 是否有「意想不到但很合理」的设计决策？
+> Detailed reference for Phase 7. Provides scoring criteria, scenario-specific emphases, common-problem checklists.
 
 ---
 
-## 场景评审侧重
+## Scoring Criteria in Detail
 
-不同输出类型的评审重点不同：
+### 1. Philosophy Alignment
 
-| 场景 | 最重要维度 | 次重要 | 可放宽 |
+| Score | Criteria |
+|------|------|
+| 9-10 | Design perfectly embodies the spirit of the chosen philosophy; every detail has a philosophical basis |
+| 7-8 | Overall direction is right, core traits land, individual details drift |
+| 5-6 | Intent is visible, but execution mixes in other style elements; not pure enough |
+| 3-4 | Surface mimicry only; the philosophical core isn't understood |
+| 1-2 | Essentially unrelated to the chosen philosophy |
+
+**Review points**:
+- Are the chosen designer/studio's signature moves used?
+- Do color, type, and layout fit that philosophical system?
+- Are there "self-contradictory" elements? (e.g., choosing Kenya Hara but cramming it full of content)
+
+### 2. Visual Hierarchy
+
+| Score | Criteria |
+|------|------|
+| 9-10 | The user's eye naturally flows along the designer's intent; zero friction acquiring information |
+| 7-8 | Primary/secondary relationships clear, 1-2 spots with ambiguous hierarchy |
+| 5-6 | Title and body distinguish, but middle levels are muddled |
+| 3-4 | Information is flat, no clear visual entry point |
+| 1-2 | Chaotic, the user doesn't know where to look first |
+
+**Review points**:
+- Is the font-size contrast between title and body sufficient? (at least 2.5×)
+- Do color / weight / size establish 3-4 clear hierarchy levels?
+- Is white space guiding the eye?
+- "Squint test": squint at it — is the hierarchy still clear?
+
+### 3. Craft Quality
+
+| Score | Criteria |
+|------|------|
+| 9-10 | Pixel-precise; alignment, spacing, color flawless |
+| 7-8 | Overall polished, 1-2 minor alignment/spacing issues |
+| 5-6 | Mostly aligned, but spacing isn't consistent, color use isn't systematic |
+| 3-4 | Obvious alignment errors, spacing chaos, too many colors |
+| 1-2 | Rough, looks like a draft |
+
+**Review points**:
+- Is a unified spacing system used (e.g., 8pt grid)?
+- Is spacing consistent across like elements?
+- Is the color count controlled? (usually no more than 3-4)
+- Is the font family unified? (usually no more than 2)
+- Are edges precisely aligned?
+
+### 4. Functionality
+
+| Score | Criteria |
+|------|------|
+| 9-10 | Every design element serves the goal; zero redundancy |
+| 7-8 | Function-driven, with a small amount of removable decoration |
+| 5-6 | Usable, but obvious decorative elements distract |
+| 3-4 | Form over function; users have to work to find information |
+| 1-2 | Drowned in decoration, has lost the ability to convey information |
+
+**Review points**:
+- If you delete any single element, does the design get worse? (If no, delete it)
+- Is the CTA / key information in the most prominent position?
+- Are there elements added "because it looks good"?
+- Does information density match the medium? (slides shouldn't be too dense, PDFs can be denser)
+
+### 5. Originality
+
+| Score | Criteria |
+|------|------|
+| 9-10 | Refreshing — found a unique expression within the philosophical frame |
+| 7-8 | Has its own ideas, not just template-applied |
+| 5-6 | Middle of the road, looks like a template |
+| 3-4 | Leans heavily on clichés (e.g., gradient orbs to represent AI) |
+| 1-2 | Pure template or stock-asset assembly |
+
+**Review points**:
+- Did it avoid common clichés? (see "Common Problems checklist" below)
+- Is there personal expression alongside fidelity to the design philosophy?
+- Are there "unexpected but justified" design decisions?
+
+---
+
+## Scenario-Specific Critique Emphasis
+
+Different output types weight critique differently:
+
+| Scenario | Most important | Secondary | Can relax |
 |------|-----------|--------|--------|
-| 公众号封面/配图 | 创新性、视觉层级 | 哲学一致性 | 功能性（单图不涉及交互） |
-| 信息图 | 功能性、视觉层级 | 细节执行 | 创新性（准确优先） |
-| PPT/Keynote | 视觉层级、功能性 | 细节执行 | 创新性（清晰优先） |
-| PDF/白皮书 | 细节执行、功能性 | 视觉层级 | 创新性（专业优先） |
-| 落地页/官网 | 功能性、视觉层级 | 创新性 | —（全面要求） |
-| App UI | 功能性、细节执行 | 视觉层级 | 哲学一致性（可用性优先） |
-| 小红书配图 | 创新性、视觉层级 | 哲学一致性 | 细节执行（氛围优先） |
+| WeChat public account cover/insert | Originality, visual hierarchy | Philosophy alignment | Functionality (single image, no interaction) |
+| Infographic | Functionality, visual hierarchy | Craft quality | Originality (accuracy first) |
+| PPT / Keynote | Visual hierarchy, functionality | Craft quality | Originality (clarity first) |
+| PDF / whitepaper | Craft quality, functionality | Visual hierarchy | Originality (professionalism first) |
+| Landing page / website | Functionality, visual hierarchy | Originality | — (all required) |
+| App UI | Functionality, craft quality | Visual hierarchy | Philosophy alignment (usability first) |
+| Xiaohongshu image | Originality, visual hierarchy | Philosophy alignment | Craft quality (vibe first) |
 
 ---
 
-## 常见设计问题 Top 10
+## Common Design Problems Top 10
 
-### 1. AI科技cliché
-**问题**：渐变圆球、数字雨、蓝色电路板、机器人脸
-**为什么是问题**：用户已经对这些视觉疲劳，无法区分你和其他人
-**修复**：用抽象隐喻替代直白符号（如用「对话」的隐喻而非聊天气泡图标）
+### 1. AI tech clichés
+**Problem**: gradient orbs, digital rain, blue circuit boards, robot faces
+**Why it's a problem**: users are visually exhausted by these — they can't tell you apart from anyone else
+**Fix**: replace direct symbols with abstract metaphors (e.g., a "dialogue" metaphor instead of a chat-bubble icon)
 
-### 2. 字号层级不足
-**问题**：标题和正文差距太小（<2.5倍）
-**为什么是问题**：用户无法快速定位关键信息
-**修复**：标题至少为正文的3倍（如正文16px → 标题48-64px）
+### 2. Insufficient type hierarchy
+**Problem**: the gap between title and body is too small (<2.5×)
+**Why it's a problem**: users can't quickly locate key information
+**Fix**: title at least 3× the body (e.g., body 16px → title 48-64px)
 
-### 3. 颜色过多
-**问题**：使用5种以上颜色，没有主次
-**为什么是问题**：视觉混乱，品牌感弱
-**修复**：限制为1个主色+1个辅色+1个强调色+灰阶
+### 3. Too many colors
+**Problem**: 5+ colors used with no hierarchy
+**Why it's a problem**: visual chaos, weak brand feel
+**Fix**: limit to 1 primary + 1 secondary + 1 accent + grayscale
 
-### 4. 间距不统一
-**问题**：元素间距随意，没有系统
-**为什么是问题**：看起来不专业，视觉节奏混乱
-**修复**：建立8pt网格系统（间距只用8/16/24/32/48/64px）
+### 4. Inconsistent spacing
+**Problem**: arbitrary spacing between elements, no system
+**Why it's a problem**: looks unprofessional, visual rhythm is muddled
+**Fix**: establish an 8pt grid system (only use 8/16/24/32/48/64px)
 
-### 5. 留白不足
-**问题**：所有空间都被内容填满
-**为什么是问题**：信息拥挤导致阅读疲劳，反而降低信息传达效率
-**修复**：留白至少占总面积40%（极简风格60%+）
+### 5. Insufficient white space
+**Problem**: every spot is filled with content
+**Why it's a problem**: information overcrowding causes reading fatigue, lowers transfer efficiency
+**Fix**: white space at least 40% of total area (minimalist styles 60%+)
 
-### 6. 字体过多
-**问题**：使用3种以上字体
-**为什么是问题**：视觉噪音，削弱统一感
-**修复**：最多2种字体（1种标题+1种正文），用字重和大小创造变化
+### 6. Too many fonts
+**Problem**: 3+ fonts used
+**Why it's a problem**: visual noise, weakens unity
+**Fix**: at most 2 fonts (1 title + 1 body); create variation via weight and size
 
-### 7. 对齐不一致
-**问题**：有的左对齐，有的居中，有的右对齐
-**为什么是问题**：破坏视觉秩序感
-**修复**：选定一种对齐方式（推荐左对齐），全局统一
+### 7. Inconsistent alignment
+**Problem**: some left-aligned, some centered, some right-aligned
+**Why it's a problem**: breaks visual order
+**Fix**: pick one alignment (left recommended), apply globally
 
-### 8. 装饰大于内容
-**问题**：背景图案/渐变/阴影抢了主要内容的风头
-**为什么是问题**：本末倒置，用户来看信息不是看装饰
-**修复**：「如果删掉这个装饰，设计会变差吗？」如果不会，就删
+### 8. Decoration overpowering content
+**Problem**: background patterns / gradients / shadows steal the show from the main content
+**Why it's a problem**: priorities inverted — users came for information, not decoration
+**Fix**: "If I delete this decoration, does the design get worse?" If no, delete it
 
-### 9. 赛博霓虹滥用
-**问题**：深蓝底(#0D1117) + 霓虹色发光效果
-**为什么是问题**：默认审美禁区（本 skill 的品位基线），且已成为最大 cliché 之一——用户可按自己品牌 override
-**修复**：选择更有辨识度的配色方案（参考20种风格的色彩系统）
+### 9. Cyber-neon overuse
+**Problem**: deep blue base (#0D1117) + neon glow effect
+**Why it's a problem**: default aesthetic no-go zone (this skill's taste baseline), and one of the biggest clichés — the user can override this for their own brand
+**Fix**: pick a more distinctive palette (see the color systems of the 20 styles)
 
-### 10. 信息密度与载体不匹配
-**问题**：PPT里放了一整页文字 / 封面图里塞了10个元素
-**为什么是问题**：不同载体的最佳信息密度不同
-**修复**：
-- PPT：每页1个核心观点
-- 封面图：1个视觉焦点
-- 信息图：分层展示
-- PDF：可以更密，但需要清晰的导航
+### 10. Information density doesn't match medium
+**Problem**: an entire page of text in a slide / 10 elements crammed into a cover image
+**Why it's a problem**: different mediums have different optimal densities
+**Fix**:
+- Slides: 1 core point per page
+- Cover image: 1 visual focus
+- Infographic: layered presentation
+- PDF: can be denser, but needs clear navigation
 
 ---
 
-## 评审输出模板
+## Critique Output Template
 
 ```
-## 设计评审报告
+## Design Critique Report
 
-**总体评分**：X.X/10 [优秀(8+)/良好(6-7.9)/需改进(4-5.9)/不合格(<4)]
+**Overall score**: X.X/10 [Excellent (8+) / Good (6-7.9) / Needs work (4-5.9) / Failing (<4)]
 
-**分项评分**：
-- 哲学一致性：X/10 [一句话说明]
-- 视觉层级：X/10 [一句话说明]
-- 细节执行：X/10 [一句话说明]
-- 功能性：X/10 [一句话说明]
-- 创新性：X/10 [一句话说明]
+**Per-axis scores**:
+- Philosophy alignment: X/10 [one-line note]
+- Visual hierarchy: X/10 [one-line note]
+- Craft quality: X/10 [one-line note]
+- Functionality: X/10 [one-line note]
+- Originality: X/10 [one-line note]
 
-### 优点（Keep）
-- [具体指出做得好的地方，用设计语言描述]
+### Strengths (Keep)
+- [Call out specifically what works, in design language]
 
-### 问题（Fix）
-[按严重程度排序]
+### Issues (Fix)
+[Sorted by severity]
 
-**1. [问题名称]** — ⚠️致命 / ⚡重要 / 💡优化
-- 当前：[描述现状]
-- 问题：[为什么这是问题]
-- 修复：[具体操作，含数值]
+**1. [Issue name]** — ⚠️ Critical / ⚡ Important / 💡 Polish
+- Currently: [describe state]
+- Problem: [why it's a problem]
+- Fix: [specific action, with values]
 
-### 快速修复清单（Quick Wins）
-如果只有5分钟，优先做这3件事：
-- [ ] [最有影响力的修复]
-- [ ] [第二重要的修复]
-- [ ] [第三重要的修复]
+### Quick Wins
+If you only have 5 minutes, prioritize these 3:
+- [ ] [Highest-impact fix]
+- [ ] [Second priority]
+- [ ] [Third priority]
 ```
 
 ---
 
-**版本**：v1.0
-**更新日期**：2026-02-13
+**Version**: v1.0
+**Updated**: 2026-02-13

--- a/references/design-context.md
+++ b/references/design-context.md
@@ -1,171 +1,171 @@
-# Design Context：从已有上下文出发
+# Design Context: Start from What's Already There
 
-**这是这个skill最重要的one thing。**
+**This is the most important one thing in this skill.**
 
-好的hi-fi设计一定是从已有design context长出来的。**凭空做hi-fi是last resort，一定会产出generic的作品**。所以每次设计任务开始，先问：有没有可以参考的东西？
+Good hi-fi design always grows out of existing design context. **Doing hi-fi from a blank slate is a last resort — it will always produce something generic**. So at the start of every design task, ask: is there anything to reference?
 
-## 什么是Design Context
+## What Counts as Design Context
 
-按优先级从高到低：
+In priority order, high to low:
 
-### 1. 用户的Design System/UI Kit
-用户自己产品已有的组件库、色彩token、字型规范、icon系统。**最完美的情况**。
+### 1. The user's Design System / UI Kit
+The user's own product's component library, color tokens, type spec, icon system. **The ideal case**.
 
-### 2. 用户的Codebase
-如果用户给了代码库，里面就有活生生的组件实现。Read那些组件文件：
+### 2. The user's Codebase
+If the user provides a codebase, it contains living component implementations. Read those component files:
 - `theme.ts` / `colors.ts` / `tokens.css` / `_variables.scss`
-- 具体的组件（Button.tsx、Card.tsx）
-- Layout scaffold（App.tsx、MainLayout.tsx）
+- Specific components (Button.tsx, Card.tsx)
+- Layout scaffolds (App.tsx, MainLayout.tsx)
 - Global stylesheets
 
-**读代码抄exact values**：hex codes、spacing scale、font stack、border radius。不要凭记忆重画。
+**Read the code and copy exact values**: hex codes, spacing scale, font stack, border radius. Don't redraw from memory.
 
-### 3. 用户已发布的产品
-如果用户有上线的产品但没给代码，用Playwright或让用户提供截图。
+### 3. The user's shipped product
+If the user has a live product but no code, use Playwright or ask for screenshots.
 
 ```bash
-# 用Playwright截图一个公开URL
+# Screenshot a public URL with Playwright
 npx playwright screenshot https://example.com screenshot.png --viewport-size=1920,1080
 ```
 
-让你看到真实的视觉vocabulary。
+This lets you see the real visual vocabulary.
 
-### 4. 品牌指南/Logo/已有素材
-用户可能有：Logo文件、品牌色规范、营销物料、slide模板。这些都是context。
+### 4. Brand guidelines / Logo / existing assets
+The user may have: logo files, brand color spec, marketing materials, slide templates. These are all context.
 
-### 5. 竞品参考
-用户说"像XX网站那样"——让他提供URL或截图。**不要**凭你训练数据里的模糊印象做。
+### 5. Competitor references
+If the user says "like that XX site" — have them provide the URL or a screenshot. **Don't** work from a vague impression in your training data.
 
-### 6. 已知的design system（fallback）
-如果以上都没有，用公认的设计系统作为base：
+### 6. Known design systems (fallback)
+If none of the above exist, use a recognized design system as a base:
 - Apple HIG
 - Material Design 3
-- Radix Colors（配色）
-- shadcn/ui（组件）
-- Tailwind默认palette
+- Radix Colors (palette)
+- shadcn/ui (components)
+- Tailwind default palette
 
-明确告诉用户你用的什么，让他知道这是起点不是定稿。
+Tell the user explicitly what you're using, so they know it's a starting point, not the final answer.
 
-## 获取Context的流程
+## Workflow for Acquiring Context
 
-### Step 1：问用户
+### Step 1: Ask the user
 
-任务开始时的必问清单（来自`workflow.md`）：
+Required questions at task start (from `workflow.md`):
 
 ```markdown
-1. 你有现成的design system/UI kit/组件库吗？在哪？
-2. 有品牌指南、色彩/字体规范吗？
-3. 可以给我现有产品的截图或URL吗？
-4. 有codebase我可以读吗？
+1. Do you have an existing design system / UI kit / component library? Where?
+2. Brand guidelines, color / type spec?
+3. Can you share screenshots or URLs of the existing product?
+4. Is there a codebase I can read?
 ```
 
-### Step 2：用户说"没有"时，帮他找
+### Step 2: When the user says "no", help them find it
 
-别直接放弃。尝试：
+Don't give up immediately. Try:
 
 ```markdown
-让我看看有没有线索：
-- 你之前的项目有相关设计吗？
-- 公司的marketing网站用什么色彩/字型？
-- 你产品的Logo什么风格？能给我一张吗？
-- 有什么你欣赏的产品作为参考？
+Let me look for clues:
+- Do your past projects have related designs?
+- What colors / type does your marketing site use?
+- What style is your product's logo? Got an image?
+- Any product you admire as a reference?
 ```
 
-### Step 3：Read所有能找到的context
+### Step 3: Read every piece of context you can find
 
-如果用户给了codebase路径，你读：
-1. **先list文件结构**：找style/theme/component相关的文件
-2. **读theme/token文件**：lift具体的hex/px values
-3. **读2-3个代表性组件**：看视觉vocabulary（hover state、shadow、border、padding node pattern）
-4. **读global stylesheet**：基础重置、font loading
-5. **如果有Figma链接/截图**：看图，但**更相信代码**
+If the user provided a codebase path, you read:
+1. **List the file structure first**: find style / theme / component-related files
+2. **Read theme / token files**: lift specific hex / px values
+3. **Read 2-3 representative components**: see the visual vocabulary (hover state, shadow, border, padding node pattern)
+4. **Read the global stylesheet**: base reset, font loading
+5. **If there's a Figma link / screenshots**: look at the image, but **trust the code more**
 
-**重要**：**不要**看了一眼就凭印象做。读下来有30+个具体values才真的lift到了。
+**Important**: **Do not** glance once and design from impression. Lifting 30+ specific values is what counts as actually internalizing it.
 
-### Step 4：Vocalize你要用的系统
+### Step 4: Vocalize the system you're going to use
 
-看完context后，告诉用户你要用的系统：
+After reading the context, tell the user the system you're going to use:
 
 ```markdown
-根据你的codebase和产品截图，我提炼的设计系统：
+Based on your codebase and product screenshots, the design system I distilled:
 
-**色彩**
-- Primary: #C27558（从tokens.css）
+**Color**
+- Primary: #C27558 (from tokens.css)
 - Background: #FDF9F0
 - Text: #1A1A1A
 - Muted: #6B6B6B
 
-**字型**
-- Display: Instrument Serif（从global.css的@font-face）
+**Type**
+- Display: Instrument Serif (from @font-face in global.css)
 - Body: Geist Sans
 - Mono: JetBrains Mono
 
-**Spacing**（来自你的scale系统）
+**Spacing** (from your scale system)
 - 4, 8, 12, 16, 24, 32, 48, 64
 
 **Shadow pattern**
-- `0 1px 2px rgba(0,0,0,0.04)`（subtle card）
-- `0 10px 40px rgba(0,0,0,0.1)`（elevated modal）
+- `0 1px 2px rgba(0,0,0,0.04)` (subtle card)
+- `0 10px 40px rgba(0,0,0,0.1)` (elevated modal)
 
 **Border-radius**
-- 小组件 4px，卡片 12px，按钮 8px
+- Small elements 4px, cards 12px, buttons 8px
 
-**component vocabulary**
-- Button：filled primary，outlined secondary，ghost tertiary，全部圆角8px
-- Card：白色背景，subtle shadow，无border
+**Component vocabulary**
+- Button: filled primary, outlined secondary, ghost tertiary, all 8px radius
+- Card: white background, subtle shadow, no border
 
-我按这套系统开始做。确认没问题？
+I'll start building with this. Sound right?
 ```
 
-用户确认后再动手。
+Move once the user confirms.
 
-## 凭空做设计（没Context时的 fallback）
+## Designing from a Blank Slate (fallback when there's no context)
 
-**强烈警告**：这种情况下的产出质量会显著下降。明确告诉用户。
+**Strong warning**: output quality drops significantly in this case. Tell the user clearly.
 
 ```markdown
-你没有design context，我就只能基于通用直觉做。
-产出会是"看起来OK但缺乏独特性"的东西。
-你愿意继续，还是先补一些参考材料？
+You have no design context, so I can only work from generic intuition.
+The output will be "looks OK but lacks uniqueness".
+Want to keep going, or supply some reference material first?
 ```
 
-用户执意要你做，按这个顺序做决策：
+If the user insists, decide in this order:
 
-### 1. 选一个aesthetic direction
-不要给generic结果。挑一个明确方向：
+### 1. Pick an aesthetic direction
+Don't ship generic results. Pick a clear direction:
 - brutally minimal
-- editorial/magazine
-- brutalist/raw
-- organic/natural
-- luxury/refined
-- playful/toy
+- editorial / magazine
+- brutalist / raw
+- organic / natural
+- luxury / refined
+- playful / toy
 - retro-futuristic
-- soft/pastel
+- soft / pastel
 
-告诉用户你选了哪个。
+Tell the user which you picked.
 
-### 2. 选一个known design system作为骨架
-- 用Radix Colors做配色（https://www.radix-ui.com/colors）
-- 用shadcn/ui做组件vocabulary（https://ui.shadcn.com）
-- 用Tailwind spacing scale（4的倍数）
+### 2. Pick a known design system as a skeleton
+- Use Radix Colors for palette (https://www.radix-ui.com/colors)
+- Use shadcn/ui for component vocabulary (https://ui.shadcn.com)
+- Use Tailwind spacing scale (multiples of 4)
 
-### 3. 选有特点的字体配对
+### 3. Pick a distinctive type pairing
 
-不要用Inter/Roboto。建议组合（从Google Fonts白嫖）：
+Don't use Inter/Roboto. Suggested combos (free from Google Fonts):
 - Instrument Serif + Geist Sans
 - Cormorant Garamond + Inter Tight
-- Bricolage Grotesque + Söhne（付费）
-- Fraunces + Work Sans（注意Fraunces已经被AI用烂）
-- JetBrains Mono + Geist Sans（technical feel）
+- Bricolage Grotesque + Söhne (paid)
+- Fraunces + Work Sans (note: Fraunces has been overused by AI)
+- JetBrains Mono + Geist Sans (technical feel)
 
-### 4. 每个关键决策都有reasoning
+### 4. Every key decision gets reasoning
 
-不要默默选。在HTML的comment里写：
+Don't decide silently. Write it in an HTML comment:
 
 ```html
 <!--
 Design decisions:
-- Primary color: warm terracotta (oklch 0.65 0.18 25) — fits the "editorial" direction  
+- Primary color: warm terracotta (oklch 0.65 0.18 25) — fits the "editorial" direction
 - Display: Instrument Serif for humanist, literary feel
 - Body: Geist Sans for cleanness contrast
 - No gradients — committed to minimal, no AI slop
@@ -173,41 +173,41 @@ Design decisions:
 -->
 ```
 
-## Import策略（用户给了codebase）
+## Import Strategy (user gave you a codebase)
 
-如果用户说"import这个codebase做参考"：
+If the user says "import this codebase as reference":
 
-### 小型（<50文件）
-全部Read，把context内化。
+### Small (<50 files)
+Read all of it, internalize the context.
 
-### 中型（50-500文件）
-Focus在：
-- `src/components/` 或 `components/`
-- 所有styles/tokens/theme相关的文件
-- 2-3个代表性的整页组件（Home.tsx、Dashboard.tsx）
+### Medium (50-500 files)
+Focus on:
+- `src/components/` or `components/`
+- All styles / tokens / theme-related files
+- 2-3 representative full-page components (Home.tsx, Dashboard.tsx)
 
-### 大型（>500文件）
-让用户指明focus：
-- "我要做settings页面" → 读现有的settings相关
-- "我要做一个新的feature" → 读整体shell + 最接近的参考
-- 不求全，求准
+### Large (>500 files)
+Have the user point you at the focus:
+- "I want to do the settings page" → read existing settings-related code
+- "I'm doing a new feature" → read the overall shell + closest reference
+- Don't aim for complete, aim for precise.
 
-## 和Figma/设计稿的配合
+## Working with Figma / Design Mockups
 
-如果用户给了Figma链接：
+If the user provides a Figma link:
 
-- **不要**期望你能直接"转Figma为HTML"——那需要额外工具
-- Figma链接通常不公开可访问
-- 让用户：导出为**截图**发给你 + 告诉你具体的color/spacing values
+- **Don't** expect to "convert Figma to HTML" directly — that needs extra tooling
+- Figma links often aren't publicly accessible
+- Ask the user to: export as **screenshots** + tell you the specific color / spacing values
 
-如果只给了Figma截图，告诉用户：
-- 我能看到视觉，但取不到精确values
-- 关键数字（hex、px）请告诉我，或者export as code（Figma支持）
+If you only get Figma screenshots, tell the user:
+- I can see the visuals but can't pull exact values
+- Send me the key numbers (hex, px), or export as code (Figma supports it)
 
-## 最后的提醒
+## Final Reminder
 
-**一个项目的设计质量上限，由你拿到的context质量决定**。
+**A project's design quality ceiling is set by the quality of context you receive**.
 
-花10分钟收集context，比花1小时凭空画hi-fi更有价值。
+10 minutes spent gathering context beats 1 hour doing hi-fi from thin air.
 
-**遇到没context的情况，优先问用户要，而不是硬上**。
+**When there's no context, prioritize asking the user — don't muscle through**.

--- a/references/design-styles.md
+++ b/references/design-styles.md
@@ -1,53 +1,53 @@
-# 设计哲学风格库：20种体系
+# Design-Philosophy Style Library: 20 Systems
 
-> 用于视觉设计（网页/PPT/PDF/信息图/配图/App等）的设计风格库。
-> 每种风格提供：哲学内核 + 核心特征 + 提示词DNA（与场景模板组合使用）。
+> A design-style library for visual design (web / PPT / PDF / infographic / illustration / app, etc.).
+> Each style provides: philosophical core + key traits + Prompt DNA (combine with scene templates).
 
-## 风格×场景×执行路径 速查表
+## Style × Scene × Execution Path quick-reference
 
-| 风格 | 网页 | PPT | PDF | 信息图 | 封面 | AI生成 | 最佳路径 |
+| Style | Web | PPT | PDF | Infographic | Cover | AI gen | Best path |
 |------|:---:|:---:|:---:|:-----:|:---:|:-----:|---------|
 | 01 Pentagram | ★★★ | ★★★ | ★★☆ | ★★☆ | ★★★ | ★☆☆ | HTML |
-| 02 Stamen Design | ★★☆ | ★★☆ | ★★☆ | ★★★ | ★★☆ | ★★☆ | 混合 |
+| 02 Stamen Design | ★★☆ | ★★☆ | ★★☆ | ★★★ | ★★☆ | ★★☆ | Hybrid |
 | 03 Information Architects | ★★★ | ★☆☆ | ★★★ | ★☆☆ | ★☆☆ | ★☆☆ | HTML |
 | 04 Fathom | ★★☆ | ★★★ | ★★★ | ★★★ | ★★☆ | ★☆☆ | HTML |
-| 05 Locomotive | ★★★ | ★★☆ | ★☆☆ | ★☆☆ | ★★☆ | ★★☆ | 混合 |
-| 06 Active Theory | ★★★ | ★☆☆ | ★☆☆ | ★☆☆ | ★★☆ | ★★★ | AI生成 |
-| 07 Field.io | ★★☆ | ★★☆ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI生成 |
-| 08 Resn | ★★★ | ★☆☆ | ★☆☆ | ★☆☆ | ★★☆ | ★★☆ | AI生成 |
-| 09 Experimental Jetset | ★★☆ | ★★☆ | ★★☆ | ★★☆ | ★★★ | ★★☆ | 混合 |
+| 05 Locomotive | ★★★ | ★★☆ | ★☆☆ | ★☆☆ | ★★☆ | ★★☆ | Hybrid |
+| 06 Active Theory | ★★★ | ★☆☆ | ★☆☆ | ★☆☆ | ★★☆ | ★★★ | AI gen |
+| 07 Field.io | ★★☆ | ★★☆ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI gen |
+| 08 Resn | ★★★ | ★☆☆ | ★☆☆ | ★☆☆ | ★★☆ | ★★☆ | AI gen |
+| 09 Experimental Jetset | ★★☆ | ★★☆ | ★★☆ | ★★☆ | ★★★ | ★★☆ | Hybrid |
 | 10 Müller-Brockmann | ★★☆ | ★★★ | ★★★ | ★★★ | ★★☆ | ★☆☆ | HTML |
 | 11 Build | ★★★ | ★★★ | ★★☆ | ★☆☆ | ★★★ | ★☆☆ | HTML |
-| 12 Sagmeister & Walsh | ★★☆ | ★★★ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI生成 |
-| 13 Zach Lieberman | ★☆☆ | ★☆☆ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI生成 |
-| 14 Raven Kwok | ★☆☆ | ★★☆ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI生成 |
-| 15 Ash Thorp | ★★☆ | ★★☆ | ★☆☆ | ★☆☆ | ★★★ | ★★★ | AI生成 |
-| 16 Territory Studio | ★★☆ | ★★☆ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI生成 |
+| 12 Sagmeister & Walsh | ★★☆ | ★★★ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI gen |
+| 13 Zach Lieberman | ★☆☆ | ★☆☆ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI gen |
+| 14 Raven Kwok | ★☆☆ | ★★☆ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI gen |
+| 15 Ash Thorp | ★★☆ | ★★☆ | ★☆☆ | ★☆☆ | ★★★ | ★★★ | AI gen |
+| 16 Territory Studio | ★★☆ | ★★☆ | ★☆☆ | ★★☆ | ★★★ | ★★★ | AI gen |
 | 17 Takram | ★★★ | ★★★ | ★★★ | ★★☆ | ★★☆ | ★☆☆ | HTML |
 | 18 Kenya Hara | ★★☆ | ★★★ | ★★★ | ★☆☆ | ★★★ | ★☆☆ | HTML |
-| 19 Irma Boom | ★☆☆ | ★★☆ | ★★★ | ★★☆ | ★★★ | ★★☆ | 混合 |
-| 20 Neo Shen | ★★☆ | ★★☆ | ★★☆ | ★★☆ | ★★★ | ★★★ | AI生成 |
+| 19 Irma Boom | ★☆☆ | ★★☆ | ★★★ | ★★☆ | ★★★ | ★★☆ | Hybrid |
+| 20 Neo Shen | ★★☆ | ★★☆ | ★★☆ | ★★☆ | ★★★ | ★★★ | AI gen |
 
-> 场景适配：★★★ = 强烈推荐 / ★★☆ = 适合 / ★☆☆ = 需改造
-> AI生成：★★★ = 直出效果好 / ★★☆ = 需调整 / ★☆☆ = 建议HTML执行
-> 最佳路径：AI生成（图片直出）/ HTML（代码渲染，数据精确）/ 混合（HTML布局+AI配图）
+> Scene fit: ★★★ = strongly recommended / ★★☆ = suitable / ★☆☆ = needs adaptation
+> AI gen: ★★★ = great direct output / ★★☆ = needs tuning / ★☆☆ = HTML execution recommended
+> Best path: AI gen (image direct) / HTML (code-rendered, data-precise) / Hybrid (HTML layout + AI imagery)
 
-**核心规律**：有明确视觉元素的风格（插画/粒子/生成艺术）AI直出效果好；依赖精确排版和数据的风格（网格/信息架构/留白）HTML渲染更可控。
+**Core rule**: styles with explicit visual elements (illustration / particles / generative art) produce great direct AI output; styles dependent on precise typography and data (grid / information architecture / whitespace) are more controllable via HTML rendering.
 
 ---
 
-## 一、信息建筑派（01-04）
-> 哲学：「数据不是装饰，是建筑材料」
+## I. Information Architecture school (01–04)
+> Philosophy: "Data isn't decoration — it's the building material."
 
-### 01. Pentagram - Michael Bierut风格
-**哲学**：字体即语言，网格即思想
-**核心特征**：
-- 极度克制的颜色（黑白+1个品牌色）
-- 瑞士网格系统的现代演绎
-- 字体排印作为主要视觉语言
-- 负空间的战略性使用（60%+留白）
+### 01. Pentagram — Michael Bierut style
+**Philosophy**: type is language, the grid is thought
+**Key traits**:
+- Extremely restrained color (black + white + one brand color)
+- Modern interpretation of the Swiss grid
+- Typography as the primary visual language
+- Strategic use of negative space (60%+ whitespace)
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Pentagram/Michael Bierut style:
 - Extreme typographic hierarchy, Helvetica/Univers family
@@ -58,20 +58,20 @@ Pentagram/Michael Bierut style:
 - Data visualization as primary decoration
 ```
 
-**代表作**：Hillary Clinton 2016 campaign identity
-**搜索关键词**：pentagram hillary logo system
+**Representative work**: Hillary Clinton 2016 campaign identity
+**Search keywords**: pentagram hillary logo system
 
 ---
 
-### 02. Stamen Design - 数据诗学
-**哲学**：让数据成为可触摸的风景
-**核心特征**：
-- 地图学思维应用于信息设计
-- 算法生成的有机图形
-- 温暖的数据可视化色调（赭石、鼠尾草绿、深蓝）
-- 可交互的层级系统
+### 02. Stamen Design — data poetics
+**Philosophy**: turn data into a landscape you can touch
+**Key traits**:
+- Cartographic thinking applied to information design
+- Algorithmically generated organic shapes
+- Warm data-viz palette (terracotta, sage green, deep blue)
+- Interactive layered system
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Stamen Design aesthetic:
 - Cartographic approach to data visualization
@@ -82,20 +82,20 @@ Stamen Design aesthetic:
 - Soft shadows and depth
 ```
 
-**代表作**：COVID-19 surge map
-**搜索关键词**：stamen covid map visualization
+**Representative work**: COVID-19 surge map
+**Search keywords**: stamen covid map visualization
 
 ---
 
-### 03. Information Architects - 内容优先原则
-**哲学**：设计不是装饰，是内容的建筑
-**核心特征**：
-- 极端的内容层级清晰度
-- 只使用系统字体（优化阅读）
-- 蓝色超链接传统的坚守
-- 性能即美学
+### 03. Information Architects — content-first principle
+**Philosophy**: design isn't decoration — it's architecture for content
+**Key traits**:
+- Extreme content-hierarchy clarity
+- System fonts only (optimized for reading)
+- Loyal to the classic blue-hyperlink tradition
+- Performance as aesthetic
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Information Architects philosophy:
 - Content-first hierarchy, zero decorative elements
@@ -106,20 +106,20 @@ Information Architects philosophy:
 - Text-heavy, fast-loading design
 ```
 
-**代表作**：iA Writer app
-**搜索关键词**：information architects ia writer
+**Representative work**: iA Writer app
+**Search keywords**: information architects ia writer
 
 ---
 
-### 04. Fathom Information Design - 科学叙事
-**哲学**：每一个像素都必须承载信息
-**核心特征**：
-- 科学期刊的严谨+设计的优雅
-- 定量数据的精确可视化
-- 冷静的专业色调（灰、海军蓝）
-- 注释与引用系统的设计化
+### 04. Fathom Information Design — scientific storytelling
+**Philosophy**: every pixel must carry information
+**Key traits**:
+- Scientific-journal rigor + design elegance
+- Precise visualization of quantitative data
+- Calm, professional palette (gray, navy)
+- Footnote-and-citation system designed into the layout
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Fathom Information Design style:
 - Scientific journal aesthetic meets modern design
@@ -130,23 +130,23 @@ Fathom Information Design style:
 - Information density without clutter
 ```
 
-**代表作**：Bill & Melinda Gates Foundation年度报告
-**搜索关键词**：fathom information design gates foundation
+**Representative work**: Bill & Melinda Gates Foundation annual report
+**Search keywords**: fathom information design gates foundation
 
 ---
 
-## 二、运动诗学派（05-08）
-> 哲学：「技术本身就是一种流动的诗」
+## II. Motion poetics school (05–08)
+> Philosophy: "Technology itself is a kind of flowing poetry."
 
-### 05. Locomotive - 滚动叙事大师
-**哲学**：滚动不是浏览，是旅程
-**核心特征**：
-- 丝滑的视差滚动
-- 电影化的分镜叙事
-- 大胆的空间留白
-- 动态元素的精确编排
+### 05. Locomotive — master of scroll storytelling
+**Philosophy**: scrolling isn't browsing — it's a journey
+**Key traits**:
+- Silky parallax scrolling
+- Cinematic, shot-by-shot storytelling
+- Bold spatial whitespace
+- Precise choreography of moving elements
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Locomotive scroll narrative style:
 - Film-like scene composition with parallax depth
@@ -158,20 +158,20 @@ Locomotive scroll narrative style:
 - Hero sections 100vh tall
 ```
 
-**代表作**：Lusion.co website
-**搜索关键词**：locomotive scroll lusion
+**Representative work**: Lusion.co website
+**Search keywords**: locomotive scroll lusion
 
 ---
 
-### 06. Active Theory - WebGL诗人
-**哲学**：让技术可见化即让技术可理解
-**核心特征**：
-- 3D粒子系统作为核心元素
-- 实时渲染的数据可视化
-- 鼠标交互驱动的世界构建
-- 霓虹与深空的配色
+### 06. Active Theory — WebGL poets
+**Philosophy**: making technology visible is making it comprehensible
+**Key traits**:
+- 3D particle systems as a core element
+- Real-time rendered data visualization
+- World-building driven by mouse interaction
+- Neon-and-deep-space palette
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Active Theory WebGL aesthetic:
 - Particle systems representing data flow
@@ -182,20 +182,20 @@ Active Theory WebGL aesthetic:
 - Floating UI with glassmorphism
 ```
 
-**代表作**：NASA Prospect
-**搜索关键词**：active theory nasa webgl
+**Representative work**: NASA Prospect
+**Search keywords**: active theory nasa webgl
 
 ---
 
-### 07. Field.io - 算法美学
-**哲学**：代码即设计师
-**核心特征**：
-- 生成艺术系统
-- 每次访问都不同的动态图形
-- 抽象几何的智能编排
-- 技术感与艺术性的平衡
+### 07. Field.io — algorithmic aesthetics
+**Philosophy**: code is the designer
+**Key traits**:
+- Generative-art systems
+- Dynamic graphics that change with every visit
+- Intelligent choreography of abstract geometry
+- Balance of technical feel and artistry
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Field.io generative design style:
 - Abstract geometric patterns, algorithmically generated
@@ -206,20 +206,20 @@ Field.io generative design style:
 - Clean code aesthetic
 ```
 
-**代表作**：British Council digital installations
-**搜索关键词**：field.io generative design
+**Representative work**: British Council digital installations
+**Search keywords**: field.io generative design
 
 ---
 
-### 08. Resn - 叙事驱动的交互
-**哲学**：每个点击都推进故事
-**核心特征**：
-- 游戏化的用户旅程
-- 强烈的情感化设计
-- 插画与代码的深度结合
-- 非线性的探索体验
+### 08. Resn — narrative-driven interaction
+**Philosophy**: every click advances the story
+**Key traits**:
+- Gamified user journeys
+- Strongly emotionalized design
+- Deep blend of illustration and code
+- Non-linear exploration experience
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Resn interactive storytelling approach:
 - Illustrative style mixed with UI elements
@@ -230,23 +230,23 @@ Resn interactive storytelling approach:
 - Editorial illustration meets product design
 ```
 
-**代表作**：Resn.co.nz portfolio
-**搜索关键词**：resn interactive storytelling
+**Representative work**: Resn.co.nz portfolio
+**Search keywords**: resn interactive storytelling
 
 ---
 
-## 三、极简主义派（09-12）
-> 哲学：「删减到无法再删」
+## III. Minimalism school (09–12)
+> Philosophy: "Reduce until nothing more can be reduced."
 
-### 09. Experimental Jetset - 概念极简
-**哲学**：一个想法=一个形式
-**核心特征**：
-- 单一视觉隐喻贯穿整个设计
-- 蓝/红/黄+黑白的蒙德里安色系
-- 字体即图形
-- 反商业的诚实设计
+### 09. Experimental Jetset — conceptual minimalism
+**Philosophy**: one idea = one form
+**Key traits**:
+- A single visual metaphor running through the whole design
+- Mondrian palette of blue/red/yellow + black/white
+- Type as graphic
+- Honest, anti-commercial design
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Experimental Jetset conceptual minimalism:
 - Single visual metaphor for entire design
@@ -257,20 +257,20 @@ Experimental Jetset conceptual minimalism:
 - Anti-commercial, honest aesthetic
 ```
 
-**代表作**：Whitney Museum identity
-**搜索关键词**：experimental jetset whitney responsive w
+**Representative work**: Whitney Museum identity
+**Search keywords**: experimental jetset whitney responsive w
 
 ---
 
-### 10. Müller-Brockmann传承 - 瑞士网格纯粹主义
-**哲学**：客观性即美
-**核心特征**：
-- 数学精确的网格系统（8pt基线）
-- 绝对的左对齐或居中
-- 单色或双色方案
-- 功能主义至上
+### 10. Müller-Brockmann lineage — Swiss-grid purism
+**Philosophy**: objectivity is beauty
+**Key traits**:
+- Mathematically precise grid system (8pt baseline)
+- Absolute left- or center-alignment
+- One- or two-color scheme
+- Functionalism above all
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Josef Müller-Brockmann Swiss modernism:
 - Mathematical grid system (8pt baseline)
@@ -281,20 +281,20 @@ Josef Müller-Brockmann Swiss modernism:
 - Timeless, objective aesthetic
 ```
 
-**代表作**：《Grid Systems in Graphic Design》
-**搜索关键词**：muller brockmann grid systems poster
+**Representative work**: *Grid Systems in Graphic Design*
+**Search keywords**: muller brockmann grid systems poster
 
 ---
 
-### 11. Build - 当代极简品牌
-**哲学**：精致的简单比复杂更难
-**核心特征**：
-- 奢侈品级的留白（70%+）
-- 微妙的字重对比（200-600）
-- 单一强调色的战略使用
-- 呼吸感的节奏
+### 11. Build — contemporary minimal branding
+**Philosophy**: refined simplicity is harder than complexity
+**Key traits**:
+- Luxury-grade whitespace (70%+)
+- Subtle font-weight contrast (200–600)
+- Strategic use of a single accent color
+- Breathing-room rhythm
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Build studio luxury minimalism:
 - Generous whitespace (70%+ of area)
@@ -305,20 +305,20 @@ Build studio luxury minimalism:
 - Golden ratio proportions
 ```
 
-**代表作**：Build studio portfolio
-**搜索关键词**：build studio london branding
+**Representative work**: Build studio portfolio
+**Search keywords**: build studio london branding
 
 ---
 
-### 12. Sagmeister & Walsh - 快乐极简
-**哲学**：美即功能的情感维度
-**核心特征**：
-- 意外的色彩爆发
-- 手工感与数字的融合
-- 正能量的视觉语言
-- 实验性但可读
+### 12. Sagmeister & Walsh — joyful minimalism
+**Philosophy**: beauty is the emotional dimension of function
+**Key traits**:
+- Unexpected bursts of color
+- Fusion of handmade and digital
+- Positive visual language
+- Experimental but legible
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Sagmeister & Walsh joyful philosophy:
 - Unexpected color bursts on minimal base
@@ -329,23 +329,23 @@ Sagmeister & Walsh joyful philosophy:
 - Mix of analog and digital aesthetics
 ```
 
-**代表作**：The Happy Show
-**搜索关键词**：sagmeister walsh happy show
+**Representative work**: The Happy Show
+**Search keywords**: sagmeister walsh happy show
 
 ---
 
-## 四、实验先锋派（13-16）
-> 哲学：「打破规则即创造规则」
+## IV. Experimental avant-garde school (13–16)
+> Philosophy: "Breaking the rules is making the rules."
 
-### 13. Zach Lieberman - 代码诗学
-**哲学**：编程即绘画
-**核心特征**：
-- 手绘感的算法图形
-- 实时生成艺术
-- 黑白的纯粹表达
-- 工具本身的可见性
+### 13. Zach Lieberman — code poetics
+**Philosophy**: programming is painting
+**Key traits**:
+- Hand-drawn-feeling algorithmic graphics
+- Real-time generative art
+- Pure expression in black and white
+- Visibility of the tool itself
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Zach Lieberman code-as-art style:
 - Hand-drawn aesthetic generated by code
@@ -356,20 +356,20 @@ Zach Lieberman code-as-art style:
 - Poetic interpretation of algorithms
 ```
 
-**代表作**：openFrameworks creative coding
-**搜索关键词**：zach lieberman openframeworks generative
+**Representative work**: openFrameworks creative coding
+**Search keywords**: zach lieberman openframeworks generative
 
 ---
 
-### 14. Raven Kwok - 参数化美学
-**哲学**：系统的美胜过个体的美
-**核心特征**：
-- 分形与递归图形
-- 黑白高对比
-- 建筑化的信息结构
-- 东方园林的算法演绎
+### 14. Raven Kwok — parametric aesthetics
+**Philosophy**: the beauty of the system beats the beauty of the individual
+**Key traits**:
+- Fractal and recursive graphics
+- High-contrast black and white
+- Architectural information structures
+- An algorithmic interpretation of the Eastern garden
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Raven Kwok parametric aesthetic:
 - Fractal patterns and recursive structures
@@ -380,20 +380,20 @@ Raven Kwok parametric aesthetic:
 - Processing/Creative coding aesthetic
 ```
 
-**代表作**：Raven Kwok generative art exhibitions
-**搜索关键词**：raven kwok processing generative art
+**Representative work**: Raven Kwok generative-art exhibitions
+**Search keywords**: raven kwok processing generative art
 
 ---
 
-### 15. Ash Thorp - 赛博诗意
-**哲学**：未来不是冰冷的，是孤独的诗
-**核心特征**：
-- 电影级的光影
-- 赛博朋克的温暖版本（橙/青，非冷蓝）
-- 故事性的概念设计
-- 工业美学的精致化
+### 15. Ash Thorp — cyber poetics
+**Philosophy**: the future isn't cold — it's a lonely poem
+**Key traits**:
+- Cinema-grade light and shadow
+- A warm version of cyberpunk (orange/teal, not cold blue)
+- Narrative-driven concept design
+- Refinement of industrial aesthetics
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Ash Thorp cinematic concept art:
 - Film-grade lighting and atmospheric effects
@@ -404,20 +404,20 @@ Ash Thorp cinematic concept art:
 - Blade Runner warmth over Tron coldness
 ```
 
-**代表作**：Ghost in the Shell concept art
-**搜索关键词**：ash thorp ghost shell concept art
+**Representative work**: Ghost in the Shell concept art
+**Search keywords**: ash thorp ghost shell concept art
 
 ---
 
-### 16. Territory Studio - 屏幕界面虚构
-**哲学**：未来UI的今日想象
-**核心特征**：
-- 科幻电影中的屏幕设计（FUI）
-- 全息投影感
-- 多层叠加的数据可视化
-- 可信的未来感
+### 16. Territory Studio — screen-interface fiction
+**Philosophy**: today's imagination of tomorrow's UI
+**Key traits**:
+- Screen design for sci-fi cinema (FUI)
+- Holographic-projection feel
+- Multi-layered overlapping data viz
+- A believable future
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Territory Studio FUI (Fantasy User Interface):
 - Fantasy User Interface design
@@ -428,23 +428,23 @@ Territory Studio FUI (Fantasy User Interface):
 - Technical readouts and data streams
 ```
 
-**代表作**：Blade Runner 2049 screen graphics
-**搜索关键词**：territory studio blade runner interface
+**Representative work**: Blade Runner 2049 screen graphics
+**Search keywords**: territory studio blade runner interface
 
 ---
 
-## 五、东方哲学派（17-20）
-> 哲学：「留白即内容」
+## V. Eastern-philosophy school (17–20)
+> Philosophy: "Whitespace is content."
 
-### 17. Takram - 日式思辨设计
-**哲学**：技术是思考的媒介
-**核心特征**：
-- 概念原型的优雅
-- 柔和的科技感（圆角、柔和阴影）
-- 图表即艺术
-- 谦逊的精致
+### 17. Takram — Japanese speculative design
+**Philosophy**: technology is a medium for thought
+**Key traits**:
+- Elegance in concept prototypes
+- Soft tech feel (rounded corners, gentle shadows)
+- Charts as art pieces
+- Modest sophistication
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Takram Japanese speculative design:
 - Elegant concept prototypes and diagrams
@@ -455,20 +455,20 @@ Takram Japanese speculative design:
 - Design as philosophical inquiry
 ```
 
-**代表作**：NHK Fabricated City
-**搜索关键词**：takram nhk data visualization
+**Representative work**: NHK Fabricated City
+**Search keywords**: takram nhk data visualization
 
 ---
 
-### 18. Kenya Hara - 空的设计
-**哲学**：设计不是填充，是清空
-**核心特征**：
-- 极致的留白（80%+）
-- 纸张质感的数字化
-- 白色的层次（暖白、冷白、米白）
-- 触觉的视觉化
+### 18. Kenya Hara — the design of emptiness
+**Philosophy**: design isn't filling — it's emptying
+**Key traits**:
+- Extreme whitespace (80%+)
+- Digital expression of paper texture
+- Layers of white (warm white, cool white, off-white)
+- Visualization of the tactile
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Kenya Hara "emptiness" design:
 - Extreme whitespace (80%+)
@@ -479,20 +479,20 @@ Kenya Hara "emptiness" design:
 - Zen simplicity
 ```
 
-**代表作**：Muji art direction, 《Designing Design》
-**搜索关键词**：kenya hara designing design muji
+**Representative work**: Muji art direction, *Designing Design*
+**Search keywords**: kenya hara designing design muji
 
 ---
 
-### 19. Irma Boom - 书籍建筑师
-**哲学**：信息的物理诗学
-**核心特征**：
-- 非线性的信息架构
-- 边缘与边界的游戏
-- 意外的颜色组合（粉+红、橙+棕）
-- 手工艺的数字转译
+### 19. Irma Boom — book architect
+**Philosophy**: the physical poetics of information
+**Key traits**:
+- Non-linear information architecture
+- Play with edges and margins
+- Unexpected color combinations (pink+red, orange+brown)
+- Craft translated to digital
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Irma Boom book architecture style:
 - Non-linear information structure
@@ -503,20 +503,20 @@ Irma Boom book architecture style:
 - Editorial design, unconventional grid
 ```
 
-**代表作**：SHV Think Book (2136 pages)
-**搜索关键词**：irma boom shv think book
+**Representative work**: SHV Think Book (2,136 pages)
+**Search keywords**: irma boom shv think book
 
 ---
 
-### 20. Neo Shen - 东方光影诗
-**哲学**：技术需要人的温度
-**核心特征**：
-- 水墨晕染的数字化
-- 柔和的光晕效果
-- 诗意的留白
-- 情感化的色彩（深蓝、暖灰、柔金）
+### 20. Neo Shen — Eastern light-and-shadow poetry
+**Philosophy**: technology needs human warmth
+**Key traits**:
+- Digital ink-wash bleed
+- Soft light-halo effects
+- Poetic whitespace
+- Emotional palette (deep blue, warm gray, soft gold)
 
-**提示词DNA**：
+**Prompt DNA**:
 ```
 Neo Shen poetic Chinese aesthetic:
 - Digital interpretation of ink wash painting
@@ -527,29 +527,29 @@ Neo Shen poetic Chinese aesthetic:
 - Atmospheric depth
 ```
 
-**代表作**：Neo Shen digital art series
-**搜索关键词**：neo shen digital ink wash art
+**Representative work**: Neo Shen digital-art series
+**Search keywords**: neo shen digital ink wash art
 
 ---
 
-## 提示词使用说明
+## Prompt usage notes
 
-**组合公式**：`[风格提示词DNA] + [场景模板（见scene-templates.md）] + [具体内容]`
+**Combination formula**: `[Style Prompt DNA] + [Scene Template (see scene-templates.md)] + [Specific content]`
 
-### 核心原则：描述情绪而非布局（Mood, Not Layout）
+### Core principle: describe mood, not layout
 
-AI图像生成的关键：短提示词 > 长提示词。描述3句情绪和内容，比30行布局细节效果更好。
+The key to AI image generation: short prompts beat long prompts. Three sentences of mood and content outperform 30 lines of layout detail.
 
-| 杀死多样性的写法 | 激发创造力的写法 |
+| Diversity-killing approach | Creativity-igniting approach |
 |----------------|----------------|
-| 指定颜色比例（60%/25%/15%） | 描述情绪（"warm like Sunday morning"） |
-| 规定布局位置（"标题居中，图片右侧"） | 引用具体美学（"Pentagram editorial feel"） |
-| 限制角色姿势和表情 | 让AI自然诠释风格 |
-| 列出所有要包含的视觉元素 | 描述观众应该感受到什么 |
+| Specify color ratios (60%/25%/15%) | Describe mood ("warm like Sunday morning") |
+| Specify layout positions ("title centered top, image on right") | Reference a specific aesthetic ("Pentagram editorial feel") |
+| Constrain character pose and expression | Let the AI interpret the style naturally |
+| List every visual element to include | Describe what the audience should feel |
 
-### Good / Bad 示例
+### Good / Bad examples
 
-**Bad — 过度约束（AI生成出来空且平）：**
+**Bad — over-constrained (AI generates flat and empty):**
 ```
 Professional presentation slide. Dark background, light text.
 Title centered at top. Two columns below. Left column: bullet points.
@@ -557,7 +557,7 @@ Right column: bar chart. Colors: navy 60%, white 30%, gold 10%.
 Font size: title 36pt, body 18pt. Margins: 40px all sides.
 ```
 
-**Good — 情绪驱动（生成多样且有质感）：**
+**Good — mood-driven (diverse and textured output):**
 ```
 A data visualization that feels like a Bloomberg Businessweek
 editorial spread. The key number "28.5%" should dominate the
@@ -565,27 +565,27 @@ composition like a headline. Warm cream tones with sharp black
 typography. The data tells a story of dramatic channel shift.
 ```
 
-### 执行路径选择
+### Choosing the execution path
 
-根据速查表的「最佳路径」列选择：
-- **AI生成**：有明确视觉元素的风格（06/07/12/13/14/15/16/20），用 Gemini/Midjourney 直出
-- **HTML渲染**：依赖精确排版的风格（01/03/04/10/11/17/18），代码控制数据和布局
-- **混合**：HTML做骨架布局 + AI生成配图/背景（02/05/08/09/19）
+Pick by the "Best path" column in the quick-reference table:
+- **AI gen**: styles with explicit visual elements (06/07/12/13/14/15/16/20) — generate directly via Gemini / Midjourney
+- **HTML render**: styles dependent on precise typography (01/03/04/10/11/17/18) — code controls data and layout
+- **Hybrid**: HTML for skeleton layout + AI-generated imagery / backgrounds (02/05/08/09/19)
 
-### 质量控制
+### Quality control
 
-1. ❌ 不要直接写 "in the style of Pentagram" → ✅ 用具体设计特征描述
-2. 文字在AI生成中常出错 → 生成后替换文字
-3. 比例易失真 → 明确指定 aspect ratio
-4. 先生成3-5个变体，选择最佳后细化
+1. Bad: write "in the style of Pentagram" directly → Good: describe concrete design traits
+2. Text often comes out wrong in AI generation → replace text after generation
+3. Proportions distort easily → specify aspect ratio explicitly
+4. Generate 3–5 variants first, pick the best, then refine
 
-**默认审美禁区**（用户可按自己品牌 override）：
-- ❌ 赛博霓虹/深蓝色底（#0D1117）
-- ❌ 封面图加个人署名/水印
+**Default aesthetic no-go zones** (users may override per their brand):
+- Bad: cyber-neon / deep-blue background (#0D1117)
+- Bad: personal signature / watermark on cover images
 
 ---
 
-**版本**：v2.1
-**更新日期**：2026-02-13
-**适用场景**：网页/PPT/PDF/信息图/封面/配图/App等所有视觉设计
-**与 image-to-slides 联动**：PPT场景可直接引用本文件风格，通过 image-to-slides skill 执行生成
+**Version**: v2.1
+**Updated**: 2026-02-13
+**Applicable**: web / PPT / PDF / infographic / cover / illustration / app — all visual design
+**Integration with image-to-slides**: PPT scenes can reference styles in this file directly, then run via the image-to-slides skill to generate

--- a/references/editable-pptx.md
+++ b/references/editable-pptx.md
@@ -1,195 +1,195 @@
-# 可编辑 PPTX 导出：HTML 硬约束 + 尺寸决策 + 常见错误
+# Editable PPTX Export: HTML Hard Constraints + Sizing Decisions + Common Errors
 
-本文档讲的是**用 `scripts/html2pptx.js` + `pptxgenjs` 把 HTML 逐元素翻译成真·可编辑 PowerPoint 文本框**的路径，也是 `export_deck_pptx.mjs` 唯一支持的路径。
+This document covers the path of **using `scripts/html2pptx.js` + `pptxgenjs` to translate HTML element-by-element into truly editable PowerPoint text frames** — also the only path supported by `export_deck_pptx.mjs`.
 
-> **核心前提**：要走这条路，HTML 必须从第一行就按下面 4 条约束写。**不是写完再转**——事后补救会触发 2-3 小时返工（2026-04-20 期权私董会项目实测踩坑）。
+> **Core prerequisite**: to go down this path, the HTML must be written to the 4 constraints below **from the very first line**. **Not "write it then convert"** — retrofitting triggers 2-3 hours of rework (verified in the 2026-04-20 options-roundtable project).
 >
-> 视觉自由度优先的场景（动画 / web component / CSS 渐变 / 复杂 SVG）请改走 PDF 路径（`export_deck_pdf.mjs` / `export_deck_stage_pdf.mjs`），**不要**指望 pptx 导出能兼得视觉保真和可编辑——这是 PPTX 文件格式本身的物理约束（见文末「为什么 4 条约束不是 Bug 而是物理约束」）。
+> If your scenario prioritizes visual freedom (animation / web component / CSS gradients / complex SVG), take the PDF path instead (`export_deck_pdf.mjs` / `export_deck_stage_pdf.mjs`). **Do not** expect pptx export to give you both visual fidelity and editability — that's a physical constraint of the PPTX file format itself (see the closing section "Why the 4 Constraints Aren't Bugs but Physical Constraints").
 
 ---
 
-## 画布尺寸：用 960×540pt（LAYOUT_WIDE）
+## Canvas Size: Use 960×540pt (LAYOUT_WIDE)
 
-PPTX 单位是 **inch**（物理尺寸），不是 px。决策原则：body 的 computedStyle 尺寸要**匹配 presentation layout 的 inch 尺寸**（±0.1"，由 `html2pptx.js` 的 `validateDimensions` 强制检查）。
+PPTX's unit is **inch** (physical size), not px. Decision principle: the body's computedStyle dimensions must **match the presentation layout's inch dimensions** (±0.1″, enforced by `html2pptx.js`'s `validateDimensions`).
 
-### 3 个候选尺寸对比
+### Comparison of the 3 candidate sizes
 
-| HTML body | 物理尺寸 | 对应 PPT layout | 何时选 |
+| HTML body | Physical size | Matching PPT layout | When to choose |
 |---|---|---|---|
-| **`960pt × 540pt`** | **13.333″ × 7.5″** | **pptxgenjs `LAYOUT_WIDE`** | ✅ **默认推荐**（现代 PowerPoint 16:9 标配） |
-| `720pt × 405pt` | 10″ × 5.625″ | 自定义 | 仅当用户指定「老版 PowerPoint Widescreen」模板时 |
-| `1920px × 1080px` | 20″ × 11.25″ | 自定义 | ❌ 非标尺寸，投影后字体显得异常小 |
+| **`960pt × 540pt`** | **13.333″ × 7.5″** | **pptxgenjs `LAYOUT_WIDE`** | ✅ **Default recommendation** (the modern PowerPoint 16:9 standard) |
+| `720pt × 405pt` | 10″ × 5.625″ | custom | Only when the user specifies an "old PowerPoint Widescreen" template |
+| `1920px × 1080px` | 20″ × 11.25″ | custom | ❌ Non-standard size; fonts look unusually small once projected |
 
-**别把 HTML 尺寸当分辨率想。** PPTX 是矢量文档，body 尺寸决定的是**物理尺寸**不是清晰度。超大 body（20″×11.25″）不会让文字更清晰——只会让字号 pt 相对画布变小，投影/打印时反而更难看。
+**Do not think of the HTML size as resolution.** PPTX is a vector document — the body size determines **physical size**, not clarity. An oversized body (20″×11.25″) does not make text sharper — it just makes pt font sizes smaller relative to the canvas, and they look worse when projected/printed.
 
-### body 写法三选一（等价）
+### Three equivalent ways to write the body
 
 ```css
-body { width: 960pt;  height: 540pt; }    /* 最清晰，推荐 */
-body { width: 1280px; height: 720px; }    /* 等价，px 习惯 */
-body { width: 13.333in; height: 7.5in; }  /* 等价，英寸直觉 */
+body { width: 960pt;  height: 540pt; }    /* clearest, recommended */
+body { width: 1280px; height: 720px; }    /* equivalent, px habit */
+body { width: 13.333in; height: 7.5in; }  /* equivalent, inch intuition */
 ```
 
-配套的 pptxgenjs 代码：
+Matching pptxgenjs code:
 
 ```js
 const pptx = new pptxgen();
-pptx.layout = 'LAYOUT_WIDE';  // 13.333 × 7.5 inch, 无需自定义
+pptx.layout = 'LAYOUT_WIDE';  // 13.333 × 7.5 inch, no customization needed
 ```
 
 ---
 
-## 4 条硬约束（违反会直接报错）
+## The 4 Hard Constraints (violations error out immediately)
 
-`html2pptx.js` 把 HTML 的 DOM 逐元素翻译成 PowerPoint 对象。PowerPoint 的格式约束投射到 HTML 上 = 下面 4 条规则。
+`html2pptx.js` translates the HTML DOM element-by-element into PowerPoint objects. PowerPoint's format constraints projected onto HTML = the 4 rules below.
 
-### 规则 1：DIV 里不能直接写文字 — 必须用 `<p>` 或 `<h1>`-`<h6>` 包裹
+### Rule 1: No raw text inside DIVs — wrap with `<p>` or `<h1>`-`<h6>`
 
 ```html
-<!-- ❌ 错误：文字直接在 div 里 -->
-<div class="title">Q3营收增长23%</div>
+<!-- ❌ Wrong: text directly in a div -->
+<div class="title">Q3 revenue up 23%</div>
 
-<!-- ✅ 正确：文字在 <p> 或 <h1>-<h6> 里 -->
-<div class="title"><h1>Q3营收增长23%</h1></div>
-<div class="body"><p>新用户是主要驱动力</p></div>
+<!-- ✅ Right: text inside <p> or <h1>-<h6> -->
+<div class="title"><h1>Q3 revenue up 23%</h1></div>
+<div class="body"><p>New users are the main driver</p></div>
 ```
 
-**为什么**：PowerPoint 文本必须存在 text frame 里，text frame 对应 HTML 的段落级元素（p/h*/li）。裸 `<div>` 在 PPTX 里没有对应的文本容器。
+**Why**: PowerPoint text must live inside a text frame, and text frames correspond to HTML paragraph-level elements (p/h*/li). A bare `<div>` has no matching text container in PPTX.
 
-**也不能用 `<span>` 承载主文字**——span 是行内元素，没法独立对齐成文本框。span 只能**夹在 p/h\* 里**做局部样式（加粗、换色）。
+**You also cannot use `<span>` to carry the main text** — span is inline, it can't independently align as a text frame. Span can only **sit inside a p/h\*** for local styling (bold, color change).
 
-### 规则 2：不支持 CSS 渐变 — 只能用纯色
+### Rule 2: No CSS gradients — solid colors only
 
 ```css
-/* ❌ 错误 */
+/* ❌ Wrong */
 background: linear-gradient(to right, #FF6B6B, #4ECDC4);
 
-/* ✅ 正确：纯色 */
+/* ✅ Right: solid color */
 background: #FF6B6B;
 
-/* ✅ 如果必须多色条纹，用 flex 子元素各自纯色 */
+/* ✅ If you really need multi-color stripes, use flex children each in a solid color */
 .stripe-bar { display: flex; }
 .stripe-bar div { flex: 1; }
 .red   { background: #FF6B6B; }
 .teal  { background: #4ECDC4; }
 ```
 
-**为什么**：PowerPoint 的 shape fill 只支持 solid/gradient-fill 两种，但 pptxgenjs 的 `fill: { color: ... }` 只映射 solid。渐变走 PowerPoint 原生 gradient 需要另写结构，目前工具链不支持。
+**Why**: PowerPoint's shape fill supports only solid / gradient-fill, but pptxgenjs's `fill: { color: ... }` maps only to solid. Going through PowerPoint's native gradient requires a different structure that the current tool chain doesn't support.
 
-### 规则 3：背景/边框/阴影只能在 DIV 上，不能在文字标签上
+### Rule 3: Background/border/shadow only on DIV, not on text tags
 
 ```html
-<!-- ❌ 错误：<p> 有背景色 -->
-<p style="background: #FFD700; border-radius: 4px;">重点内容</p>
+<!-- ❌ Wrong: <p> has background -->
+<p style="background: #FFD700; border-radius: 4px;">Highlight</p>
 
-<!-- ✅ 正确：外层 div 承载背景/边框，<p> 只负责文字 -->
+<!-- ✅ Right: outer div carries background/border, <p> only carries text -->
 <div style="background: #FFD700; border-radius: 4px; padding: 8pt 12pt;">
-  <p>重点内容</p>
+  <p>Highlight</p>
 </div>
 ```
 
-**为什么**：PowerPoint 里 shape（方块/圆角矩形）和 text frame 是两个对象。HTML 的 `<p>` 只翻译成 text frame，背景/边框/阴影属于 shape——必须在**包裹 text 的 div** 上写。
+**Why**: in PowerPoint, shapes (boxes / rounded rectangles) and text frames are two separate objects. HTML's `<p>` translates only into a text frame; background/border/shadow belong to the shape — they must be written on the **div that wraps the text**.
 
-### 规则 4：DIV 不能用 `background-image` — 用 `<img>` 标签
+### Rule 4: DIV cannot use `background-image` — use an `<img>` tag
 
 ```html
-<!-- ❌ 错误 -->
+<!-- ❌ Wrong -->
 <div style="background-image: url('chart.png')"></div>
 
-<!-- ✅ 正确 -->
+<!-- ✅ Right -->
 <img src="chart.png" style="position: absolute; left: 50%; top: 20%; width: 300pt; height: 200pt;" />
 ```
 
-**为什么**：`html2pptx.js` 只从 `<img>` 元素提取图片路径，不解析 CSS 的 `background-image` URL。
+**Why**: `html2pptx.js` only extracts image paths from `<img>` elements — it does not parse the URL in a CSS `background-image`.
 
 ---
 
-## 合并文本框（`data-pptx-merge`）
+## Merging Text Frames (`data-pptx-merge`)
 
-**默认行为**：HTML 里每个 `<p>`/`<h1>`-`<h6>` 在 PPTX 里都是**独立文本框**。卡片里写 3 个 `<p>` → PPT 里 3 个文本框摞着，编辑时不能整段回车换行加段，得逐个改字号/对齐。
+**Default behavior**: every `<p>`/`<h1>`-`<h6>` in HTML becomes an **independent text frame** in PPTX. Three `<p>` inside a card → 3 stacked text frames in PPT; you can't add a new paragraph with a single return, you have to edit font size / alignment one by one.
 
-**解决方法**：给外层 div 加 `data-pptx-merge="true"`，容器内的所有 `<p>/<h*>` 会合并为**一个可编辑文本框**，每段之间用段落分隔符隔开，PPT 里就是一段一段连续编辑。
+**Solution**: add `data-pptx-merge="true"` to the outer div, and all the `<p>/<h*>` inside the container will merge into **one editable text frame**, with paragraph separators between segments — in PPT you edit segment-by-segment continuously.
 
 ```html
-<!-- ✅ 合并写法：4 段全部在一个文本框里 -->
+<!-- ✅ Merged form: all 4 paragraphs live in a single text frame -->
 <div class="card" data-pptx-merge="true"
      style="position: absolute; top: 60pt; left: 60pt; width: 420pt;
             background: #1A4A8A; border-radius: 8pt; padding: 20pt 24pt;">
-  <h2 style="font-size: 24pt; color: #FFFFFF;">标题</h2>
-  <p  style="font-size: 14pt; color: #DDEEFF;">第一段正文。</p>
-  <p  style="font-size: 14pt; color: #FFD166;">第二段：换颜色作为强调。</p>
-  <p  style="font-size: 14pt; color: #DDEEFF;">第三段：同一个文本框里继续写。</p>
+  <h2 style="font-size: 24pt; color: #FFFFFF;">Title</h2>
+  <p  style="font-size: 14pt; color: #DDEEFF;">First paragraph of body text.</p>
+  <p  style="font-size: 14pt; color: #FFD166;">Second paragraph: change color for emphasis.</p>
+  <p  style="font-size: 14pt; color: #DDEEFF;">Third paragraph: keep writing in the same text frame.</p>
 </div>
 ```
 
-**保留的样式**（per-paragraph 作为 run options 写入）：`font-size`、`color`、`font-family`、`font-weight`（bold）、`font-style`（italic）、`text-decoration: underline`、`<b>/<i>/<u>/<strong>/<em>/<span>` 内联样式。
+**Preserved styles** (per-paragraph, written as run options): `font-size`, `color`, `font-family`, `font-weight` (bold), `font-style` (italic), `text-decoration: underline`, inline styles on `<b>/<i>/<u>/<strong>/<em>/<span>`.
 
-**取自第一段、整框统一**：`text-align`、`line-height`。因为 PowerPoint 的对齐和行距是 paragraph/textbox 级别——一框里只能有一种对齐。如果几段对齐不同，请别用 merge，让它们各自独立。
+**Taken from the first paragraph and unified across the frame**: `text-align`, `line-height`. Because PowerPoint's alignment and line-height are paragraph/textbox-level — one frame can hold only one alignment. If multiple paragraphs differ, don't use merge, let them stay independent.
 
-**容器自身的 `background`/`border`/`box-shadow`/`border-radius`** 照常作为 shape 渲染，行为和普通 div 完全一样——也就是说蓝色卡片底 + 文本仍然是「shape + text frame」两层，只是文本层从 3-4 个文本框塌缩成 1 个。
+**The container's own `background`/`border`/`box-shadow`/`border-radius`** still render as a shape, with exactly the same behavior as a normal div — meaning a blue card background + text is still "shape + text frame" in two layers, just with the text layer collapsed from 3-4 frames into 1.
 
-**限制**：
-- 不能嵌套 `data-pptx-merge`（会报错）。
-- 容器不能用 `background-image`（同 4 条硬约束规则 4）。
-- 容器内不要再放有 `background`/`border` 的子 div——它们仍会被当作独立 shape 渲染，但里面的文字已被合并走了，可能产生视觉错位。
+**Limitations**:
+- You can't nest `data-pptx-merge` (errors out).
+- The container can't use `background-image` (same as rule 4 of the 4 hard constraints).
+- Don't put more child divs with `background`/`border` inside the container — they still render as independent shapes, but the text inside has already been merged out, so you may get visual misalignment.
 
-**什么时候用**：内容会反复改、要在 PPT 里继续编辑的场景。一次性导出归档的不用加，行为一致。
+**When to use**: scenarios where the content will be edited repeatedly and continue to be edited in PPT. No need to add it for one-shot archival exports — the behavior is the same.
 
 ---
 
-## Path A HTML 模板骨架
+## Path A HTML Template Skeleton
 
-每张 slide 一个独立 HTML 文件，彼此作用域隔离（避开单文件 deck 的 CSS 污染）。
+One independent HTML file per slide, scopes isolated from each other (avoiding the CSS pollution of single-file decks).
 
 ```html
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
-    width: 960pt; height: 540pt;           /* ⚠️ 匹配 LAYOUT_WIDE */
+    width: 960pt; height: 540pt;           /* ⚠️ Match LAYOUT_WIDE */
     font-family: system-ui, -apple-system, "PingFang SC", sans-serif;
-    background: #FEFEF9;                    /* 纯色，不能渐变 */
+    background: #FEFEF9;                    /* Solid color, no gradient */
     overflow: hidden;
   }
-  /* DIV 负责布局/背景/边框 */
+  /* DIVs handle layout / background / border */
   .card {
     position: absolute;
-    background: #1A4A8A;                    /* 背景在 DIV 上 */
+    background: #1A4A8A;                    /* Background on the DIV */
     border-radius: 4pt;
     padding: 12pt 16pt;
   }
-  /* 文字标签只负责字体样式，不加背景/边框 */
+  /* Text tags only carry typography — no background / border */
   .card h2 { font-size: 24pt; color: #FFFFFF; font-weight: 700; }
   .card p  { font-size: 14pt; color: rgba(255,255,255,0.85); }
 </style>
 </head>
 <body>
 
-  <!-- 标题区：外层 div 定位，内层文字标签 -->
+  <!-- Title area: outer div positions, inner text tags carry the text -->
   <div style="position: absolute; top: 40pt; left: 60pt; right: 60pt;">
-    <h1 style="font-size: 36pt; color: #1A1A1A; font-weight: 700;">标题用断言句，不是主题词</h1>
-    <p style="font-size: 16pt; color: #555555; margin-top: 10pt;">副标题补充说明</p>
+    <h1 style="font-size: 36pt; color: #1A1A1A; font-weight: 700;">Use an assertion as the title, not a topic word</h1>
+    <p style="font-size: 16pt; color: #555555; margin-top: 10pt;">Subtitle supplements</p>
   </div>
 
-  <!-- 内容卡片：div 负责背景，h2/p 负责文字 -->
+  <!-- Content card: div carries the background, h2/p carry the text -->
   <div class="card" style="top: 130pt; left: 60pt; width: 240pt; height: 160pt;">
-    <h2>要点一</h2>
-    <p>简短说明文字</p>
+    <h2>Point one</h2>
+    <p>Brief explanation</p>
   </div>
 
-  <!-- 列表：使用 ul/li，不用手动 • 符号 -->
+  <!-- List: use ul/li, not manual • characters -->
   <div style="position: absolute; top: 320pt; left: 60pt; width: 540pt;">
     <ul style="font-size: 16pt; color: #1A1A1A; padding-left: 24pt; list-style: disc;">
-      <li>第一条要点</li>
-      <li>第二条要点</li>
-      <li>第三条要点</li>
+      <li>First bullet</li>
+      <li>Second bullet</li>
+      <li>Third bullet</li>
     </ul>
   </div>
 
-  <!-- 插图：用 <img> 标签，不用 background-image -->
+  <!-- Illustration: <img> tag, not background-image -->
   <img src="illustration.png" style="position: absolute; right: 60pt; top: 110pt; width: 320pt; height: 240pt;" />
 
 </body>
@@ -198,44 +198,44 @@ background: #FF6B6B;
 
 ---
 
-## 常见错误速查
+## Common Errors Quick Reference
 
-| 错误信息 | 原因 | 修复方法 |
+| Error message | Cause | Fix |
 |---------|------|---------|
-| `DIV element contains unwrapped text "XXX"` | div 里有裸文字 | 把文字包进 `<p>` 或 `<h1>`-`<h6>` |
-| `CSS gradients are not supported` | 用了 linear/radial-gradient | 改为纯色，或用 flex 子元素分段 |
-| `Text element <p> has background` | `<p>` 标签加了背景色 | 外套 `<div>` 承载背景，`<p>` 只写文字 |
-| `Background images on DIV elements are not supported` | div 用了 background-image | 改为 `<img>` 标签 |
-| `HTML content overflows body by Xpt vertically` | 内容超出 540pt | 减少内容或缩小字号，或 `overflow: hidden` 截断 |
-| `HTML dimensions don't match presentation layout` | body 尺寸和 pres layout 对不上 | body 用 `960pt × 540pt` 配 `LAYOUT_WIDE`；或 defineLayout 自定义尺寸 |
-| `Text box "XXX" ends too close to bottom edge` | 大字号 `<p>` 距离 body 底边 < 0.5 inch | 往上挪，留足下边距；PPT 底部本身就会被遮住一部分 |
+| `DIV element contains unwrapped text "XXX"` | Raw text inside a div | Wrap the text in `<p>` or `<h1>`-`<h6>` |
+| `CSS gradients are not supported` | Used linear/radial-gradient | Switch to solid color, or split with flex children |
+| `Text element <p> has background` | `<p>` tag has a background | Wrap with an outer `<div>` to carry the background; `<p>` only carries the text |
+| `Background images on DIV elements are not supported` | div uses background-image | Switch to an `<img>` tag |
+| `HTML content overflows body by Xpt vertically` | Content exceeds 540pt | Reduce content or shrink the font, or `overflow: hidden` to clip |
+| `HTML dimensions don't match presentation layout` | body size doesn't match pres layout | Use `960pt × 540pt` with `LAYOUT_WIDE`; or defineLayout with custom dimensions |
+| `Text box "XXX" ends too close to bottom edge` | A large-font `<p>` is less than 0.5 inch from the body bottom | Move it up, leave bottom margin; the very bottom of PPT is partly hidden anyway |
 
 ---
 
-## 基本工作流（3 步出 PPTX）
+## Basic Workflow (3 steps to PPTX)
 
-### Step 1：按约束写每页独立 HTML
+### Step 1: write per-slide independent HTML to the constraints
 
 ```
-我的Deck/
+My Deck/
 ├── slides/
-│   ├── 01-cover.html    # 每个文件都是完整 960×540pt HTML
+│   ├── 01-cover.html    # each file is a complete 960×540pt HTML
 │   ├── 02-agenda.html
 │   └── ...
-└── illustration/        # 所有 <img> 引用的图片
+└── illustration/        # all images referenced by <img>
     ├── chart1.png
     └── ...
 ```
 
-### Step 2：写 build.js 调用 `html2pptx.js`
+### Step 2: write build.js that calls `html2pptx.js`
 
 ```js
 const pptxgen = require('pptxgenjs');
-const html2pptx = require('../scripts/html2pptx.js');  // 本 skill 脚本
+const html2pptx = require('../scripts/html2pptx.js');  // this skill's script
 
 (async () => {
   const pres = new pptxgen();
-  pres.layout = 'LAYOUT_WIDE';  // 13.333 × 7.5 inch，匹配 HTML 的 960×540pt
+  pres.layout = 'LAYOUT_WIDE';  // 13.333 × 7.5 inch, matches HTML's 960×540pt
 
   const slides = ['01-cover.html', '02-agenda.html', '03-content.html'];
   for (const file of slides) {
@@ -246,89 +246,89 @@ const html2pptx = require('../scripts/html2pptx.js');  // 本 skill 脚本
 })();
 ```
 
-### Step 3：打开检查
+### Step 3: open and check
 
-- PowerPoint/Keynote 打开导出 PPTX
-- 双击任意文字应能直接编辑（如果是图片说明第 1 条违反了）
-- 验证 overflow：每页应该在 body 范围内，没有被截
+- Open the exported PPTX in PowerPoint/Keynote
+- Double-clicking any text should let you edit it directly (if it's an image, rule 1 was violated)
+- Verify overflow: every slide should be within the body area, nothing clipped
 
 ---
 
-## 这条路径 vs 其他选项（什么时候选什么）
+## This Path vs. Other Options (what to pick when)
 
-| 需求 | 选什么 |
+| Need | Pick |
 |------|------|
-| 同事会改 PPTX 里的文字 / 发给非技术人员继续编辑 | **本文路径**（editable，需从头按 4 条约束写 HTML） |
-| 只是演讲用 / 发存档，不再改 | `export_deck_pdf.mjs`（多文件）或 `export_deck_stage_pdf.mjs`（单文件 deck-stage），出矢量 PDF |
-| 视觉自由度优先（动画、web component、CSS 渐变、复杂 SVG），接受不可编辑 | **PDF**（同上）——PDF 既保真又跨平台，比「图片 PPTX」更合适 |
+| Colleagues will edit text in PPTX / send to non-technical people to keep editing | **This path** (editable, must write HTML to the 4 constraints from the start) |
+| Just for presenting / sending to archive, no more editing | `export_deck_pdf.mjs` (multi-file) or `export_deck_stage_pdf.mjs` (single-file deck-stage) — vector PDF |
+| Visual freedom is the priority (animation, web component, CSS gradient, complex SVG) and you accept non-editable | **PDF** (same as above) — PDF is both faithful and cross-platform, more suitable than an "image PPTX" |
 
-**绝不要在视觉自由写好的 HTML 上硬跑 html2pptx**——实测视觉驱动的 HTML pass 率 < 30%，剩下的逐页改造比重写还慢。这种场景应该出 PDF，不是硬挤 PPTX。
+**Never force `html2pptx` to run on HTML written for visual freedom** — in practice visual-driven HTML's pass rate on html2pptx is <30%, and retrofitting the rest page-by-page is slower than rewriting. That scenario should ship a PDF, not jam a PPTX through.
 
 ---
 
-## Fallback：已有视觉稿但用户坚持要 editable PPTX
+## Fallback: Visual Mock Already Exists but the User Insists on Editable PPTX
 
-偶尔会遇到这个场景：你/用户已经写好一份视觉驱动的 HTML（渐变、web component、复杂 SVG 都用上了），本来出 PDF 最合适，但用户明确说「不行，必须是可编辑的 PPTX」。
+Occasionally you'll hit this scenario: you/the user have already written a visually driven HTML (gradients, web components, complex SVG all used), and PDF would be the right deliverable, but the user explicitly says "no, it has to be editable PPTX".
 
-**不要硬跑 `html2pptx` 期待它 pass**——实测视觉驱动 HTML 在 html2pptx 上 pass 率 <30%，剩下 70% 会报错或走样。正确的 fallback 是：
+**Don't force `html2pptx` to run hoping it'll pass** — in practice, visual-driven HTML's pass rate on html2pptx is <30%, and the other 70% will error out or render wrong. The correct fallback is:
 
-### Step 1 · 先告知局限性（透明沟通）
+### Step 1 · Disclose the limitations first (transparent communication)
 
-一句话跟用户说清三件事：
+In one sentence, make these three things clear to the user:
 
-> 「你现在的 HTML 用了 [具体列出：渐变 / web component / 复杂 SVG / ...]，直接转 editable PPTX 会 fail。我有两个方案：
-> - A. **出 PDF**（推荐）——视觉 100% 保留，接收方能看能印但不能改文字
-> - B. **以视觉稿为蓝本，重写一版 editable HTML**（保留色彩/布局/文案的设计决策，但按 4 条硬约束重新组织 HTML 结构，**牺牲**渐变、web component、复杂 SVG 等视觉能力）→ 再导出 editable PPTX
+> "Your current HTML uses [list specifically: gradients / web component / complex SVG / ...], and converting directly to editable PPTX will fail. I have two options:
+> - A. **Ship a PDF** (recommended) — visual is preserved 100%, the recipient can view and print but cannot edit the text
+> - B. **Treat the visual mock as a blueprint and rewrite an editable HTML version** (preserving the design decisions for color / layout / copy, but reorganizing the HTML structure to the 4 hard constraints, **giving up** visual capabilities like gradients, web component, complex SVG, etc.) → then export editable PPTX
 >
-> 你选哪个？」
+> Which one do you want?"
 
-不要把 B 方案说得云淡风轻——明确告知**会丢失什么**。让用户做取舍。
+Don't make option B sound breezy — explicitly tell them **what will be lost**. Let the user decide.
 
-### Step 2 · 如果用户选 B：AI 主动改写，不要求用户自己写
+### Step 2 · If the user picks B: the AI does the rewriting, don't ask the user to
 
-这里的 doctrine 是：**用户给的是设计意图，你负责翻译成合规实现**。不是让用户去学 4 条硬约束然后自己重写。
+The doctrine here is: **the user gives design intent, you turn it into a compliant implementation**. Don't expect the user to learn the 4 hard constraints and rewrite it themselves.
 
-改写时的遵循原则：
-- **保留**：色彩系统（主色/辅色/中性色）、信息层级（标题/副标题/正文/注解）、核心文案、layout 骨架（上中下 / 左右分栏 / 网格）、页面节奏
-- **降级**：CSS 渐变 → 纯色或 flex 分段、web component → 段落级 HTML、复杂 SVG → 简化的 `<img>` 或纯色几何、阴影 → 删除或降为极弱、自定义字体 → 向系统字体靠齐
-- **重写**：裸文字 → 包进 `<p>` / `<h*>`、`background-image` → `<img>` 标签、`<p>` 上的背景边框 → 外层 div 承载
+Principles to follow when rewriting:
+- **Preserve**: color system (primary / accent / neutral), information hierarchy (title / subtitle / body / annotation), core copy, layout skeleton (top-middle-bottom / left-right columns / grid), page rhythm
+- **Downgrade**: CSS gradient → solid color or flex segments, web component → paragraph-level HTML, complex SVG → simplified `<img>` or solid-color geometry, shadow → remove or reduce to very faint, custom font → align with system fonts
+- **Rewrite**: raw text → wrap in `<p>` / `<h*>`, `background-image` → `<img>` tag, background/border on `<p>` → moved onto outer div
 
-### Step 3 · 产出对照清单（透明交付）
+### Step 3 · Produce a before/after list (transparent delivery)
 
-改写完成后给用户一份 before/after 对照，让他知道哪些视觉细节被简化了：
+After the rewrite, give the user a before/after diff so they know which visual details were simplified:
 
 ```
-原设计 → editable 版调整
-- 标题区紫色渐变 → 主色 #5B3DE8 纯色背景
-- 数据卡片阴影 → 删除（改为 2pt 描边区分）
-- 复杂 SVG 折线图 → 简化为 <img> PNG（从 HTML 截图生成）
-- Hero 区 web component 动效 → 静态首帧（web component 无法翻译）
+Original design → editable adjustment
+- Purple gradient in the title area → primary color #5B3DE8 solid background
+- Shadow on data cards → removed (replaced with a 2pt outline)
+- Complex SVG line chart → simplified to <img> PNG (screenshot from HTML)
+- Hero-area web-component animation → static first frame (web components cannot be translated)
 ```
 
-### Step 4 · 导出 & 双格式交付
+### Step 4 · Export & dual-format delivery
 
-- `editable` 版 HTML → 跑 `scripts/export_deck_pptx.mjs` 出可编辑 PPTX
-- **建议同时保留**原视觉稿 → 跑 `scripts/export_deck_pdf.mjs` 出高保真 PDF
-- 双格式交付给用户：视觉稿的 PDF + 可编辑的 PPTX，各司其职
+- The `editable` HTML version → run `scripts/export_deck_pptx.mjs` to get an editable PPTX
+- **Recommend also keeping** the original visual mock → run `scripts/export_deck_pdf.mjs` for a high-fidelity PDF
+- Deliver both formats to the user: the PDF of the visual mock + the editable PPTX, each doing its job
 
-### 什么情况下直接拒绝 B 方案
+### When to refuse option B outright
 
-个别场景下改写代价过高，应该劝用户放弃 editable PPTX：
-- HTML 核心价值是动画或交互（改写后只剩静态首帧，信息量损失 50%+）
-- 页数 > 30，改写成本超过 2 小时
-- 视觉设计深度依赖精确 SVG / 自定义 filter（改写后和原图几乎无关）
+In some scenarios the cost of rewriting is too high and you should talk the user out of editable PPTX:
+- The core value of the HTML is animation or interaction (after rewriting, only the static first frame is left — 50%+ of the information is lost)
+- More than 30 pages, rewriting takes more than 2 hours
+- The visual design relies deeply on precise SVG / custom filters (the rewrite is almost unrelated to the original)
 
-此时告诉用户：「这个 deck 改写代价过高，建议出 PDF 而不是 PPTX。如果接收方确实要 pptx 格式，就接受视觉会大幅朴素化——要不要换成 PDF？」
+Tell the user in this case: "The rewrite cost for this deck is too high — I recommend shipping a PDF instead of PPTX. If the recipient really needs the pptx format, accept that the visuals will be heavily simplified — do you want to switch to PDF instead?"
 
 ---
 
-## 为什么 4 条约束不是 Bug 而是物理约束
+## Why the 4 Constraints Aren't Bugs but Physical Constraints
 
-这 4 条不是 `html2pptx.js` 作者偷懒——它们是 **PowerPoint 文件格式（OOXML）本身的约束**投射到 HTML 上的结果：
+These 4 aren't `html2pptx.js`'s author being lazy — they are **constraints of the PowerPoint file format (OOXML) itself** projected onto HTML:
 
-- PPTX 里文字必须在 text frame（`<a:txBody>`），对应段落级 HTML 元素
-- PPTX 的 shape 和 text frame 是两个对象，无法在同一 element 上同时画背景和写文字
-- PPTX 的 shape fill 对 gradient 支持有限（仅某些 preset gradients，不支持 CSS 任意角度渐变）
-- PPTX 的 picture 对象必须引用真实图片文件，不是 CSS 属性
+- Text in PPTX must be inside a text frame (`<a:txBody>`), corresponding to a paragraph-level HTML element
+- PPTX's shape and text frame are two separate objects — you can't draw a background and write text on the same element
+- PPTX's shape fill has limited gradient support (only certain preset gradients; arbitrary CSS angle gradients are not supported)
+- PPTX's picture object must reference a real image file, not a CSS property
 
-理解这点后，**不要期待工具变聪明** —— 是 HTML 写法要适配 PPTX 格式，不是反过来。
+Once you internalize this: **don't expect the tool to get smarter** — it's the HTML that has to adapt to the PPTX format, not the other way around.

--- a/references/hero-animation-case-study.md
+++ b/references/hero-animation-case-study.md
@@ -1,86 +1,86 @@
-# Gallery Ripple + Multi-Focus · 场景编排哲学
+# Gallery Ripple + Multi-Focus · Scene Choreography Philosophy
 
-> 从 huashu-design hero 动画 v9（25 秒，8 场景）里提炼出的**一种可复用的视觉编排结构**。
-> 不是动画制作流水线，是**什么场景下这种编排是"对的"**。
-> 实战参考：[demos/hero-animation-v9.mp4](../demos/hero-animation-v9.mp4) · [https://www.huasheng.ai/huashu-design-hero/](https://www.huasheng.ai/huashu-design-hero/)
+> A reusable visual choreography structure distilled from the Huashu Design hero animation v9 (25s, 8 scenes).
+> Not an animation production pipeline — this is about **when this choreography is "right"**.
+> Real reference: [demos/hero-animation-v9.mp4](../demos/hero-animation-v9.mp4) · [https://www.huasheng.ai/huashu-design-hero/](https://www.huasheng.ai/huashu-design-hero/)
 
-## 一句话先行
+## One-line lead
 
-> **当你有 20+ 同质视觉素材、场景需要"表达规模感和深度"时，优先考虑 Gallery Ripple + Multi-Focus 这套编排，而不是堆砌排版。**
+> **When you have 20+ visually homogeneous assets and the scene needs to express "scale and depth", reach for Gallery Ripple + Multi-Focus instead of stacking typography.**
 
-通用 SaaS feature 动画、产品发布会、skill 推广、系列作品集展示——只要素材数量够、风格一致，这套结构几乎都能出效果。
+Generic SaaS feature animations, product launches, skill promos, portfolio reels — as long as the asset count is high enough and the style is consistent, this structure almost always works.
 
 ---
 
-## 这个手法究竟在表达什么
+## What this technique actually expresses
 
-不是"秀素材"——是通过**两个节奏变化**讲一个叙事：
+It isn't "showing off assets" — it tells a story through **two rhythm shifts**:
 
-**第一拍 · Ripple 展开（~1.5s）**：从中心向四周扩散出 48 张卡片，观众被"量"震住——「哦，这东西有这么多产出」。
+**Beat one · Ripple expansion (~1.5s)**: 48 cards radiate outward from the center; the audience is struck by the *quantity* — "oh, this thing has produced that much".
 
-**第二拍 · Multi-Focus（~8s，4 次循环）**：镜头在慢速 pan 的同时，4 次把背景 dim + desaturate，把某一张卡单独放大到屏幕中央——观众从"量的冲击"切换到"质的凝视"，每次 1.7s 节奏稳定。
+**Beat two · Multi-Focus (~8s, 4 cycles)**: while the camera slow-pans, 4 times the background is dimmed + desaturated and a single card is enlarged to screen center — the audience switches from "the shock of quantity" to "the gaze of quality", each beat steady at 1.7s.
 
-**核心叙事结构**：**规模（Ripple） → 凝视（Focus × 4） → 淡出（Walloff）**。这三拍组合起来表达的是「Breadth × Depth」——不只是能做很多，每一个还都值得停下来看。
+**Core narrative structure**: **Scale (Ripple) → Gaze (Focus × 4) → Fade-out (Walloff)**. The three beats combined express "Breadth × Depth" — not just that you can do a lot, but that every single one is worth pausing on.
 
-对比一下反例：
+Contrast with counterexamples:
 
-| 做法 | 观众感知 |
+| Approach | Audience perception |
 |------|---------|
-| 48 张卡静态排列（没有 Ripple）| 好看但无叙事，像一张 grid screenshot |
-| 一张一张快切（没有 Gallery context）| 像 slideshow，失去"规模感" |
-| 只有 Ripple 没有 Focus | 震住了但没让人记住任何具体一张 |
-| **Ripple + Focus × 4（本配方）** | **先震撼于量，再凝视于质，最后平静淡出——完整情绪弧线** |
+| 48 cards arranged statically (no Ripple) | Pretty but no narrative — looks like a grid screenshot |
+| Cards cut one by one (no Gallery context) | Feels like a slideshow, the "scale" is lost |
+| Ripple but no Focus | They're shocked but won't remember any specific card |
+| **Ripple + Focus × 4 (this recipe)** | **Shocked by quantity, then gaze at quality, then fade calmly — a complete emotional arc** |
 
 ---
 
-## 前置条件（必须全部满足）
+## Preconditions (all four required)
 
-这套编排**不是万能的**，下面 4 条缺一不可：
+This choreography **isn't universal**. All four conditions below must hold:
 
-1. **素材规模 ≥ 20 张，最好 30+**
-   少于 20 张 Ripple 会显得"空"——48 格里每格都在动才有密度感。v9 用了 48 格 × 32 张图（循环填充）。
+1. **Asset count ≥ 20, ideally 30+**
+   Fewer than 20 and the Ripple looks "thin" — you need every cell of 48 to be moving for the density to register. v9 uses 48 cells × 32 images (cycled).
 
-2. **素材视觉风格一致**
-   全是 16:9 slide 预览 / 全是 app 截图 / 全是封面设计——长宽比、色调、版式得像是"一套"。混搭会让 Gallery 看起来像剪贴板。
+2. **Visually consistent assets**
+   All 16:9 slide previews / all app screenshots / all cover designs — aspect ratio, palette and layout have to look like "a set". Mixing makes the Gallery feel like a clipboard.
 
-3. **素材单独放大后仍有可读信息**
-   Focus 是把某张卡放大到 960px 宽，如果原图放大后糊了或信息稀薄，Focus 这一拍就废了。反向验证：能不能从 48 张里挑出 4 张作为"最有代表性"的？挑不出来就说明素材质量不齐。
+3. **Each asset still has readable information when enlarged**
+   Focus blows a card up to 960px wide. If the source goes blurry or feels information-thin at that size, the Focus beat is wasted. Reverse test: can you pick 4 out of 48 as "most representative"? If you can't, the asset quality isn't even.
 
-4. **场景本身是 landscape 或 square，不是竖屏**
-   Gallery 的 3D 倾斜（`rotateX(14deg) rotateY(-10deg)`）需要横向延伸感，竖屏会让倾斜效果看起来窄且别扭。
+4. **Scene is landscape or square, not portrait**
+   The Gallery's 3D tilt (`rotateX(14deg) rotateY(-10deg)`) needs lateral extension; portrait makes the tilt look narrow and awkward.
 
-**缺条件的后备路径**：
+**Fallbacks when a condition is missing**:
 
-| 缺什么 | 退化为什么 |
+| Missing | Degrade to |
 |-------|-----------|
-| 素材 < 20 张 | 改用「3-5 张并排静态展示 + 逐个 focus」 |
-| 风格不一致 | 改用「封面 + 3 章节大图」的 keynote-style |
-| 信息稀薄 | 改用「data-driven dashboard」或「金句 + 大字」 |
-| 竖屏场景 | 改用「vertical scroll + sticky cards」 |
+| Fewer than 20 assets | Switch to "3–5 side-by-side static display + focus each in turn" |
+| Inconsistent style | Switch to "cover + 3 chapter hero images" keynote-style |
+| Thin information | Switch to "data-driven dashboard" or "headline + big type" |
+| Portrait scene | Switch to "vertical scroll + sticky cards" |
 
 ---
 
-## 技术配方（v9 实战参数）
+## Technical recipe (v9 production parameters)
 
-### 4-Layer 结构
+### 4-Layer structure
 
 ```
 viewport (1920×1080, perspective: 2400px)
-  └─ canvas (4320×2520, 超大 overflow) → 3D tilt + pan
+  └─ canvas (4320×2520, large overflow) → 3D tilt + pan
       └─ 8×6 grid = 48 cards (gap 40px, padding 60px)
           └─ img (16:9, border-radius 9px)
       └─ focus-overlay (absolute center, z-index 40)
           └─ img (matches selected slide)
 ```
 
-**关键**：canvas 比 viewport 大 2.25 倍，这样 pan 才有"窥视更大世界"的感觉。
+**Key**: the canvas is 2.25× the viewport — this is what makes the pan feel like "peeking into a larger world".
 
-### Ripple 展开（距离延迟算法）
+### Ripple expansion (distance-delay algorithm)
 
 ```js
-// 每张卡的入场时间 = 距中心的距离 × 0.8s 延迟
+// Each card's entry time = distance-from-center × 0.8s delay
 const col = i % 8, row = Math.floor(i / 8);
-const dc = col - 3.5, dr = row - 2.5;       // 到中心的 offset
+const dc = col - 3.5, dr = row - 2.5;       // offset to center
 const dist = Math.hypot(dc, dr);
 const maxDist = Math.hypot(3.5, 2.5);
 const delay = (dist / maxDist) * 0.8;       // 0 → 0.8s
@@ -88,15 +88,15 @@ const localT = Math.max(0, (t - rippleStart - delay) / 0.7);
 const opacity = expoOut(Math.min(1, localT));
 ```
 
-**核心参数**：
-- 总时长 1.7s（`T.s3_ripple: [8.3, 10.0]`）
-- 最大延迟 0.8s（中心最早出，角落最晚）
-- 每张卡入场时长 0.7s
-- Easing: `expoOut`（爆发感，不是平滑）
+**Core parameters**:
+- Total duration 1.7s (`T.s3_ripple: [8.3, 10.0]`)
+- Max delay 0.8s (center first, corners last)
+- Per-card entry duration 0.7s
+- Easing: `expoOut` (explosive, not smooth)
 
-**同时做的事**：canvas scale 从 1.25 → 0.94（zoom out to reveal）—— 配合出现的同步推远感。
+**Simultaneously**: canvas scales from 1.25 → 0.94 (zoom out to reveal) — synced "pulling-back" feeling that matches the appearance.
 
-### Multi-Focus（4 次节奏）
+### Multi-Focus (4 beats)
 
 ```js
 T.focuses = [
@@ -107,14 +107,14 @@ T.focuses = [
 ];
 ```
 
-**节奏规律**：每个 focus 1.7s，间隔 0.6s 喘息。总计 8s（11.0–19.6s）。
+**Rhythm**: each focus is 1.7s with a 0.6s breath between. 8s total (11.0–19.6s).
 
-**每次 focus 内部**：
-- In ramp: 0.4s（`expoOut`）
-- Hold: 中间 0.9s（`focusIntensity = 1`）
-- Out ramp: 0.4s（`easeOut`）
+**Inside each focus**:
+- In ramp: 0.4s (`expoOut`)
+- Hold: middle 0.9s (`focusIntensity = 1`)
+- Out ramp: 0.4s (`easeOut`)
 
-**背景变化（这是关键）**：
+**Background change (this is the key)**:
 
 ```js
 if (focusIntensity > 0) {
@@ -125,13 +125,13 @@ if (focusIntensity > 0) {
 }
 ```
 
-**不只是 opacity——同时 desaturate + darken**。这让前景 overlay 的色彩"跳出来"，而不是只是"变亮一点"。
+**Not just opacity — also desaturate + darken at the same time**. This lets the foreground overlay's colors "pop", instead of just "getting a bit brighter".
 
-**Focus overlay 尺寸动画**：
-- 从 400×225（入场）→ 960×540（hold 态）
-- 外围有 3 层 shadow + 3px accent 色 outline ring，呈现"被框住的感觉"
+**Focus overlay size animation**:
+- From 400×225 (entry) → 960×540 (hold state)
+- 3 layers of shadow + a 3px accent-colored outline ring around it, giving the "framed" feeling
 
-### Pan（持续感让静止不无聊）
+### Pan (continuous motion so the still doesn't get boring)
 
 ```js
 const panT = Math.max(0, t - 8.6);
@@ -139,112 +139,112 @@ const panX = Math.sin(panT * 0.12) * 220 - panT * 8;
 const panY = Math.cos(panT * 0.09) * 120 - panT * 5;
 ```
 
-- 正弦波 + 线性 drift 双层运动——不是纯循环，每个时刻位置都不同
-- X/Y 频率不同（0.12 vs 0.09）避免视觉上看出"规律循环"
-- clamp 在 ±900/500px 防止漂出
+- Sine wave + linear drift, two layers of motion — not a pure loop; the position is different at every moment
+- X/Y frequencies differ (0.12 vs 0.09) so the audience can't pick out a "regular cycle"
+- Clamped at ±900/500px to prevent drifting off-canvas
 
-**为什么不用纯线性 pan**：纯线性观众会"预测"下一秒在哪；正弦+drift 让每一秒都是新的，3D 倾斜下产生"微晕船感"（好的那种），注意力被拉住。
+**Why not pure linear pan**: with a pure linear pan the audience can "predict" the next second; sine+drift makes every second new, and under the 3D tilt it produces a "slight seasickness" (the good kind) that keeps attention locked.
 
 ---
 
-## 5 个可复用模式（从 v6→v9 迭代中蒸馏）
+## 5 reusable patterns (distilled from the v6→v9 iteration)
 
-### 1. **expoOut 作为主 easing，不是 cubicOut**
+### 1. **expoOut as the primary easing, not cubicOut**
 
-`easeOut = 1 - (1-t)³`（平滑）vs `expoOut = 1 - 2^(-10t)`（爆发后迅速收敛）。
+`easeOut = 1 - (1-t)³` (smooth) vs `expoOut = 1 - 2^(-10t)` (burst then quick settle).
 
-**选择理由**：expoOut 的前 30% 很快达到 90%，更像物理阻尼，符合"重的东西落地"的直觉。特别适合：
-- 卡片入场（重量感）
-- Ripple 扩散（冲击波）
-- Brand 浮起（落定感）
+**Why pick it**: expoOut hits 90% of the way in the first 30% — more like physical damping, matching the intuition of "something heavy landing". Especially good for:
+- Card entries (sense of weight)
+- Ripple expansion (shockwave)
+- Brand float-up (landing-in-place)
 
-**什么时候仍用 cubicOut**：focus out ramp、对称的微动效。
+**When cubicOut still wins**: focus out ramps, symmetric micro-motion.
 
-### 2. **纸感底色 + 赤陶橙 accent（Anthropic 血统）**
+### 2. **Paper-tone ground + terracotta orange accent (Anthropic lineage)**
 
 ```css
---bg: #F7F4EE;        /* 暖纸 */
---ink: #1D1D1F;       /* 几乎黑 */
---accent: #D97757;    /* 赤陶橙 */
---hairline: #E4DED2;  /* 暖线条 */
+--bg: #F7F4EE;        /* warm paper */
+--ink: #1D1D1F;       /* near black */
+--accent: #D97757;    /* terracotta orange */
+--hairline: #E4DED2;  /* warm hairline */
 ```
 
-**为什么**：温暖底色在 GIF 压缩后依然有"呼吸感"，不像纯白会显得"屏幕感"。赤陶橙作为唯一 accent 贯穿 terminal prompt、dir-card 选中、cursor、brand hyphen、focus ring——所有视觉锚点都被这一个色串起来。
+**Why**: warm bases still feel like they "breathe" after GIF compression, unlike pure white which reads as "screen". Terracotta orange as the single accent runs through terminal prompts, dir-card selection, the cursor, brand hyphen, focus ring — every visual anchor is strung together by this one color.
 
-**v5 教训**：加了 noise overlay 以模拟"纸纹"，结果 GIF 帧压缩全废（每帧都不同）。v6 改为"只用底色 + 暖 shadow"，纸感保留 90%，GIF 体积缩小 60%。
+**Lesson from v5**: added a noise overlay to simulate "paper grain", which torched GIF frame compression (every frame different). v6 switched to "base color + warm shadow only" — paper feel preserved at 90% and GIF size dropped 60%.
 
-### 3. **两档 Shadow 模拟深度，不用真 3D**
+### 3. **Two-tier shadow simulates depth, no true 3D**
 
 ```css
 .gallery-card.depth-near { box-shadow: 0 32px 80px -22px rgba(60,40,20,0.22), ... }
 .gallery-card.depth-far  { box-shadow: 0 14px 40px -16px rgba(60,40,20,0.10), ... }
 ```
 
-用 `sin(i × 1.7) + cos(i × 0.73)` 确定性算法给每张卡分配 near/mid/far 三档 shadow——**视觉上有"三维堆叠"感，但每帧 transform 完全不变，GPU 消耗 0**。
+A deterministic `sin(i × 1.7) + cos(i × 0.73)` assigns each card one of three near/mid/far shadow tiers — **visually feels like "3D stacking", but no transform changes per frame, so GPU cost is zero**.
 
-**真 3D 的代价**：每个 card 单独 `translateZ`，GPU 每帧都在算 48 个 transform + shadow blur。v4 试过，Playwright 录制 25fps 都吃力。v6 的两档 shadow 肉眼效果差距 <5%，但成本差 10 倍。
+**Cost of real 3D**: every card needs its own `translateZ`, and the GPU computes 48 transforms + shadow blurs per frame. v4 tried this; Playwright struggled at 25fps. v6's two-tier shadow looks <5% different to the eye but costs 10× less.
 
-### 4. **字重变化（font-variation-settings）比字号变化更电影感**
+### 4. **Font weight variation (font-variation-settings) feels more cinematic than scale**
 
 ```js
 const wght = 100 + (700 - 100) * morphP;  // 100 → 700 over 0.9s
 wordmark.style.fontVariationSettings = `"wght" ${wght.toFixed(0)}`;
 ```
 
-Brand wordmark 从 Thin → Bold 用 0.9s 渐变，配合 letter-spacing 微调（-0.045 → -0.048em）。
+The brand wordmark morphs from Thin → Bold over 0.9s, paired with a letter-spacing nudge (-0.045 → -0.048em).
 
-**为什么比放大缩小好**：
-- 放大缩小观众看过太多，预期固化
-- 字重变化是"内在的充实感"，像气球被吹满，而不是"被推近"
-- variable fonts 是 2020+ 才普及的特性，观众下意识感觉"现代"
+**Why it beats scale animation**:
+- The audience has seen scale animations too many times; expectation is locked in
+- Weight variation reads as "internal filling-out", like a balloon inflating, not "being pushed forward"
+- Variable fonts only became common post-2020, so audiences subconsciously read it as "modern"
 
-**限制**：必须用支持 variable font 的字体（Inter/Roboto Flex/Recursive 等）。普通静态字体只能拟态（切换几个固定 weight 有跳变）。
+**Constraint**: needs a variable-font typeface (Inter / Roboto Flex / Recursive etc.). Static fonts can only fake it (cycling several fixed weights produces a jump).
 
-### 5. **Corner Brand 低强度持续签名**
+### 5. **Corner Brand — low-intensity persistent signature**
 
-Gallery 阶段左上角有个 `HUASHU · DESIGN` 小标识，16% opacity 色值，12px 字号，宽字距。
+During the Gallery phase, the top-left corner shows a small `HUASHU · DESIGN` mark — 16% opacity, 12px, wide letter-spacing.
 
-**为什么加这个**：
-- Ripple 爆发后观众容易"失焦"不记得在看什么，左上角轻标示帮助 anchor
-- 比全屏大 logo 更高级——做品牌的人知道，品牌签名不需要喊
-- 在 GIF 被截屏分享时仍留下归属信号
+**Why add it**:
+- After the Ripple burst the audience can "lose focus" and forget what they're watching; a small top-left mark anchors them
+- More upscale than a full-screen logo — people who do branding know that a brand signature doesn't need to shout
+- If the GIF is screenshot and shared, an attribution signal still remains
 
-**规则**：只在中段（画面 busy）出现，开场关闭（不遮 terminal），结尾关闭（brand reveal 是主角）。
-
----
-
-## 反例：什么时候不要用这套编排
-
-**❌ 产品演示（要展示功能的）**：Gallery 让每一张都一闪而过，观众记不住任何一个功能。改用「单屏 focus + tooltip 标注」。
-
-**❌ 数据驱动内容**：观众要读数字，Gallery 的快速节奏不给时间读。改用「数据图表 + 逐项 reveal」。
-
-**❌ 故事叙事**：Gallery 是"并列"结构，故事需要"因果"。改用 keynote 章节切换。
-
-**❌ 素材只有 3-5 张**：Ripple 密度不够，看起来像"补丁"。改用「静态排列 + 逐张高亮」。
-
-**❌ 竖屏（9:16）**：3D tilt 需要横向延伸，竖屏会让倾斜感觉"歪"而不是"展开"。
+**Rule**: only appears in the middle (busy frames); off during the opening (don't cover terminal); off during the close (brand reveal is the lead).
 
 ---
 
-## 如何判断自己的任务适用这套编排
+## Counter-cases: when NOT to use this choreography
 
-三步快速检查：
+**Bad fit — product demos (showing features)**: Gallery flashes every card past; the audience won't remember any one feature. Use "single-screen focus + tooltip annotations" instead.
 
-**Step 1 · 素材数量**：数一下你有多少同类视觉素材。< 15 → 停；15-25 → 凑；25+ → 直接用。
+**Bad fit — data-driven content**: audience needs to read numbers; Gallery's quick rhythm doesn't give them time. Use "data charts + item-by-item reveal".
 
-**Step 2 · 一致性测试**：把 4 张随机素材并排放，是否像「一套」？不像 → 先统一风格再做，或改方案。
+**Bad fit — story narrative**: Gallery is "parallel" structure; story needs "causal". Use keynote chapter transitions.
 
-**Step 3 · 叙事匹配**：你要表达的是「Breadth × Depth」（量 × 质）吗？还是「流程」「功能」「故事」？不是前者就别硬套。
+**Bad fit — only 3–5 assets**: Ripple density isn't there; it looks like "patching". Use "static layout + highlight each in turn".
 
-三步都 yes，直接 fork v6 HTML，改 `SLIDE_FILES` 数组和时间轴就能复用。调色板改 `--bg / --accent / --ink`，整体换皮不换骨。
+**Bad fit — portrait (9:16)**: 3D tilt needs lateral extension; portrait makes the tilt look "crooked" rather than "unfolding".
 
 ---
 
-## 相关 Reference
+## How to judge whether your task fits this choreography
 
-- 完整技术流程：[references/animations.md](animations.md) · [references/animation-best-practices.md](animation-best-practices.md)
-- 动画导出流水线：[references/video-export.md](video-export.md)
-- 音频配置（BGM + SFX 双轨）：[references/audio-design-rules.md](audio-design-rules.md)
-- Apple 画廊风格的横向参考：[references/apple-gallery-showcase.md](apple-gallery-showcase.md)
-- 源 HTML（v6 + 音频集成版）：`www.huasheng.ai/huashu-design-hero/index.html`
+Three-step quick check:
+
+**Step 1 · Asset count**: count your homogeneous visual assets. <15 → stop; 15–25 → marginal; 25+ → go.
+
+**Step 2 · Consistency test**: put 4 random assets side by side — do they look like "a set"? If not, unify the style first, or switch approach.
+
+**Step 3 · Narrative match**: are you expressing "Breadth × Depth" (quantity × quality)? Or "process / function / story"? If not the first, don't force it.
+
+Three yeses, just fork the v6 HTML, swap the `SLIDE_FILES` array and the timeline — that's all you need. Change `--bg / --accent / --ink` to reskin without changing the bones.
+
+---
+
+## Related References
+
+- Full technical pipeline: [references/animations.md](animations.md) · [references/animation-best-practices.md](animation-best-practices.md)
+- Animation export pipeline: [references/video-export.md](video-export.md)
+- Audio config (BGM + SFX twin-track): [references/audio-design-rules.md](audio-design-rules.md)
+- Apple-gallery-style lateral reference: [references/apple-gallery-showcase.md](apple-gallery-showcase.md)
+- Source HTML (v6 + audio-integrated): `www.huasheng.ai/huashu-design-hero/index.html`

--- a/references/launch-film-director-notes.md
+++ b/references/launch-film-director-notes.md
@@ -1,175 +1,175 @@
-# Launch Film 工作流：先写万字 director's notes，再做动画
+# Launch Film Workflow: Write the 10k-Char Director's Notes First, Then Animate
 
-> 高规格视觉作品（≥ 20 秒、含品牌叙事、含 slogan reveal、可能上 X / 公众号 / B 站推广）的标准工作流。
+> Standard workflow for high-spec visual work (≥ 20 seconds, with brand narrative, with slogan reveal, likely promoted on X / WeChat / Bilibili).
 >
-> 触发条件：任务是「产品升级宣传片 / 品牌 launch film / launch trailer / superbowl-tier ad / brand campaign / hero animation video」，且**用户对质量有明确预期**（如「超级碗品质感」「10x 细节」「Apple 级别」）。
+> Trigger condition: the task is "product-upgrade promo / brand launch film / launch trailer / Super-Bowl-tier ad / brand campaign / hero animation video", **and the user has stated clear quality expectations** (e.g. "Super-Bowl quality", "10x detail", "Apple-level").
 >
-> 反触发：不要在「快速做个动画 demo」「简单 motion graphic」「单个图标动画」时用这条流程——会过度工程化。
+> Anti-trigger: do not run this workflow on "quick animation demo", "simple motion graphic", or "single-icon animation" — it'll over-engineer.
 
 ---
 
-## 1. 为什么先写 director's notes
+## 1. Why write director's notes first
 
-实战教训（2026-05-11 huashu-md-html v2.0 项目）：
+Hard lesson (2026-05-11 huashu-md-html v2.0 project):
 
-第一轮直接动手写 HTML，产出的是「程序员视角的动画」——每个 capability 平均用力、节奏匀速、slogan 撞在一起、缺少叙事弧。
-第二轮接到用户「停下，先按苹果导演视角写 1 万字分镜脚本」的指令，写了 v5-director-notes.md（11500 字、13 镜 shot-by-shot spec），然后按脚本实施——一次过、每帧 pause 都耐看、节奏起伏有 climax。
+Round 1 jumped straight to HTML. The output was a "programmer-perspective animation" — every capability got equal weight, the pacing was uniform, the slogans collided with each other, and there was no narrative arc.
+Round 2 took the user's instruction "stop — write a 10,000-character storyboard from an Apple-director perspective first", produced v5-director-notes.md (11,500 chars, 13-shot shot-by-shot spec), then implemented from the script — one pass, every paused frame held up, pacing had peaks and a real climax.
 
-**核心差异**：写脚本是 think，写 HTML 是 execute。先 think 透了，execute 就是机械翻译。先 execute，每个 shot 都是临场决策，必然乱。
+**Core difference**: writing the script is *think*; writing HTML is *execute*. Think fully first and execute becomes mechanical translation. Execute first and every shot is an in-the-moment decision — guaranteed chaos.
 
-写 director's notes 不是「装」，是把所有视觉决策**在动手之前**沉淀成文档——每一镜都已经在脑里 visualize 过、reasoning 过、和上下文 trace 过。HTML 实施时不需要再做创意决策，只需要忠实翻译。
-
----
-
-## 2. 触发判断（先问自己 3 个问题）
-
-启动 launch film 工作流前问：
-
-1. **这支片承担品牌叙事吗？**（有 thesis / slogan reveal / 升级仪式感）—— 是 → 走 director's notes 流程
-2. **观众会暂停看吗？**（可能截图、做 X 海报、做封面、慢速 review）—— 是 → 每帧要耐看
-3. **客户/用户有「我希望像 XXX 那样」的参照？**（Apple / Anthropic / Nike / Penguin / 某导演）—— 是 → 必须明确视觉语境
-
-任一为「是」就走流程。三个都「否」就跳过，直接用 [animations.md](animations.md) 的标准流程。
+Writing director's notes isn't "posturing" — it's settling every visual decision into a document **before you touch code**. Every shot has already been visualized in your head, reasoned through, traced against context. When implementing HTML, no creative decisions are left — only faithful translation.
 
 ---
 
-## 3. Director's Notes 的 5 大部分结构
+## 2. Trigger judgement (ask yourself 3 questions first)
 
-万字（10000-12000 字中文 / 等量英文）director's notes 必须包含这 5 大部分。**任一部分缺失都属于不完整，质量会受影响**。
+Before launching the launch-film workflow:
 
-### Part I · Director's Statement（创作论，约 1500-2000 字）
+1. **Does this film carry brand narrative?** (a thesis / slogan reveal / upgrade ritual feel) — yes → run the director's-notes flow
+2. **Will the audience pause to look?** (might screenshot, make an X poster, make a cover, watch in slow review) — yes → every frame must hold up
+3. **Does the client/user have an "I want it like XXX" reference?** (Apple / Anthropic / Nike / Penguin / some director) — yes → the visual context must be explicit
 
-回答 5 个问题：
+Any one yes → run the flow. All three no → skip; use the standard flow in [animations.md](animations.md).
 
-1. **这部片不是什么？**（明确排除——如「这不是功能介绍片」「不是 demo」）
-2. **核心 thesis 一行**——观众看完只记一句话是哪句？
-3. **跟谁的语境对话？**——列出 5-8 个视觉参照（导演 / 设计师 / 品牌 / 摄影师 / 作品名 + 年份），说明每个参照学了什么
-4. **三类观众画像 + 对每类的承诺**：主受众 / 次受众 / 外受众，各对应一段
-5. **节奏哲学**——慢拍 / 加速 / 顶峰 / 缓收的曲线说明 + emotional climax 在第几秒（**不一定是最后一秒**）
+---
 
-最后加一段 anti-slop checklist：**这部片不做的事**（具体列出，不模糊）。
+## 3. The 5-Part Structure of Director's Notes
 
-### Part II · Visual System（视觉系统全谱，约 1500-2500 字）
+A 10k-character (10,000–12,000 chars in Chinese, equivalent in English) director's notes must contain these 5 parts. **Any missing part = incomplete, and quality will suffer**.
 
-这是工程化的视觉 spec。完整后任何执行者拿到都能产出一致的视觉。
+### Part I · Director's Statement (~1500–2000 chars)
 
-必含子节：
+Answer 5 questions:
 
-- **完整色板**：至少 8-10 色，每色含 HEX + 功能定义 + 占画面比例上限
-- **字体系统**：至少 6 个字号层级，每层级含字体名 + weight + size + letter-spacing + 用途
-- **网格系统**：画布尺寸 + 外边距 + column grid + baseline grid + 关键安全区 + 黄金分割锚点
-- **动画系统**：easing 库（4 条以内）+ duration 字典 + stagger 法则 + scene 过渡规则
-- **Chrome 元素**：贯穿全片的小细节（counter / chip / ticker / watermark / texture），每个含位置 + 入退场时机
-- **音频系统**：BGM 30 秒走向曲线（分层）+ SFX 字典（10+ cues 含时间码 + 音量 + 频段隔离）
-- **反 AI slop checklist**：per-shot 自检表（10-15 项）
+1. **What is this film NOT?** (Explicit exclusions — "this is not a feature-explainer", "not a demo")
+2. **The core thesis in one line** — if the audience remembers only one sentence after watching, which one is it?
+3. **What context are you in dialogue with?** — list 5–8 visual references (director / designer / brand / cinematographer / work-title + year), explaining what you learned from each
+4. **Three audience personas + a promise to each**: primary / secondary / outer audience, one paragraph each
+5. **Pacing philosophy** — the slow / accelerate / peak / settle curve + which second the emotional climax lands on (**not necessarily the last second**)
 
-铁律：**所有视觉决策都从 Visual System 推导，不要在 shot list 里临时发明新值**。
+End with an anti-slop checklist: **things this film will NOT do** (concrete, not vague).
 
-### Part III · Story Arc（故事弧，约 500-800 字）
+### Part II · Visual System (~1500–2500 chars)
 
-三幕结构 + 情绪曲线：
+This is the engineered visual spec. Once it's complete, any executor can deliver a consistent visual from it.
 
-- **Act I · SETUP**（0 → 第 1/5 时长，e.g. 0-6s for 30s）：观众进入，问题被提出
-- **Act II · ESCALATION**（中间 2/3）：答案展开，主题铺陈
-- **Act III · PAYOFF**（最后 1/4）：升华、slogan reveal、品牌印章
+Required subsections:
 
-含 ASCII 情绪曲线图 + emotional climax 时刻标记。
+- **Full palette**: at least 8–10 colors, each with HEX + functional definition + max screen-share
+- **Type system**: at least 6 size tiers, each with font name + weight + size + letter-spacing + usage
+- **Grid system**: canvas size + outer margin + column grid + baseline grid + key safe areas + golden-section anchors
+- **Animation system**: easing library (≤ 4) + duration dictionary + stagger rules + scene-transition rules
+- **Chrome elements**: small persistent details (counter / chip / ticker / watermark / texture), each with position + in/out timing
+- **Audio system**: 30-second BGM curve (with layers) + SFX dictionary (10+ cues with timecodes + volume + frequency-band isolation)
+- **Anti-AI-slop checklist**: per-shot self-check (10–15 items)
 
-**关键决策**：climax 不一定在末尾。30s 片子 climax 通常在 22-25s（不是 29s）——最后几秒是 resolution / decay，不是 peak。这条规则违反必然让作品「虎头蛇尾」。
+Ironclad rule: **every visual decision derives from the Visual System; don't invent new values inside the shot list**.
 
-### Part IV · Shot-by-Shot Storyboard（分镜脚本，约 5000-7000 字 · 占 60% 篇幅）
+### Part III · Story Arc (~500–800 chars)
 
-每镜含 10 个字段（缺一不可）：
+Three-act structure + emotion curve:
+
+- **Act I · SETUP** (0 → first 1/5 of runtime, e.g. 0–6s for 30s): audience enters, the problem is posed
+- **Act II · ESCALATION** (middle 2/3): the answer unfolds, theme accumulates
+- **Act III · PAYOFF** (last 1/4): elevation, slogan reveal, brand stamp
+
+Include an ASCII emotion curve + marked emotional-climax moment.
+
+**Critical decision**: the climax is NOT necessarily at the end. For 30s films the climax is usually at 22–25s (not 29s) — the last few seconds are resolution / decay, not peak. Violate this and you guarantee a "strong start, weak finish" feel.
+
+### Part IV · Shot-by-Shot Storyboard (~5000–7000 chars · 60% of the document)
+
+Each shot needs 10 fields (none optional):
 
 ```
 SHOT NN · NAME
-[TIMECODE]    起止时间 + 时长
-[FUNCTION]    这一镜在故事弧中的功能（一句话）
-[VISUAL]      画面构图 + 元素位置 + 运动方向
-[TYPE]        排版 spec（字体 / 字号 / 字距 / 行高 / 颜色 / 对齐）
-[ANIM]        每元素 in/out 时机 + easing + duration + stagger + delay
-[AUDIO]       music beat + SFX cue（每镜对应 BGM 节奏 + 必含 SFX 时间表）
-[CHROME]      四角元素状态（哪些 chrome 在 / 哪些 fade in/out / 哪个 pulse）
-[ANTI-SLOP]   这一镜通过了哪些自检项 + 有什么 120% 细节签名
-[WHY]         承接上一镜的逻辑 + 推进下一镜的钩子
+[TIMECODE]    start–end + duration
+[FUNCTION]    this shot's function in the story arc (one sentence)
+[VISUAL]      composition + element positions + motion direction
+[TYPE]        typography spec (font / size / tracking / line-height / color / alignment)
+[ANIM]        per-element in/out timing + easing + duration + stagger + delay
+[AUDIO]       music beat + SFX cue (BGM beat per shot + a must-include SFX schedule)
+[CHROME]      corner-element states (which chrome is on / which fades in/out / which pulses)
+[ANTI-SLOP]   which self-check items this shot passes + the 120% detail signature
+[WHY]         logic carrying over from previous shot + hook leading to the next
 ```
 
-**字段平均 30-80 字 → 每镜 400-700 字 → 12-15 镜 → 5000-7000 字**。
+**Fields average 30–80 chars → 400–700 chars per shot → 12–15 shots → 5000–7000 chars**.
 
-实战经验：写完 storyboard 后**自己读一遍**——任意一镜删掉，整支片是否还成立？如果可以删，那镜就是多余的，删掉。
+Real-world tip: after writing the storyboard, **read it through yourself** — delete any one shot, does the whole film still stand? If yes, that shot is redundant — delete it.
 
-### Part V · Production Manifest（制作清单，约 800-1200 字）
+### Part V · Production Manifest (~800–1200 chars)
 
-工程交付清单：
+Engineering deliverables checklist:
 
-- 字体加载 URL（含 preconnect）
-- CSS 变量（直接可粘贴）
-- BGM 来源选择标准 + Suno/Udio prompt 关键词 + 备选库
-- SFX 字典（按时间码逐 cue 列出文件路径 + 音量）
-- **关键帧验证计划**：12-15 张 pause-and-check 关键帧时间码，每帧验证项列出（fonts / positions / chrome state）
-- 录制参数（fps / codec / bitrate / preset）
-- ffmpeg 音频混合命令（含 audio stream 验证）
-- 交付物清单（mp4 / mp4-60fps / gif / poster.png / silent.mp4 / shot-list.csv）
-- 全链路时间估算（小时级精度）
-
----
-
-## 4. 写 director's notes 的 5 条建议
-
-**4.1 用导演的口吻，不用 PM 的口吻**
-
-❌「This shot displays the product features.」
-✅「This is the hero shot — if the audience pauses anywhere, I want it to be here.」
-
-导演笔记是给执行者读的，但也是给未来的自己读的。第一人称 + judgment 表达比 description 表达留更多决策线索。
-
-**4.2 引用具体作品（含年份），不只是流派名**
-
-❌「Apple-inspired」
-✅「Apple 'Designed by Apple in California' (2013, dir. Mark Romanek) — 学的是慢拍 + 衬线 + 大白底」
-
-引用具体作品的好处：(a) 任何观众都能上网搜到对照 (b) 你逼自己想清楚学的是什么具体技术 (c) 防止「灵感模糊」。
-
-**4.3 每个决策都 trace 回 first principle**
-
-整支片有一句 first principle（如 "Markdown is the new typewriter."）。每个具体决策——配色 / 字体 / 节奏 / chrome——都要能 trace 回这句话。
-
-trace 不上的决策就是装饰，删掉。
-
-**4.4 写 anti-slop 比写 do-this 更重要**
-
-「这部片不做的事」清单（紫渐变 / emoji / Lorem ipsum / Inter display / SVG 画人物 / 圆角卡 + 左 border accent）比「这部片做的事」清单更能保护质量。
-
-正向决策无穷多，负向 checklist 是有限的——但负向 checklist 一旦违反就是 slop。
-
-**4.5 写完不要立即实施——隔 30 分钟再读一遍**
-
-写作时大脑在「生产模式」，看不见 inconsistency。隔 30 分钟读自己写的 storyboard，会发现：
-- 某两镜功能重复（删一个）
-- 某镜叙事跳跃太大（加过渡）
-- emotional climax 位置错（移动）
-- chrome 元素和 shot 数量不匹配（重新对齐）
-
-这 30 分钟省下的是后期 2 小时的返工。
+- Font loading URLs (with preconnect)
+- CSS variables (paste-ready)
+- BGM source-selection criteria + Suno/Udio prompt keywords + alternate library
+- SFX dictionary (cue-by-cue file path + volume per timecode)
+- **Keyframe verification plan**: 12–15 pause-and-check keyframe timecodes, each with checklist items (fonts / positions / chrome state)
+- Recording parameters (fps / codec / bitrate / preset)
+- ffmpeg audio mix command (with audio-stream verification)
+- Deliverables list (mp4 / mp4-60fps / gif / poster.png / silent.mp4 / shot-list.csv)
+- End-to-end time estimate (hour precision)
 
 ---
 
-## 5. Director's Notes → HTML 实施流程
+## 4. 5 Tips for Writing Director's Notes
 
-写完 director's notes 后，HTML 实施步骤：
+**4.1 Use a director's voice, not a PM's voice**
 
-1. **复用 starter components**（`assets/animations.jsx` 的 Stage/Sprite/Easing/interpolate）— 不重新发明
-2. **CSS 变量直接从 Visual System Part II 粘贴** — 不在 HTML 里临时改色
-3. **按 Sprite start/end 时间轴对照 Part IV 时间码** — 不擅自加镜
-4. **chrome 元素抽成独立组件**（ChromeA/B/C/D），用 useTime() 驱动状态切换
-5. **destination cards 内容必须真实可读**（不是 fake bar lines）—— 这是 v5 项目里最被反复提及的 120% 细节签名
-6. **每写完一镜就立即截关键帧验证**（用 `?t=NN` URL 参数 + Playwright），不要写完全片再统一验证
+Bad: "This shot displays the product features."
+Good: "This is the hero shot — if the audience pauses anywhere, I want it to be here."
+
+Director's notes are written for the executor, but also for your future self. First-person + judgment leaves more decision trace than description.
+
+**4.2 Cite specific works (with year), not just school names**
+
+Bad: "Apple-inspired"
+Good: "Apple 'Designed by Apple in California' (2013, dir. Mark Romanek) — what we're learning: slow pacing + serif + big white field"
+
+Why cite specific works: (a) any audience can search for it and verify (b) you force yourself to think clearly about *which* specific technique you're learning (c) prevents "vague inspiration".
+
+**4.3 Trace every decision back to a first principle**
+
+The whole film has one first principle (e.g. "Markdown is the new typewriter."). Every concrete decision — palette / type / pacing / chrome — must trace back to this sentence.
+
+A decision that can't be traced is decoration — delete it.
+
+**4.4 Writing anti-slop matters more than writing do-this**
+
+A checklist of "things this film does NOT do" (purple gradients / emoji / Lorem ipsum / Inter display / SVG-drawn human figures / rounded card + left-border accent) protects quality better than a checklist of "things this film does".
+
+Positive decisions are infinite; the anti-slop checklist is finite — and once violated, it's slop.
+
+**4.5 Don't implement immediately after writing — let 30 minutes pass, then re-read**
+
+While writing your brain is in "production mode" — you can't see inconsistencies. 30 minutes later, re-reading your own storyboard you'll find:
+- Two shots have the same function (delete one)
+- One shot's narrative jump is too large (add a transition)
+- Emotional climax is mis-placed (move it)
+- Chrome elements and shot count don't align (re-align)
+
+These 30 minutes save 2 hours of rework later.
 
 ---
 
-## 6. 关键帧验证流程
+## 5. Director's Notes → HTML Implementation Flow
 
-URL 参数实现（必须在 Stage 组件加）：
+After the director's notes are written, the HTML implementation steps:
+
+1. **Reuse the starter components** (`Stage/Sprite/Easing/interpolate` from `assets/animations.jsx`) — don't reinvent
+2. **CSS variables paste directly from Visual System Part II** — don't tweak palette inside the HTML
+3. **Match Sprite start/end times against Part IV timecodes** — don't sneak in extra shots
+4. **Extract chrome elements as independent components** (ChromeA/B/C/D), driven by useTime() for state switching
+5. **Destination-card content must be real and readable** (not fake bar lines) — this is the 120% detail signature most repeatedly invoked in the v5 project
+6. **As soon as a shot is written, capture keyframes immediately** (using `?t=NN` URL parameter + Playwright); don't write the whole film then verify at the end
+
+---
+
+## 6. Keyframe Verification Flow
+
+URL-parameter implementation (must be added in the Stage component):
 
 ```js
 const urlMatch = window.location.search.match(/[?&]t=([\d.]+)/);
@@ -178,9 +178,9 @@ const [time, setTime] = useState(frozenTime != null ? frozenTime : 0);
 const [playing, setPlaying] = useState(frozenTime == null);
 ```
 
-→ 这样 `file:///path/animation.html?t=14.5` 直接 freeze 在 14.5 秒。
+→ Now `file:///path/animation.html?t=14.5` freezes at 14.5s.
 
-批量截图：
+Batch screenshots:
 
 ```bash
 for t in 0.5 2.5 4.9 7.0 10.5 13.5 16.5 19.0 21.5 23.4 25.5 28.0 29.9; do
@@ -192,102 +192,102 @@ for t in 0.5 2.5 4.9 7.0 10.5 13.5 16.5 19.0 21.5 23.4 25.5 28.0 29.9; do
 done
 ```
 
-每张截图必须验证：
-- [ ] 元素无溢出 1920×1080 canvas
-- [ ] 字距、行高 visually correct（不挤、不散）
-- [ ] 关键 typography 细节（句点颜色 / em-dash / italic / small caps）可识别
-- [ ] chrome 元素位置 + 状态正确
-- [ ] 反 AI slop checklist 通过
-- [ ] 「pause 时值得看」的 120% 细节存在
+Every screenshot must be verified for:
+- [ ] No element overflows the 1920×1080 canvas
+- [ ] Tracking and line-height are visually correct (not crammed, not loose)
+- [ ] Key typographic details (period color / em-dash / italic / small caps) are recognizable
+- [ ] Chrome element position + state correct
+- [ ] Anti-AI-slop checklist passes
+- [ ] The "worth-pausing" 120% detail is present
 
 ---
 
-## 7. 多视角并行策略（advanced）
+## 7. Multi-perspective Parallel Strategy (advanced)
 
-复杂项目（如 launch film 选不出方向 / 想看多个美学差异 / 客户没拍板风格）可以**启动多个 subagent 并行做不同导演视角的版本**。
+Complex projects (launch film with no clear direction / wanting to see multiple aesthetic differences / client hasn't picked a style) can **spin up multiple subagents in parallel doing director-versions in different perspectives**.
 
-实战配置（2026-05-11 huashu-md-html 项目，并行 6 个版本）：
+Real-world config (2026-05-11 huashu-md-html project, 6 parallel versions):
 
 ```
-v5  · 基线（Anthropic / Penguin Classics 出版社品位）
-v5a · Wes Anderson（对称 + 复古 + 章节卡片）
-v5b · Saul Bass（剪纸 + 60s 大字 + 几何切割）
-v5c · 王家卫（中文衬线 + 慢动作 + 怀旧）
-v5d · Massimo Vignelli（现代主义 grid + 红黑）
-v5e · 原研哉 Kenya Hara（极简日式 + 留白）
-v5f · 草间彌生 Yayoi Kusama（圆点 + 重复 + 单一强色）
+v5  · Baseline (Anthropic / Penguin Classics editorial taste)
+v5a · Wes Anderson (symmetry + retro + chapter cards)
+v5b · Saul Bass (cut-paper + 60s big type + geometric cuts)
+v5c · Wong Kar-wai (Chinese serif + slow motion + nostalgia)
+v5d · Massimo Vignelli (modernist grid + red and black)
+v5e · Kenya Hara (minimal Japanese + whitespace)
+v5f · Yayoi Kusama (polka dots + repetition + single strong color)
 ```
 
-每个 subagent 接到独立 brief：
-- 项目背景（同一份）
-- 必读参考（同一份 v5-director-notes.md 作为方法论模板）
-- **指定的艺术家 DNA**（色板 / 字体 / 视觉语言 / 节奏 / 招牌元素 / 反 slop 强化版本，每条 30-50 字）
-- 统一任务清单（director-notes.md + animation.html + keyframes/ + README.md）
-- 统一约束（30s / 1920×1080 / file:// / Google Fonts）
+Each subagent gets an independent brief:
+- Project background (same)
+- Required reading (same v5-director-notes.md as the methodology template)
+- **The artist's DNA** (palette / type / visual language / pacing / signature elements / reinforced anti-slop, 30–50 chars each)
+- Uniform task list (director-notes.md + animation.html + keyframes/ + README.md)
+- Uniform constraints (30s / 1920×1080 / file:// / Google Fonts)
 
-并行启动 + 后台运行，约 30-60 分钟出 6 套完整版本。
+Launch in parallel + run in background; about 30–60 minutes later, 6 complete versions land.
 
-完成后审校对比：
-1. 各版本核心美学决策表
-2. 关键帧并排对比（每版同时刻一帧）
-3. 投票：哪个最贴合用户的真实需求
+After completion, review and compare:
+1. Core aesthetic-decision table for each version
+2. Keyframes side-by-side (one frame per version at the same moment)
+3. Vote: which best fits the user's actual need
 
-**关键**：不要让 subagent 之间相互参考——它们必须独立产出，否则就会撞到「平均值」。每个 subagent 的指令里要明说「不要重复 v5 的美学」。
+**Key**: do NOT let subagents reference each other — they must produce independently, otherwise they converge to "the average". Each subagent's brief must explicitly say "do not repeat v5's aesthetic".
 
 ---
 
-## 8. 触发的几种典型场景
+## 8. Typical Trigger Scenarios
 
-| 用户场景 | 是否触发 | 备注 |
+| User scenario | Triggers? | Notes |
 |---------|---------|------|
-| 「做个 SaaS 升级宣传片」 | ✅ 触发 | 默认走完整流程 |
-| 「Apple 级别 / 超级碗品质感的视频」 | ✅ 触发 + 升级 | 强力推荐多视角并行 |
-| 「30 秒品牌 launch film」 | ✅ 触发 | |
-| 「这个项目 1 万字脚本再做动画」 | ✅ 触发 | 用户明确指明 |
-| 「简单 motion graphic，logo 转一下」 | ❌ 不触发 | 用 animations.md 标准流程 |
-| 「做个 onboarding 动画 demo」 | ❌ 不触发 | 用 animations.md |
-| 「教程视频带配音」 | ❌ 不触发 | 走 voiceover-pipeline.md |
-| 「单个 hero animation」 | ⚠️ 看复杂度 | 如果是高规格 hero，触发；普通 hero 用 hero-animation-case-study.md |
+| "Make a SaaS upgrade promo" | Yes | Default — run the full flow |
+| "Apple-level / Super-Bowl-quality video" | Yes + escalate | Strongly recommend multi-perspective parallel |
+| "30-second brand launch film" | Yes | |
+| "Write a 10k-char script for this project then animate" | Yes | User has stated it explicitly |
+| "Simple motion graphic, spin the logo" | No | Use the standard animations.md flow |
+| "Make an onboarding animation demo" | No | Use animations.md |
+| "Tutorial video with voiceover" | No | Use voiceover-pipeline.md |
+| "A single hero animation" | Depends on complexity | If it's a high-spec hero, trigger; ordinary hero uses hero-animation-case-study.md |
 
 ---
 
-## 9. 参考样本
+## 9. Reference sample
 
-完整 director's notes 参考样本（self-contained，本 skill 内）：
+A complete director's-notes reference sample (self-contained, inside this skill):
 
-`assets/director-notes-samples/launch-film-30s-sample.md`（约 78KB · 11500 字 · 13 镜 · 5 大部分齐全）
+`assets/director-notes-samples/launch-film-30s-sample.md` (~78KB · 11,500 chars · 13 shots · all 5 parts complete)
 
-原始项目位置（含对应实施 HTML + 关键帧）：
+Original project location (includes matching HTML implementation + keyframes):
 
-- `~/.claude/skills/huashu-md-html/demos/v5-director-notes.md`（director's notes）
-- `~/.claude/skills/huashu-md-html/demos/v5-six-forms.html`（HTML 实施）
-- `~/.claude/skills/huashu-md-html/demos/v5-keyframes/`（关键帧验证截图）
+- `~/.claude/skills/huashu-md-html/demos/v5-director-notes.md` (director's notes)
+- `~/.claude/skills/huashu-md-html/demos/v5-six-forms.html` (HTML implementation)
+- `~/.claude/skills/huashu-md-html/demos/v5-keyframes/` (keyframe-verification screenshots)
 
-写新项目时强烈建议**先 Read 这份样本**，理解工作量和细节密度，再决定要不要全套走流程。
-
----
-
-## 10. 反模式（不要这样做）
-
-❌ **写 1000 字的精简版 director's notes 就动手**
-→ 精简版必然漏 Visual System 的某个子项，导致 HTML 实施时不停回头补 spec。要做就做万字级，要省就直接跳过。
-
-❌ **storyboard 只写 5-8 镜**
-→ 30 秒片至少 12-15 镜（每镜 2-3 秒）。镜少 = 节奏匀速 = 没 climax。
-
-❌ **director's notes 写完就交付，不做实施**
-→ 文档不是交付物，动画才是。文档 + 动画一起交付，文档作为「设计依据」附录。
-
-❌ **多视角并行时让 subagent 看其他版本**
-→ 各 subagent 必须独立，否则趋同。审校阶段才对比。
-
-❌ **跳过关键帧验证直接录 MP4**
-→ 必然返工。关键帧验证是最便宜的 quality gate。
-
-❌ **把动画细节决策推迟到「等我录的时候再想」**
-→ 录制阶段是机械执行，不能做创意决策。所有决策必须在 director's notes 写死。
+For new projects, strongly recommended: **Read this sample first** to internalize the workload and detail density before deciding whether to run the full flow.
 
 ---
 
-*最后修订：2026-05-11*
-*真实案例：huashu-md-html v2.0 launch film（v5-director-notes.md）*
+## 10. Anti-patterns (don't do these)
+
+Bad: **Write a 1,000-char "trimmed" director's notes and dive in**
+→ The trimmed version inevitably misses a Visual System subsection, and you'll keep going back to add spec during HTML. Either do the 10k-char version or skip it entirely.
+
+Bad: **Storyboard only 5–8 shots**
+→ A 30-second film needs at least 12–15 shots (2–3s each). Fewer shots = uniform pacing = no climax.
+
+Bad: **Deliver after writing director's notes without implementing**
+→ The doc is not the deliverable, the animation is. Deliver both — the doc as an appendix "design rationale".
+
+Bad: **Let subagents see each other's versions during multi-perspective parallel**
+→ Subagents must be independent or they converge. Only compare during the review stage.
+
+Bad: **Skip keyframe verification and record MP4 directly**
+→ Guaranteed rework. Keyframe verification is the cheapest quality gate.
+
+Bad: **Defer animation-detail decisions to "I'll think about it when I record"**
+→ Recording is mechanical execution — no creative decisions allowed. Every decision must be locked in the director's notes.
+
+---
+
+*Last revised: 2026-05-11*
+*Real case: huashu-md-html v2.0 launch film (v5-director-notes.md)*

--- a/references/multi-perspective-parallel-case-study.md
+++ b/references/multi-perspective-parallel-case-study.md
@@ -1,237 +1,237 @@
-# 多视角并行实验 · Case Study
+# Multi-Perspective Parallel Experiment · Case Study
 
-> huashu-md-html v2.0 launch film 项目 · 2026-05-11
-> 6 位艺术家视角的并行 director's notes + HTML + 关键帧实验
-
----
-
-## 背景
-
-用户要求「为 huashu-md-html v2.0 制作 30 秒升级宣传片」时，主线程先产出了 v5 基线（Anthropic / Penguin Classics 出版社品位）。但用户认为可以做得更好，给了 critical instruction：
-
-> 「调用不同的 subagent 分别再去生成 6 个全然不同的表达方式和视觉设计的版本。你可以试试启用不同的导演和艺术家。然后全都完成后，再评判审校。」
-
-这是首次系统化的「多视角并行 director's notes」实验，验证了一套可复用的工作流。
+> huashu-md-html v2.0 launch film project · 2026-05-11
+> Six artists' perspectives — parallel director's notes + HTML + keyframes experiment
 
 ---
 
-## 6 个视角的选择逻辑
+## Background
 
-不要随便选 6 个 designer——他们必须**视觉差异度极高**，避免趋同。
+When the user asked for "a 30-second upgrade promo for huashu-md-html v2.0", the main thread first delivered the v5 baseline (Anthropic / Penguin Classics editorial taste). But the user thought it could go further and gave a critical instruction:
 
-最终选择的 6 个视角（含选择理由）：
+> "Spin up different subagents to generate 6 versions with entirely different expressions and visual designs. Try enabling different directors and artists. Once they're all done, judge and review."
 
-| 视角 | 流派 | 美学锚点 | 跟其他视角的差异 |
+This was the first systematic "multi-perspective parallel director's notes" experiment, and it validated a reusable workflow.
+
+---
+
+## Why these 6 perspectives
+
+Don't just pick any 6 designers — they must have **extremely high visual diversity** to avoid converging.
+
+The 6 perspectives chosen (with rationale):
+
+| Perspective | School | Aesthetic anchor | How it differs from the others |
 |------|------|---------|----------------|
-| **v5 基线** | 现代出版社 | Anthropic 赤陶橙 + Penguin Classics 衬线 + Vignelli grid | 安全的「品位」选择 |
-| **v5a Wes Anderson** | 电影章节美学 | The French Dispatch 杂志感 + 1960 Olivetti 工业目录 | 对称构图 + 章节卡片 + 装饰边框 |
-| **v5b Saul Bass** | 60s 影片标题艺术 | cut-paper + Trajan caps + 流动几何 | 剪纸 silhouette + 大字 + 强对角线 |
-| **v5c 王家卫** | 港式新浪潮 | 《花样年华》《2046》 letterboxing + 中文衬线 | 慢拍 + 雾化光晕 + 中文为主 |
-| **v5d Massimo Vignelli** | 1970 现代主义 | Knoll identity manual + NYC Subway map | 严格 grid + 3 色铁律 + 拒绝装饰 |
-| **v5e Kenya Hara** | 极简日式 | MUJI 海报 + 《白》 | 留白哲学 + 无 chrome + ma 间 |
-| **v5f Yayoi Kusama** | 装置艺术 | Infinity Mirror Rooms + Polka Dot Obsession | obsessive 重复 + 单一强色 + 圆点 |
+| **v5 baseline** | Modern publisher | Anthropic terracotta orange + Penguin Classics serif + Vignelli grid | Safe "good-taste" pick |
+| **v5a Wes Anderson** | Cinema chapter aesthetic | The French Dispatch magazine feel + 1960s Olivetti industrial catalogue | Symmetric composition + chapter cards + decorative borders |
+| **v5b Saul Bass** | 60s film-title art | Cut-paper + Trajan caps + flowing geometry | Cut-paper silhouettes + big type + strong diagonals |
+| **v5c Wong Kar-wai** | HK New Wave | *In the Mood for Love* / *2046* letterboxing + Chinese serif | Slow pacing + hazy halo + Chinese-led |
+| **v5d Massimo Vignelli** | 1970s modernism | Knoll identity manual + NYC Subway map | Strict grid + 3-color iron rule + refusal of ornament |
+| **v5e Kenya Hara** | Minimal Japanese | MUJI posters + *White* | Whitespace philosophy + no chrome + ma (間) |
+| **v5f Yayoi Kusama** | Installation art | Infinity Mirror Rooms + Polka Dot Obsession | Obsessive repetition + single strong color + polka dots |
 
-**选择原则**：
-1. **3 个不同地理文化**（西方电影 / 日本设计 / 港式中文）
-2. **3 个不同年代**（1960s / 1970s / 2010s+）
-3. **3 个不同载体**（电影 / 平面设计 / 装置艺术）
-4. **每个都有「跟训练语料里通用 SaaS 美学完全相反」的视觉签名**
+**Selection principles**:
+1. **3 different geographic cultures** (Western cinema / Japanese design / HK Chinese)
+2. **3 different eras** (1960s / 1970s / 2010s+)
+3. **3 different mediums** (film / graphic design / installation art)
+4. **Every one has a visual signature "completely opposite to the generic SaaS aesthetic in the training corpus"**
 
 ---
 
-## 实施流程
+## Execution flow
 
-### Step 1 · 为每个视角写独立 brief（约 15 分钟）
+### Step 1 · Write an independent brief for each perspective (~15 min)
 
-每个 brief 包含 8 个固定字段：
+Each brief contains 8 fixed fields:
 
 ```
-1. 项目背景（同一份）
-2. 必读参考（同一份 v5-director-notes.md 作方法论模板）
-3. 你要做的事（4 项交付清单）
-4. 该艺术家 DNA（核心字段 6 项）：
-   - 色板（具体 HEX）
-   - 字体（具体名字 + 替代方案）
-   - 视觉语言（核心几条）
-   - 招牌元素（identifiable signatures）
-   - 节奏（区别其他视角）
-   - 反 AI slop 强化版（在该风格语境下的禁区）
-5. 30 秒结构参考（4-6 个 shot 草拟）
-6. destination cards 设计要求（保持真实可读）
-7. 关键约束（30s / 1920×1080 / file:// / Google Fonts CDN）
-8. 输出验证清单 + 完成报告格式
+1. Project background (same across all)
+2. Required reading (the same v5-director-notes.md as a methodology template)
+3. What you have to do (4 deliverables)
+4. The artist's DNA (6 core fields):
+   - Palette (specific HEX)
+   - Typography (specific names + alternates)
+   - Visual language (a few core rules)
+   - Signature elements (identifiable signatures)
+   - Pacing (differentiates from other perspectives)
+   - Anti-AI-slop reinforcement (no-go zones in this style's context)
+5. 30-second structural reference (4–6 shot drafts)
+6. Destination-card design requirement (must stay real and readable)
+7. Hard constraints (30s / 1920×1080 / file:// / Google Fonts CDN)
+8. Output verification checklist + completion-report format
 ```
 
-**关键**：每个 brief 必须强调「**不要重复 v5 的美学**」——否则 subagent 会被 v5 director-notes 影响而趋同。
+**Key**: every brief must emphasize "**do NOT repeat v5's aesthetic**" — otherwise the subagent gets influenced by v5 director-notes and converges.
 
-### Step 2 · 并行启动 6 个 subagent（同一 message 中 6 个 Agent tool calls）
+### Step 2 · Launch 6 subagents in parallel (6 Agent tool calls in one message)
 
 ```js
 Agent({ subagent_type: "general-purpose", run_in_background: true, name: "v5a-anderson", ... })
 Agent({ subagent_type: "general-purpose", run_in_background: true, name: "v5b-bass", ... })
-// ... 6 个
+// ... 6 total
 ```
 
-后台运行，预期 30-60 分钟。
+Run in background; expect 30–60 min.
 
-### Step 3 · 等待期间的 idle work
+### Step 3 · Idle work during the wait
 
-不要 polling agent 状态。subagent 完成会自动 task-notification。等待期间做：
+Don't poll agent status. Subagents auto-emit task-notifications when they finish. While waiting, do:
 
-- 修主线程的 v5 基线 bug
-- 写 review framework（每个版本要打的分维度 / Q&A）
-- 沉淀方法论到 skill（这正是这份 case study 的来源）
-- 准备 final summary 文档骨架
+- Fix bugs in the main thread's v5 baseline
+- Write the review framework (the dimensions to score each version + Q&A)
+- Distill methodology back into the skill (which is exactly where this case study came from)
+- Prepare the final summary doc skeleton
 
-### Step 4 · 失败处理（约 16% 失败率，可接受）
+### Step 4 · Failure handling (~16% failure rate, acceptable)
 
-实战观测：6 个 subagent 中约 1 个会因网络或 token 超限失败（Bass 首轮 socket error）。处理：
+Real-world observation: roughly 1 of 6 subagents fails from network or token-limit issues (Bass first-round socket error). Handling:
 
-1. 收到 completion notification 时**立即检查**该 agent 的输出文件夹
-2. 缺少关键交付物 → 重启该 agent（同样 brief，可标注「上次失败，请重新执行」）
-3. 部分完成（如有 html 没截图）→ 主线程补 Playwright 截图，不重启 agent
+1. When the completion notification arrives, **immediately inspect that agent's output folder**
+2. Missing key deliverables → restart that agent (same brief, optionally noting "previous run failed, please re-execute")
+3. Partial completion (e.g. has html but no screenshots) → main thread fills in Playwright screenshots; do not restart the agent
 
-### Step 5 · 6 版本完成后系统审校
+### Step 5 · Systematic review once all 6 complete
 
-审校 framework（5 维度 + 3 顶层问 + use case 分配）：
+Review framework (5 dimensions + 3 top-level questions + use-case mapping):
 
 ```
-5 维度评分（每维 1-10）：
-- Distinctiveness 视觉差异化
-- Coherence 美学一致性
-- Anti-slop 反 AI slop 执行
-- Story arc 节奏与故事弧
-- Pause-and-look 细节密度
+5-dimension scoring (each 1–10):
+- Distinctiveness — visual differentiation
+- Coherence — aesthetic consistency
+- Anti-slop — execution against AI slop
+- Story arc — pacing and narrative arc
+- Pause-and-look — detail density
 
-3 顶层问：
-- Q1 截图分享？（能在社交平台触发暂停）
-- Q2 记一句话？（能留下命题级记忆）
-- Q3 跨时代？（5 年后回看不显廉价）
+3 top-level questions:
+- Q1 Screenshot-worthy? (can it trigger a pause on social platforms)
+- Q2 One-liner memory? (does a thesis-level memory stick)
+- Q3 Time-resistant? (does it still look upmarket 5 years later)
 
-use case 分配（按平台和受众）：
-- 公众号 / X / B 站 / 朋友圈 / Dribbble / 客户演示 / 私域 / ...
+Use case assignment (by platform and audience):
+- WeChat / X / Bilibili / Moments / Dribbble / client demo / private channel / ...
 ```
 
-详见 `assets/director-notes-samples/launch-film-30s-sample.md` 的同目录 REVIEW.md。
+See REVIEW.md alongside `assets/director-notes-samples/launch-film-30s-sample.md`.
 
 ---
 
-## 实验产出（事实）
+## Experiment output (facts)
 
-### 文档量
+### Document volume
 
-- v5 基线 director-notes：11500 字
-- 6 视角 director-notes 各 4000-12000 字
-- 总文档量：约 55000-70000 字
-- 5 大部分结构齐全：6/6 版本
+- v5 baseline director-notes: 11,500 characters
+- 6 perspective director-notes, each 4,000–12,000 characters
+- Total doc volume: ~55,000–70,000 characters
+- All 5 sections complete: 6/6 versions
 
-### HTML 实施
+### HTML implementation
 
-- 每版独立 animation.html，30 秒，1920×1080
-- 文件大小 28-74KB
-- 全部 file:// 可打开（不依赖 server）
+- One animation.html per version, 30 seconds, 1920×1080
+- File size 28–74KB
+- All open via file:// (no server needed)
 
-### 关键帧
+### Keyframes
 
-- 每版 10-18 张 PNG，覆盖完整 30 秒故事弧
-- 总截图量：80+ 张
-- 平均每张 PNG 大小：100-200KB
+- 10–18 PNGs per version, covering the full 30-second arc
+- Total screenshots: 80+
+- Average PNG size: 100–200KB
 
-### 时长
+### Duration
 
-- 6 个 subagent 并行运行：约 12-15 分钟（duration_ms 显示）
-- 主线程并行 idle work（修 v5 + 写方法论）：同期完成
-- 整体「从启动 6 视角到所有 deliverable 到位」：约 60 分钟
+- 6 subagents running in parallel: ~12–15 minutes (per duration_ms)
+- Main thread parallel idle work (v5 fixes + methodology writing): completed in the same window
+- Overall "from launching the 6 perspectives to all deliverables in place": ~60 minutes
 
 ---
 
-## 关键洞察（写给 huashu-design 的未来用户）
+## Key insights (for future huashu-design users)
 
-### 洞察 1 · 「先写万字 director's notes」方法论**完全 reproducible**
+### Insight 1 · The "write the 10k-char director's notes first" methodology is **fully reproducible**
 
-6 个 subagent 都按 5 大部分结构产出了 4000-12000 字的完整 spec，且实施 HTML 时都达到了 marketing-ready 质量。这证明方法论本身不依赖单一执行者的天赋——**只要 brief 给得清楚，多个独立执行者能产出一致的高质量结果**。
+All 6 subagents produced 4,000–12,000-character complete specs following the 5-part structure, and every HTML implementation hit marketing-ready quality. That proves the methodology does not depend on a single executor's talent — **as long as the brief is clear, multiple independent executors can produce consistently high-quality results**.
 
-### 洞察 2 · 「视角」必须具体到「作品 + 年份」
+### Insight 2 · "Perspectives" must be specific down to "work + year"
 
-每个 brief 里都列出具体作品对话：
+Every brief listed specific works to dialogue with:
 - Anderson → *The French Dispatch* (2021) + *Moonrise Kingdom* (2012) + Penguin Classics dust jackets + 1960s Olivetti catalogues
 - WKW → *In the Mood for Love* (2000) + *2046* (2004)
 - Vignelli → 1972 NYC Subway map + Knoll identity manual + *The Vignelli Canon*
-- Hara → MUJI brand 1995-2023 + 《白》 + Junya Ishigami transparency
-- Kusama → Infinity Mirrored Rooms (2013-2023) + Polka Dot Obsession 装置
+- Hara → MUJI brand 1995–2023 + *White* + Junya Ishigami transparency
+- Kusama → Infinity Mirrored Rooms (2013–2023) + Polka Dot Obsession installations
 
-**实战结果**：所有 subagent 都准确捕捉到了该作品的核心 visual DNA，而不是流派的「平均值」。
+**Result**: every subagent accurately captured that work's core visual DNA, not the "average" of the school.
 
-### 洞察 3 · 反 AI slop 的「风格强化版本」是关键
+### Insight 3 · The "style-specific reinforced version" of the anti-AI-slop checklist is critical
 
-通用 anti-slop（紫渐变 / emoji / SVG 人物）适用所有版本。但**每个风格还要写「专属 anti-slop」**：
+Generic anti-slop (purple gradients / emoji / SVG-drawn human figures) applies to every version. But **each style also needs its own anti-slop**:
 
-- Bass: 不用 Helvetica（太干净，Bass 是粗犷）
-- Vignelli: 不用圆角（所有 corner 90°）
-- Hara: 不用任何渐变 + 不用 sans display
-- Kusama: 不用现代 SaaS look
-- Anderson: 不用 cyber 配色
-- WKW: 不用 Inter（WKW 用衬线）
+- Bass: no Helvetica (too clean — Bass is rough)
+- Vignelli: no rounded corners (every corner 90°)
+- Hara: no gradients of any kind + no sans display
+- Kusama: no modern SaaS look
+- Anderson: no cyber palette
+- WKW: no Inter (WKW uses serifs)
 
-加了这些后，6 个版本风格纯度极高，无一相互趋同。
+With these added, the 6 versions hit a very high purity and none of them converged.
 
-### 洞察 4 · 多视角的真正价值不是「选 winner」
+### Insight 4 · The real value of multiple perspectives is not "pick the winner"
 
-最初设想是 A/B test 选最好的版本。实际审校时发现：**6 个版本各自有清晰 use case**：
-- v5 基线 → 产品页 / 微信读书（信息密度高）
-- Anderson → 公众号长文头图（翻杂志感强）
-- WKW → B 站 / 中文文化向（怀旧温度）
-- Vignelli → 设计圈 / Dribbble（每帧都是印刷海报）
-- Hara → 客户演示 / 静态截图（极简哲学）
-- Kusama → X 短视频 / 病毒传播（视觉冲击）
+The original idea was to A/B-test and pick the best one. During review, the discovery was: **all 6 versions have clear use cases**:
+- v5 baseline → product page / WeChat reader (high information density)
+- Anderson → WeChat long-form header (magazine-flip feel)
+- WKW → Bilibili / Chinese-culture-leaning (nostalgia warmth)
+- Vignelli → design community / Dribbble (every frame is a printed poster)
+- Hara → client demo / static screenshots (minimal philosophy)
+- Kusama → X short video / viral propagation (visual impact)
 
-**结论**：marketing 不是 single-shot，是 platform-specific multiplex。6 视角并行的真正价值是**让一个项目有 6 个差异化武器**，不是让 5 个版本上不了台面。
+**Conclusion**: marketing isn't single-shot, it's platform-specific multiplex. The real value of 6 parallel perspectives is **giving a single project 6 differentiated weapons**, not making 5 of them unfit for primetime.
 
-### 洞察 5 · subagent 的失败率 ~16% 是可接受的
+### Insight 5 · ~16% subagent failure rate is acceptable
 
-6 个里 1 个失败（Bass 首轮 socket error）。处理代价：重启 + 5 分钟简化版 brief，再等 12-15 分钟。**对比 vs. 等 1 个 agent 顺序跑 6 个版本（90+ 分钟）**——并行 + 重试明显更经济。
+1 of 6 failed (Bass first-round socket error). Recovery cost: restart + 5-minute trimmed brief, then another 12–15 min wait. **Compared to running 6 versions sequentially through 1 agent (90+ min)** — parallel + retry is clearly more economical.
 
-### 洞察 6 · 主线程在等待期间必须做 substantive idle work
+### Insight 6 · The main thread MUST do substantive idle work during the wait
 
-subagent 完成需要 12-15 分钟。这段时间主线程绝不该空闲：
+Subagent completion takes 12–15 minutes. The main thread absolutely shouldn't sit idle:
 
-- **修主版本 bug**（用户已经反馈的）
-- **写 review framework**（等审校时填）
-- **沉淀方法论到 skill**（如这份 case study）
-- **准备 final summary**（用户回来一目了然）
+- **Fix bugs in the main version** (whatever the user has already flagged)
+- **Write the review framework** (to fill in during review)
+- **Distill methodology into the skill** (this case study, for example)
+- **Prepare the final summary** (so the user comes back to clarity)
 
-这是 parallel multi-agent workflow 的「主线程职责」——不是 PM 等结果，是 orchestrator 同步推进。
+This is the main thread's responsibility in a parallel multi-agent workflow — not a PM waiting on results, but an orchestrator pushing work in sync.
 
 ---
 
-## 何时启用「多视角并行」
+## When to engage "multi-perspective parallel"
 
-| 场景 | 是否启用 | 原因 |
+| Scenario | Engage? | Reason |
 |------|---------|------|
-| 用户明确说「想看不同方向」「再多做几个版本」 | ✅ 立刻启用 | 直接需求 |
-| 第一版做出来用户不满意但说不清要啥 | ✅ 启用 | A/B 选优于「我猜你要啥」 |
-| 项目准备多平台分发（X / 公众号 / B 站 / 朋友圈） | ✅ 启用 | 每平台一个版本 |
-| 客户没拍板风格但有预算（time + token） | ✅ 启用 | 反复改 = 5 倍代价 |
-| 用户已经给了明确风格参考且只要 1 个版本 | ❌ 不启用 | 浪费 |
-| 任务是简单 motion graphic / icon 动画 | ❌ 不启用 | 过度工程化 |
-| 时间紧 < 30 分钟 | ❌ 不启用 | subagent 跑不完 |
+| User explicitly says "show me different directions" / "make a few more versions" | Yes — engage immediately | Direct request |
+| First version delivered but user is unsatisfied and can't articulate why | Yes | A/B beats "I'll guess what you want" |
+| Project will be distributed across multiple platforms (X / WeChat / Bilibili / Moments) | Yes | One version per platform |
+| Client hasn't picked a style but has budget (time + tokens) | Yes | Iterating back-and-forth = 5× cost |
+| User already gave a clear style reference and wants only one version | No | Waste |
+| Task is a simple motion graphic / icon animation | No | Over-engineering |
+| Time-constrained < 30 minutes | No | Subagents can't finish |
 
 ---
 
-## 完整方法论流程图
+## Full methodology flowchart
 
 ```
-用户 brief（含质量预期）
+User brief (with quality expectations)
        ↓
-[主线程] 写 v5 基线 director's notes（万字级 5 大部分）
+[Main thread] Write v5 baseline director's notes (10k-char 5-part)
        ↓
-[主线程] 实施 v5 HTML + 截关键帧（marketing baseline）
+[Main thread] Implement v5 HTML + capture keyframes (marketing baseline)
        ↓
-[决策点] 是否启用多视角？
+[Decision point] Engage multi-perspective?
        ↓ YES
-[主线程] 选 6 个差异化视角 + 写 6 份独立 brief（每份 8 字段）
+[Main thread] Pick 6 differentiated perspectives + write 6 independent briefs (8 fields each)
        ↓
-[6 subagents 并行]
+[6 subagents in parallel]
    ├── v5a brief → director-notes + html + keyframes + README
    ├── v5b brief → ...
    ├── v5c brief → ...
@@ -239,27 +239,27 @@ subagent 完成需要 12-15 分钟。这段时间主线程绝不该空闲：
    ├── v5e brief → ...
    └── v5f brief → ...
        ↓
-[主线程同步做] 修 v5 bug · 写 review framework · 沉淀方法论
+[Main thread in sync] Fix v5 bugs · write review framework · distill methodology
        ↓
-[全 6 通知到达]
+[All 6 notifications arrive]
        ↓
-[主线程] 失败检测 + 重试 / 补截图
+[Main thread] Failure detection + retry / supplementary screenshots
        ↓
-[主线程] 5 维度评分 + 3 顶层问 + use case 分配
+[Main thread] 5-dimension scoring + 3 top-level questions + use-case mapping
        ↓
-[主线程] 写 final REVIEW.md
+[Main thread] Write final REVIEW.md
        ↓
-[交付] 6 完整版本 + review + 平台分发推荐
+[Delivery] 6 complete versions + review + per-platform distribution recommendations
 ```
 
 ---
 
-## 相关文档
+## Related docs
 
-- 完整方法论：`references/launch-film-director-notes.md`
-- 单视角样本：`assets/director-notes-samples/launch-film-30s-sample.md`（v5 基线）
-- 实战项目位置：`~/.claude/skills/huashu-md-html/demos/`（含 6 + 1 视角全套文件）
-- 审校 review：`~/.claude/skills/huashu-md-html/demos/REVIEW.md`
+- Full methodology: `references/launch-film-director-notes.md`
+- Single-perspective sample: `assets/director-notes-samples/launch-film-30s-sample.md` (v5 baseline)
+- Real project location: `~/.claude/skills/huashu-md-html/demos/` (contains all 6 + 1 perspectives)
+- Review writeup: `~/.claude/skills/huashu-md-html/demos/REVIEW.md`
 
 ---
 

--- a/references/react-setup.md
+++ b/references/react-setup.md
@@ -1,10 +1,10 @@
-# React + Babel 项目规范
+# React + Babel Project Conventions
 
-用HTML+React+Babel做原型时必须遵守的技术规范。不遵守会炸。
+Technical conventions you must follow when prototyping with HTML + React + Babel. Violate them and things blow up.
 
-## Pinned Script Tags（必须用这些版本）
+## Pinned Script Tags (use exactly these versions)
 
-在HTML的`<head>`里放这三个script tag，用**固定版本+integrity hash**：
+Drop these three script tags into the HTML `<head>`, with **pinned versions + integrity hashes**:
 
 ```html
 <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
@@ -12,55 +12,55 @@
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 ```
 
-**不要**用`react@18`或`react@latest`这种unpinned版本——会出现版本漂移/缓存问题。
+**Do not** use unpinned versions like `react@18` or `react@latest` — they cause version drift and cache issues.
 
-**不要**省略`integrity`——CDN一旦被劫持或篡改，这是防线。
+**Do not** drop the `integrity` attribute — if the CDN is hijacked or tampered with, this is your line of defense.
 
-## 文件结构
+## File Structure
 
 ```
-项目名/
-├── index.html               # 主HTML
-├── components.jsx           # 组件文件（type="text/babel"加载）
-├── data.js                  # 数据文件
-└── styles.css               # 额外CSS（可选）
+project-name/
+├── index.html               # main HTML
+├── components.jsx           # component file (loaded with type="text/babel")
+├── data.js                  # data file
+└── styles.css               # extra CSS (optional)
 ```
 
-HTML里加载方式：
+How to load in HTML:
 
 ```html
-<!-- 先React+Babel -->
+<!-- React + Babel first -->
 <script src="https://unpkg.com/react@18.3.1/..."></script>
 <script src="https://unpkg.com/react-dom@18.3.1/..."></script>
 <script src="https://unpkg.com/@babel/standalone@7.29.0/..."></script>
 
-<!-- 然后你的组件文件 -->
+<!-- then your component files -->
 <script type="text/babel" src="components.jsx"></script>
 <script type="text/babel" src="pages.jsx"></script>
 
-<!-- 最后主入口 -->
+<!-- finally the main entry -->
 <script type="text/babel">
   const root = ReactDOM.createRoot(document.getElementById('root'));
   root.render(<App />);
 </script>
 ```
 
-**不要**用`type="module"`——会和Babel冲突。
+**Do not** use `type="module"` — it clashes with Babel.
 
-## 三条不可违反的规矩
+## Three Ironclad Rules
 
-### 规矩1：styles 对象必须用唯一命名
+### Rule 1: styles objects must have unique names
 
-**错误**（多组件时必炸）：
+**Wrong** (guaranteed to blow up with multiple components):
 ```jsx
 // components.jsx
 const styles = { button: {...}, card: {...} };
 
-// pages.jsx  ← 同名覆盖！
+// pages.jsx  ← same name, collides!
 const styles = { container: {...}, header: {...} };
 ```
 
-**正确**：每个组件文件的styles用唯一前缀。
+**Right**: every component file's styles uses a unique prefix.
 
 ```jsx
 // terminal.jsx
@@ -76,73 +76,73 @@ const sidebarStyles = {
 };
 ```
 
-**或者用inline styles**（小组件推荐）：
+**Or use inline styles** (recommended for small components):
 ```jsx
 <div style={{ padding: 16, background: '#111' }}>...</div>
 ```
 
-这条是**非协商**的。每次写`const styles = {...}`都必须replace成specific命名，否则多组件加载时全栈报错。
+This rule is **non-negotiable**. Every time you write `const styles = {...}` you must replace it with a specific name, otherwise the whole stack reports errors when multiple components load.
 
-### 规矩2：Scope 不共享，需手动export
+### Rule 2: Scope is not shared — export manually
 
-**关键认知**：每个`<script type="text/babel">`被Babel独立编译，它们之间**scope不通**。`components.jsx`里定义的`Terminal`组件，在`pages.jsx`里**默认是undefined**。
+**Key insight**: every `<script type="text/babel">` is compiled independently by Babel, and their scopes **do not** see each other. A `Terminal` component defined in `components.jsx` is **undefined** in `pages.jsx` by default.
 
-**解决方式**：在每个组件文件末尾，把要共享的组件/工具export到`window`：
+**Solution**: at the end of each component file, export the shared components/utilities onto `window`:
 
 ```jsx
-// components.jsx 末尾
+// end of components.jsx
 function Terminal(props) { ... }
 function Line(props) { ... }
 const colors = { green: '#...', red: '#...' };
 
 Object.assign(window, {
   Terminal, Line, colors,
-  // 所有你要在别处用的都列在这里
+  // list everything you want to use elsewhere
 });
 ```
 
-然后`pages.jsx`就能直接用`<Terminal />`，因为JSX会去`window.Terminal`找。
+Then `pages.jsx` can use `<Terminal />` directly, because JSX will look up `window.Terminal`.
 
-### 规矩3：不要用 scrollIntoView
+### Rule 3: Do not use scrollIntoView
 
-`scrollIntoView`会把整个HTML容器往上推，搞坏web harness的布局。**永远不要用**。
+`scrollIntoView` shoves the entire HTML container upward and breaks the web harness layout. **Never use it.**
 
-替代方案：
+Alternatives:
 ```js
-// 滚到容器内某个位置
+// scroll to a position inside the container
 container.scrollTop = targetElement.offsetTop;
 
-// 或者用element.scrollTo
+// or use element.scrollTo
 container.scrollTo({
   top: targetElement.offsetTop - 100,
   behavior: 'smooth'
 });
 ```
 
-## 调 Claude API（HTML内）
+## Calling the Claude API (inside HTML)
 
-部分原生 design-agent 环境（如 Claude.ai Artifacts）有免配置的 `window.claude.complete`，但大部分 agent 环境（Claude Code / Codex / Cursor / Trae / etc.）本地里**没有**。
+Some native design-agent environments (like Claude.ai Artifacts) ship a zero-config `window.claude.complete`, but most agent environments (Claude Code / Codex / Cursor / Trae / etc.) **do not** have it locally.
 
-如果你的 HTML 原型需要调用 LLM 做 demo（比如做个聊天 interface），两个选项：
+If your HTML prototype needs to call an LLM for a demo (e.g. building a chat interface), you have two options:
 
-### 选项A：不真调，用mock
+### Option A: Don't actually call it — use a mock
 
-Demo场景推荐。写一个假helper，返回预设的response：
+Recommended for demos. Write a fake helper that returns a preset response:
 ```jsx
 window.claude = {
   async complete(prompt) {
-    await new Promise(r => setTimeout(r, 800)); // 模拟延迟
-    return "这是一个mock响应。真部署时请替换为真API。";
+    await new Promise(r => setTimeout(r, 800)); // simulate latency
+    return "This is a mock response. Replace with a real API call when deploying.";
   }
 };
 ```
 
-### 选项B：真调Anthropic API
+### Option B: Actually call the Anthropic API
 
-需要API key，用户必须在HTML里填入自己的key才能跑。**永远不要把key硬编码在HTML里**。
+Requires an API key — the user must paste their own key into the HTML for it to run. **Never hardcode a key in the HTML.**
 
 ```html
-<input id="api-key" placeholder="粘贴你的Anthropic API key" />
+<input id="api-key" placeholder="Paste your Anthropic API key" />
 <script>
 window.claude = {
   async complete(prompt) {
@@ -167,19 +167,19 @@ window.claude = {
 </script>
 ```
 
-**注意**：浏览器直接调Anthropic API会遇到CORS问题。如果用户给你的预览环境不支持CORS bypass，这条路不通。这时候用选项A mock，或者告诉用户需要一个proxy后端。
+**Note**: calling the Anthropic API directly from the browser hits CORS. If the preview environment the user gives you doesn't support a CORS bypass, this path is closed. In that case use Option A's mock, or tell the user they need a proxy backend.
 
-### 选项 C：用 agent 侧的 LLM 能力生成 mock 数据
+### Option C: Use the agent's LLM to generate mock data
 
-如果只是本地演示用，可以在当前 agent 会话里临时调用该 agent 的 LLM 能力（或用户装的 multi-model 类 skill）先生成 mock 响应数据，再硬编码写进 HTML。这样 HTML 运行时完全不依赖任何 API。
+If it's only for local demo use, you can temporarily call the current agent session's LLM (or a multi-model skill the user has installed) to generate mock response data, then hardcode it into the HTML. The HTML then has zero runtime API dependency.
 
-## 典型 HTML 起手模板
+## A Typical HTML Starter Template
 
-拷贝这个模板作为React原型的骨架：
+Copy this template as the skeleton of a React prototype:
 
 ```html
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -204,10 +204,10 @@ window.claude = {
 <body>
   <div id="root"></div>
 
-  <!-- 你的组件文件 -->
+  <!-- your component files -->
   <script type="text/babel" src="components.jsx"></script>
 
-  <!-- 主入口 -->
+  <!-- main entry -->
   <script type="text/babel">
     const { useState, useEffect } = React;
 
@@ -226,43 +226,43 @@ window.claude = {
 </html>
 ```
 
-## 常见报错及解决
+## Common Errors and Fixes
 
-**`styles is not defined` 或 `Cannot read property 'button' of undefined`**
-→ 你在一个文件里定义了`const styles`，另一个文件覆盖了。给每个改成specific命名。
+**`styles is not defined` or `Cannot read property 'button' of undefined`**
+→ You defined `const styles` in one file and another file overwrote it. Rename each to a specific name.
 
 **`Terminal is not defined`**
-→ 跨文件引用时scope不通。在定义Terminal的文件末尾加`Object.assign(window, {Terminal})`。
+→ Cross-file references don't share scope. Add `Object.assign(window, {Terminal})` at the end of the file that defines Terminal.
 
-**整个页面白屏，控制台没错误**
-→ 多半是JSX语法错误但Babel没报在控制台。把`babel.min.js`临时换成`babel.js`非压缩版，错误信息更清晰。
+**Whole page is blank, no console errors**
+→ Most likely a JSX syntax error that Babel didn't surface to the console. Temporarily swap `babel.min.js` for the unminified `babel.js` — the error message will be clearer.
 
 **ReactDOM.createRoot is not a function**
-→ 版本不对。确认用了react-dom@18.3.1（而不是17或其他）。
+→ Wrong version. Confirm you're using react-dom@18.3.1 (not 17 or something else).
 
 **`Objects are not valid as a React child`**
-→ 你渲染了一个对象而不是JSX/字符串。通常是`{someObj}`写成了`{someObj.name}`。
+→ You rendered an object instead of JSX/string. Usually `{someObj}` written where you meant `{someObj.name}`.
 
-## 大项目怎么拆文件
+## How to Split a Large Project
 
-**>1000行的单文件**难维护。分拆思路：
+A single file over **1000 lines** is hard to maintain. Split it like this:
 
 ```
-项目/
+project/
 ├── index.html
 ├── src/
-│   ├── primitives.jsx      # 基础元素：Button、Card、Badge...
-│   ├── components.jsx      # 业务组件：UserCard、PostList...
+│   ├── primitives.jsx      # base elements: Button, Card, Badge...
+│   ├── components.jsx      # business components: UserCard, PostList...
 │   ├── pages/
-│   │   ├── home.jsx        # 首页
-│   │   ├── detail.jsx      # 详情页
-│   │   └── settings.jsx    # 设置页
-│   ├── router.jsx          # 简单路由（React state切换）
-│   └── app.jsx             # 入口组件
+│   │   ├── home.jsx        # home page
+│   │   ├── detail.jsx      # detail page
+│   │   └── settings.jsx    # settings page
+│   ├── router.jsx          # simple router (React state switching)
+│   └── app.jsx             # entry component
 └── data.js                 # mock data
 ```
 
-HTML里按顺序加载：
+Load them in order in HTML:
 ```html
 <script type="text/babel" src="src/primitives.jsx"></script>
 <script type="text/babel" src="src/components.jsx"></script>
@@ -273,4 +273,4 @@ HTML里按顺序加载：
 <script type="text/babel" src="src/app.jsx"></script>
 ```
 
-**每个文件末尾**都要`Object.assign(window, {...})`导出要共享的东西。
+**At the end of every file**, run `Object.assign(window, {...})` to export what should be shared.

--- a/references/scene-templates.md
+++ b/references/scene-templates.md
@@ -1,27 +1,27 @@
-# 场景模板库：按输出类型组织
+# Scene Template Library: Organized by Output Type
 
-> 与 design-styles.md 的「提示词DNA」组合使用。
-> 公式：`[风格提示词DNA] + [场景模板] + [具体内容描述]`
+> Use combined with the "Prompt DNA" in design-styles.md.
+> Formula: `[Style Prompt DNA] + [Scene Template] + [Specific content description]`
 
 ---
 
-## 1. 公众号封面 / 文章题图
+## 1. WeChat Official Account Cover / Article Header
 
-**规格**：
-- 封面图：2.35:1（900×383px 或 1200×510px）
-- 正文插图：16:9（1200×675px）或 4:3（1200×900px）
+**Specs**:
+- Cover image: 2.35:1 (900×383px or 1200×510px)
+- In-article illustration: 16:9 (1200×675px) or 4:3 (1200×900px)
 
-**关键设计要素**：
-- 视觉冲击力优先（用户在信息流中快速扫过）
-- 文字极少或无文字（公众号标题会覆盖在上面）
-- 色彩饱和度适中（微信阅读环境偏白）
-- 避免过度细节（缩略图也要可辨识）
+**Key design considerations**:
+- Visual impact first (readers scan past quickly in the feed)
+- Minimal or no text (the WeChat title overlays on top)
+- Moderate color saturation (WeChat reading environment leans white)
+- Avoid excessive detail (must read at thumbnail size)
 
-**推荐风格**：01 Pentagram / 11 Build / 12 Sagmeister / 18 Kenya Hara / 07 Field.io
+**Recommended styles**: 01 Pentagram / 11 Build / 12 Sagmeister / 18 Kenya Hara / 07 Field.io
 
-**场景提示词模板**：
+**Scene prompt template**:
 ```
-[风格DNA插入此处]
+[Insert Style DNA here]
 - Article cover image for WeChat subscription
 - Landscape format, 2.35:1 aspect ratio
 - Bold visual impact, minimal or no text
@@ -32,51 +32,51 @@
 
 ---
 
-## 2. 正文配图 / 概念插画
+## 2. In-Article Illustration / Concept Artwork
 
-**规格**：
-- 16:9（1200×675px）最通用
-- 1:1（800×800px）适合强调
-- 4:3（1200×900px）适合信息密集
+**Specs**:
+- 16:9 (1200×675px) most universal
+- 1:1 (800×800px) for emphasis
+- 4:3 (1200×900px) for dense information
 
-**关键设计要素**：
-- 服务于文章论点，不是装饰
-- 与上下文形成视觉节奏
-- 简洁表达一个核心概念
-- AI生成优先，HTML截图仅在精确数据表格时用
+**Key design considerations**:
+- Serves the article's argument, not decoration
+- Forms visual rhythm with surrounding context
+- Expresses one core concept concisely
+- AI generation first; HTML screenshots only when precise data tables are required
 
-**推荐风格**：根据文章调性选择，常用 01/04/10/17/18
+**Recommended styles**: chosen by article tone; commonly 01/04/10/17/18
 
-**场景提示词模板**：
+**Scene prompt template**:
 ```
-[风格DNA插入此处]
+[Insert Style DNA here]
 - Article illustration, concept visualization
 - [16:9 / 1:1 / 4:3] aspect ratio
-- Single clear concept: [描述核心概念]
+- Single clear concept: [describe core concept]
 - Serve the argument, not decoration
 - [Light/Dark] background to match article tone
 ```
 
 ---
 
-## 3. 信息图 / 数据可视化
+## 3. Infographics / Data Visualization
 
-**规格**：
-- 竖版长图：1080×1920px（手机阅读）
-- 横版：1920×1080px（文章内嵌）
-- 方形：1080×1080px（社交媒体）
+**Specs**:
+- Vertical long-form: 1080×1920px (mobile reading)
+- Horizontal: 1920×1080px (embedded in articles)
+- Square: 1080×1080px (social media)
 
-**关键设计要素**：
-- 信息层级清晰（标题 → 核心数据 → 细节）
-- 数据准确，不编造
-- 视觉引导线（用户阅读路径）
-- 适当使用图标/图表辅助理解
+**Key design considerations**:
+- Clear information hierarchy (title → core data → details)
+- Accurate data, never fabricated
+- Visual guide lines (the reader's path)
+- Use icons/charts judiciously to aid comprehension
 
-**推荐风格**：04 Fathom / 10 Müller-Brockmann / 02 Stamen / 17 Takram
+**Recommended styles**: 04 Fathom / 10 Müller-Brockmann / 02 Stamen / 17 Takram
 
-**场景提示词模板**：
+**Scene prompt template**:
 ```
-[风格DNA插入此处]
+[Insert Style DNA here]
 - Infographic / data visualization
 - [Vertical 1080x1920 / Horizontal 1920x1080 / Square 1080x1080]
 - Clear information hierarchy: title → key data → details
@@ -87,24 +87,24 @@
 
 ---
 
-## 4. PPT / Keynote 演示
+## 4. PPT / Keynote Presentation
 
-**规格**：
-- 标准：16:9（1920×1080px）
-- 宽屏：16:10（1920×1200px）
+**Specs**:
+- Standard: 16:9 (1920×1080px)
+- Widescreen: 16:10 (1920×1200px)
 
-**关键设计要素**：
-- 每页一个核心信息（不堆砌）
-- 字号层级明确（标题40pt+ / 正文24pt+ / 注释16pt+）
-- 大量留白，投影时更清晰
-- 图文比例至少 60:40
-- 一致的视觉系统（颜色、字体、间距）
+**Key design considerations**:
+- One core message per slide (do not pile up)
+- Clear font hierarchy (title 40pt+ / body 24pt+ / annotations 16pt+)
+- Generous whitespace — projection clarity demands it
+- Image-to-text ratio at least 60:40
+- Consistent visual system (colors, fonts, spacing)
 
-**推荐风格**：01 Pentagram / 10 Müller-Brockmann / 11 Build / 18 Kenya Hara / 04 Fathom
+**Recommended styles**: 01 Pentagram / 10 Müller-Brockmann / 11 Build / 18 Kenya Hara / 04 Fathom
 
-**场景提示词模板**：
+**Scene prompt template**:
 ```
-[风格DNA插入此处]
+[Insert Style DNA here]
 - Presentation slide design, 16:9
 - One core message per slide
 - Clear type hierarchy (title 40pt+, body 24pt+)
@@ -115,25 +115,25 @@
 
 ---
 
-## 5. PDF 白皮书 / 技术报告
+## 5. PDF Whitepaper / Technical Report
 
-**规格**：
-- A4 纵向（210×297mm / 595×842pt）
-- Letter 纵向（216×279mm / 612×792pt）
+**Specs**:
+- A4 portrait (210×297mm / 595×842pt)
+- Letter portrait (216×279mm / 612×792pt)
 
-**关键设计要素**：
-- 长文阅读优化（行宽66字符、行高1.5-1.8）
-- 清晰的章节导航系统
-- 页眉/页脚/页码的统一设计
-- 图表与正文的优雅共存
-- 引用/注释系统
-- 封面页设计精致
+**Key design considerations**:
+- Long-form reading optimization (66-character line width, 1.5–1.8 line height)
+- Clear chapter navigation
+- Unified header/footer/page-number design
+- Elegant coexistence of charts and body text
+- Citation/footnote system
+- Refined cover page
 
-**推荐风格**：10 Müller-Brockmann / 04 Fathom / 03 Information Architects / 17 Takram / 19 Irma Boom
+**Recommended styles**: 10 Müller-Brockmann / 04 Fathom / 03 Information Architects / 17 Takram / 19 Irma Boom
 
-**场景提示词模板**：
+**Scene prompt template**:
 ```
-[风格DNA插入此处]
+[Insert Style DNA here]
 - PDF document / white paper design
 - A4 portrait format (210×297mm)
 - Long-form reading optimized (66 char line width, 1.5 line height)
@@ -145,24 +145,24 @@
 
 ---
 
-## 6. 落地页 / 产品官网
+## 6. Landing Page / Product Website
 
-**规格**：
-- Desktop: 1440px 宽度设计（响应至320px）
-- 首屏高度：100vh
+**Specs**:
+- Desktop: design at 1440px width (responsive down to 320px)
+- Hero height: 100vh
 
-**关键设计要素**：
-- 首屏5秒内传达核心价值
-- 清晰的CTA（行动按钮）
-- 滚动叙事结构（问题→方案→证明→行动）
-- 移动端适配
-- 加载速度
+**Key design considerations**:
+- First screen delivers core value within 5 seconds
+- Clear CTA (call-to-action button)
+- Scroll narrative structure (problem → solution → proof → action)
+- Mobile adaptation
+- Load performance
 
-**推荐风格**：05 Locomotive / 01 Pentagram / 11 Build / 08 Resn / 06 Active Theory
+**Recommended styles**: 05 Locomotive / 01 Pentagram / 11 Build / 08 Resn / 06 Active Theory
 
-**场景提示词模板**：
+**Scene prompt template**:
 ```
-[风格DNA插入此处]
+[Insert Style DNA here]
 - Landing page / product website
 - Desktop 1440px width, responsive
 - Hero section 100vh, core value in 5 seconds
@@ -173,24 +173,24 @@
 
 ---
 
-## 7. App UI / 原型界面
+## 7. App UI / Prototype Interface
 
-**规格**：
-- iOS: 390×844pt（iPhone 15）
+**Specs**:
+- iOS: 390×844pt (iPhone 15)
 - Android: 360×800dp
-- 平板: 1024×1366pt（iPad Pro）
+- Tablet: 1024×1366pt (iPad Pro)
 
-**关键设计要素**：
-- 触摸友好（最小点击区44×44pt）
-- 系统设计语言一致性
-- 状态栏/导航栏/Tab栏的标准处理
-- 信息密度适中（移动端不宜过密）
+**Key design considerations**:
+- Touch-friendly (minimum tap target 44×44pt)
+- Consistent platform design language
+- Standard handling of status bar / navigation bar / tab bar
+- Moderate information density (mobile should not be too dense)
 
-**推荐风格**：17 Takram / 11 Build / 03 Information Architects / 01 Pentagram
+**Recommended styles**: 17 Takram / 11 Build / 03 Information Architects / 01 Pentagram
 
-**场景提示词模板**：
+**Scene prompt template**:
 ```
-[风格DNA插入此处]
+[Insert Style DNA here]
 - Mobile app UI design
 - iOS [390×844pt] / Android [360×800dp]
 - Touch-friendly (44pt minimum tap targets)
@@ -201,24 +201,24 @@
 
 ---
 
-## 8. 小红书配图
+## 8. Xiaohongshu (RED) Image
 
-**规格**：
-- 竖版：3:4（1080×1440px）最佳
-- 方形：1:1（1080×1080px）
-- 首图决定点击率
+**Specs**:
+- Vertical: 3:4 (1080×1440px) best
+- Square: 1:1 (1080×1080px)
+- The first image decides click-through
 
-**关键设计要素**：
-- 视觉吸引力第一（在瀑布流中竞争）
-- 可以有少量文字（但不超过画面20%）
-- 色彩鲜明但不俗
-- 生活感/质感/氛围感
+**Key design considerations**:
+- Visual appeal first (competes in a waterfall feed)
+- A little text is fine (but not more than 20% of the canvas)
+- Vivid but not gaudy colors
+- Lifestyle / texture / atmosphere
 
-**推荐风格**：12 Sagmeister / 11 Build / 20 Neo Shen / 09 Experimental Jetset
+**Recommended styles**: 12 Sagmeister / 11 Build / 20 Neo Shen / 09 Experimental Jetset
 
-**场景提示词模板**：
+**Scene prompt template**:
 ```
-[风格DNA插入此处]
+[Insert Style DNA here]
 - Social media image for Xiaohongshu (RED)
 - Vertical 3:4 (1080×1440px)
 - Eye-catching in waterfall feed
@@ -229,12 +229,12 @@
 
 ---
 
-## 组合示例
+## Combination Example
 
-**场景**：公众号封面，介绍一款AI编程工具，想要专业但有温度
+**Scenario**: WeChat cover introducing an AI coding tool — needs to feel professional yet warm.
 
-**Step 1**：选风格 → 17 Takram（专业+温度）
-**Step 2**：取Takram提示词DNA + 公众号封面模板
+**Step 1**: Pick a style → 17 Takram (professional + warmth)
+**Step 2**: Take Takram's Prompt DNA + the WeChat cover template
 
 ```
 Takram Japanese speculative design:
@@ -258,5 +258,5 @@ in software development, warm and professional atmosphere
 
 ---
 
-**版本**：v1.0
-**更新日期**：2026-02-13
+**Version**: v1.0
+**Updated**: 2026-02-13

--- a/references/sfx-library.md
+++ b/references/sfx-library.md
@@ -1,16 +1,16 @@
 # SFX Library · huashu-design
 
-> 全部由 ElevenLabs Sound Generation API 生成，苹果发布会级音质。
-> 产品级 SFX 资产库，覆盖花叔动画/演示/产品 Demo 全场景。
+> All generated via the ElevenLabs Sound Generation API — Apple-keynote-grade audio.
+> Production-grade SFX asset library, covering Huashu Design animations / demos / product demos end to end.
 
-**资产位置**：`assets/sfx/<category>/<name>.mp3`
-**总数**：37 个 SFX（30 批量生成 + 7 个 v7b 保留）
-**生成模型**：ElevenLabs Sound Generation API（prompt_influence 0.4）
-**音质**：44.1kHz MP3，苹果发布会级清晰度，无额外混响
+**Asset location**: `assets/sfx/<category>/<name>.mp3`
+**Total**: 37 SFX (30 batch-generated + 7 retained from v7b)
+**Generation model**: ElevenLabs Sound Generation API (prompt_influence 0.4)
+**Audio quality**: 44.1kHz MP3, Apple-keynote clarity, no extra reverb
 
 ---
 
-## 目录结构
+## Directory Structure
 
 ```
 assets/sfx/
@@ -27,158 +27,158 @@ assets/sfx/
 
 ---
 
-## 快速索引
+## Quick Index
 
-### ⌨️ Keyboard（键盘输入）
+### ⌨️ Keyboard
 
-| 文件 | 时长 | 用途 | Prompt 要点 |
+| File | Duration | Use | Prompt summary |
 |---|---|---|---|
-| `sfx/keyboard/type.mp3` | 0.5s | 单键敲击（mechanical keyboard single key） | mechanical keyboard single key press |
-| `sfx/keyboard/type-fast.mp3` | 1.5s | 连续快速打字（演示输入提示词） | fast continuous typing rhythm, apple magic keyboard |
-| `sfx/keyboard/delete-key.mp3` | 0.5s | backspace 回删 | single backspace key, low pitched thud |
-| `sfx/keyboard/space-tap.mp3` | 0.5s | 空格键轻击 | soft spacebar tap, wide flat |
-| `sfx/keyboard/enter.mp3` | 0.5s | 回车确认（v7b 保留） | enter key press, crisp tactile |
+| `sfx/keyboard/type.mp3` | 0.5s | Single keystroke (mechanical keyboard single key) | mechanical keyboard single key press |
+| `sfx/keyboard/type-fast.mp3` | 1.5s | Continuous fast typing (prompt-entry demo) | fast continuous typing rhythm, apple magic keyboard |
+| `sfx/keyboard/delete-key.mp3` | 0.5s | Backspace | single backspace key, low pitched thud |
+| `sfx/keyboard/space-tap.mp3` | 0.5s | Soft spacebar tap | soft spacebar tap, wide flat |
+| `sfx/keyboard/enter.mp3` | 0.5s | Enter / confirm (retained from v7b) | enter key press, crisp tactile |
 
-### 🎯 UI（界面交互）
+### 🎯 UI
 
-| 文件 | 时长 | 用途 | Prompt 要点 |
+| File | Duration | Use | Prompt summary |
 |---|---|---|---|
-| `sfx/ui/click.mp3` | 0.5s | 标准 UI 点击（v7b 保留） | crisp modern interface click |
-| `sfx/ui/click-soft.mp3` | 0.5s | 柔和 UI click（次要按钮/链接） | soft gentle button click, mid pitched |
-| `sfx/ui/focus.mp3` | 0.5s | 元素聚焦/选中（v7b 保留） | subtle focus tone, element highlight |
-| `sfx/ui/hover-subtle.mp3` | 0.5s | 悬停提示（微秒级反馈） | barely audible tick, air whisper |
-| `sfx/ui/tap-finger.mp3` | 0.5s | 移动端 tap（iOS 界面） | finger tap on touchscreen, muted thud |
-| `sfx/ui/toggle-on.mp3` | 0.5s | 开关打开 | ios toggle switch flip, satisfying click |
+| `sfx/ui/click.mp3` | 0.5s | Standard UI click (retained from v7b) | crisp modern interface click |
+| `sfx/ui/click-soft.mp3` | 0.5s | Soft UI click (secondary buttons / links) | soft gentle button click, mid pitched |
+| `sfx/ui/focus.mp3` | 0.5s | Element focus / selection (retained from v7b) | subtle focus tone, element highlight |
+| `sfx/ui/hover-subtle.mp3` | 0.5s | Hover hint (sub-second feedback) | barely audible tick, air whisper |
+| `sfx/ui/tap-finger.mp3` | 0.5s | Mobile tap (iOS UI) | finger tap on touchscreen, muted thud |
+| `sfx/ui/toggle-on.mp3` | 0.5s | Toggle switch on | ios toggle switch flip, satisfying click |
 
-### 🌊 Transition（过渡）
+### 🌊 Transition
 
-| 文件 | 时长 | 用途 | Prompt 要点 |
+| File | Duration | Use | Prompt summary |
 |---|---|---|---|
-| `sfx/transition/whoosh.mp3` | 0.5s | 标准 whoosh（v7b 保留） | air whoosh transition |
-| `sfx/transition/whoosh-fast.mp3` | 0.6s | 快速 whoosh（标题闪入、标签切换） | quick fast air whoosh, cinematic |
-| `sfx/transition/swipe-horizontal.mp3` | 0.7s | 横向滑动（轮播、tab 切换） | smooth left-to-right air movement |
-| `sfx/transition/slide-in.mp3` | 0.6s | 元素滑入（side panel、抽屉） | smooth soft whoosh with arrival |
-| `sfx/transition/dissolve.mp3` | 0.8s | 柔化融化（图片淡出淡入） | soft dissolve, airy shimmer |
+| `sfx/transition/whoosh.mp3` | 0.5s | Standard whoosh (retained from v7b) | air whoosh transition |
+| `sfx/transition/whoosh-fast.mp3` | 0.6s | Fast whoosh (title flash, tab swap) | quick fast air whoosh, cinematic |
+| `sfx/transition/swipe-horizontal.mp3` | 0.7s | Horizontal swipe (carousel, tab swap) | smooth left-to-right air movement |
+| `sfx/transition/slide-in.mp3` | 0.6s | Element slide-in (side panel, drawer) | smooth soft whoosh with arrival |
+| `sfx/transition/dissolve.mp3` | 0.8s | Soft dissolve (image fade in/out) | soft dissolve, airy shimmer |
 
-### 🃏 Container（卡片/容器）
+### 🃏 Container
 
-| 文件 | 时长 | 用途 | Prompt 要点 |
+| File | Duration | Use | Prompt summary |
 |---|---|---|---|
-| `sfx/container/card-snap.mp3` | 0.5s | 卡片吸附/定位（v7b 保留） | card snap into place |
-| `sfx/container/card-flip.mp3` | 0.7s | 卡片翻转（前后面切换） | playing card flip, crisp snap |
-| `sfx/container/stack-collapse.mp3` | 0.8s | 堆叠合拢（列表聚合） | cards stacking, paper taps collapsing |
-| `sfx/container/modal-open.mp3` | 0.6s | 模态框打开 | modal popping open, whoosh + thud |
+| `sfx/container/card-snap.mp3` | 0.5s | Card snap into position (retained from v7b) | card snap into place |
+| `sfx/container/card-flip.mp3` | 0.7s | Card flip (front/back swap) | playing card flip, crisp snap |
+| `sfx/container/stack-collapse.mp3` | 0.8s | Stack collapse (list aggregate) | cards stacking, paper taps collapsing |
+| `sfx/container/modal-open.mp3` | 0.6s | Modal open | modal popping open, whoosh + thud |
 
-### 🔔 Feedback（通知/反馈）
+### 🔔 Feedback
 
-| 文件 | 时长 | 用途 | Prompt 要点 |
+| File | Duration | Use | Prompt summary |
 |---|---|---|---|
-| `sfx/feedback/success-chime.mp3` | 1.0s | 成功提示（支付成功、任务完成） | two ascending bell tones, ios-style |
-| `sfx/feedback/error-tone.mp3` | 0.7s | 错误提示（警告、失败） | descending two-note warning, soft |
-| `sfx/feedback/notification-pop.mp3` | 0.6s | 消息弹出（toast、通知） | notification bloop, ios message alert |
-| `sfx/feedback/achievement.mp3` | 1.5s | 成就达成（里程碑、徽章） | triumphant rising arpeggio, game-style |
+| `sfx/feedback/success-chime.mp3` | 1.0s | Success cue (payment success, task done) | two ascending bell tones, ios-style |
+| `sfx/feedback/error-tone.mp3` | 0.7s | Error cue (warning, failure) | descending two-note warning, soft |
+| `sfx/feedback/notification-pop.mp3` | 0.6s | Message pop (toast, notification) | notification bloop, ios message alert |
+| `sfx/feedback/achievement.mp3` | 1.5s | Achievement unlocked (milestone, badge) | triumphant rising arpeggio, game-style |
 
-### ⏳ Progress（进度/状态）
+### ⏳ Progress
 
-| 文件 | 时长 | 用途 | Prompt 要点 |
+| File | Duration | Use | Prompt summary |
 |---|---|---|---|
-| `sfx/progress/loading-tick.mp3` | 0.5s | 加载计时（进度条节拍） | soft short pulse, minimal ambient |
-| `sfx/progress/complete-done.mp3` | 0.8s | 完成确认（step 完成） | two ascending satisfying tones |
-| `sfx/progress/generate-start.mp3` | 0.8s | AI 开始生成 | soft rising shimmer, magical whoosh |
+| `sfx/progress/loading-tick.mp3` | 0.5s | Loading tick (progress-bar beat) | soft short pulse, minimal ambient |
+| `sfx/progress/complete-done.mp3` | 0.8s | Step complete | two ascending satisfying tones |
+| `sfx/progress/generate-start.mp3` | 0.8s | AI generation start | soft rising shimmer, magical whoosh |
 
-### 💥 Impact（品牌/冲击）
+### 💥 Impact
 
-| 文件 | 时长 | 用途 | Prompt 要点 |
+| File | Duration | Use | Prompt summary |
 |---|---|---|---|
-| `sfx/impact/logo-reveal.mp3` | 0.7s | Logo impact（v7b 保留） | logo reveal thud |
-| `sfx/impact/logo-reveal-v2.mp3` | 1.5s | 更长的 Logo impact（电影感） | cinematic bass hit with shimmer tail |
-| `sfx/impact/brand-stamp.mp3` | 1.0s | 印章重击（认证、盖章） | rubber stamp thud, paper contact |
-| `sfx/impact/drop-thud.mp3` | 0.7s | 物件落地（插入、放置） | heavy thud, wood surface contact |
+| `sfx/impact/logo-reveal.mp3` | 0.7s | Logo impact (retained from v7b) | logo reveal thud |
+| `sfx/impact/logo-reveal-v2.mp3` | 1.5s | Longer logo impact (cinematic) | cinematic bass hit with shimmer tail |
+| `sfx/impact/brand-stamp.mp3` | 1.0s | Stamp slam (certification, sealing) | rubber stamp thud, paper contact |
+| `sfx/impact/drop-thud.mp3` | 0.7s | Object landing (insertion, placement) | heavy thud, wood surface contact |
 
-### ✨ Magic（AI 变换）
+### ✨ Magic (AI transforms)
 
-| 文件 | 时长 | 用途 | Prompt 要点 |
+| File | Duration | Use | Prompt summary |
 |---|---|---|---|
-| `sfx/magic/sparkle.mp3` | 0.8s | 魔法闪光（AI 高亮、惊喜） | bright twinkling stars, fairy dust |
-| `sfx/magic/ai-process.mp3` | 1.2s | AI 处理音（thinking 状态） | modulating digital hum with shimmer |
-| `sfx/magic/transform.mp3` | 1.0s | 变换过渡（morph 效果） | rising shimmer whoosh with sparkle tail |
+| `sfx/magic/sparkle.mp3` | 0.8s | Magic sparkle (AI highlight, delight) | bright twinkling stars, fairy dust |
+| `sfx/magic/ai-process.mp3` | 1.2s | AI processing (thinking state) | modulating digital hum with shimmer |
+| `sfx/magic/transform.mp3` | 1.0s | Transform transition (morph effect) | rising shimmer whoosh with sparkle tail |
 
-### 💻 Terminal（命令行）
+### 💻 Terminal
 
-| 文件 | 时长 | 用途 | Prompt 要点 |
+| File | Duration | Use | Prompt summary |
 |---|---|---|---|
-| `sfx/terminal/command-execute.mp3` | 0.5s | 命令执行 | crisp digital beep with tick, hacker ui |
-| `sfx/terminal/output-appear.mp3` | 0.6s | 输出出现 | rapid digital ticks, retro printout |
-| `sfx/terminal/cursor-blink.mp3` | 0.5s | 光标闪烁 | subtle soft digital pulse, rhythmic |
+| `sfx/terminal/command-execute.mp3` | 0.5s | Command execution | crisp digital beep with tick, hacker ui |
+| `sfx/terminal/output-appear.mp3` | 0.6s | Output appears | rapid digital ticks, retro printout |
+| `sfx/terminal/cursor-blink.mp3` | 0.5s | Cursor blink | subtle soft digital pulse, rhythmic |
 
 ---
 
-## 按场景推荐搭配
+## Recommended Pairings by Scene
 
-### 💻 Terminal 交互演示
+### 💻 Terminal Interaction Demo
 ```
 type (0.5s) → enter (0.5s) → command-execute (0.5s) → output-appear (0.6s)
 ```
-循环元素：`cursor-blink` 作为 idle 时的环境音。
+Loop element: `cursor-blink` as ambient during idle.
 
-### 🃏 卡片选择流程
+### 🃏 Card Selection Flow
 ```
-hover-subtle (0.5s, UI悬停) → click-soft (0.5s, 点击) → card-snap (0.5s, 定位)
+hover-subtle (0.5s, UI hover) → click-soft (0.5s, click) → card-snap (0.5s, settle)
 ```
-或进阶版：`card-flip` 做前后面切换。
+Or upgraded: `card-flip` for front/back swap.
 
-### 🤖 AI 生成全流程
+### 🤖 Full AI Generation Flow
 ```
-generate-start (0.8s, 启动) → ai-process (1.2s, 处理) → sparkle (0.8s, 闪现) → complete-done (0.8s, 完成)
+generate-start (0.8s, kickoff) → ai-process (1.2s, processing) → sparkle (0.8s, reveal) → complete-done (0.8s, done)
 ```
-错误时用 `error-tone` 替代 `complete-done`。
+On error, swap `complete-done` for `error-tone`.
 
-### 🎬 Logo Reveal（品牌时刻）
+### 🎬 Logo Reveal (brand moment)
 ```
-whoosh-fast (0.6s, 铺垫) → logo-reveal-v2 (1.5s, 落点) → sparkle (0.8s, 尾韵)
+whoosh-fast (0.6s, setup) → logo-reveal-v2 (1.5s, hit) → sparkle (0.8s, tail)
 ```
-简版：`whoosh → logo-reveal`（直接 v7b 两件套）。
+Simple version: `whoosh → logo-reveal` (v7b two-piece).
 
-### 📱 UI 交互演示（移动端）
+### 📱 UI Interaction Demo (mobile)
 ```
-tap-finger (0.5s, 点击) → slide-in (0.6s, 面板滑入) → toggle-on (0.5s, 开关)
+tap-finger (0.5s, tap) → slide-in (0.6s, panel slide) → toggle-on (0.5s, toggle)
 ```
-完成后：`success-chime` 或 `notification-pop`。
+On completion: `success-chime` or `notification-pop`.
 
-### 📊 数据可视化/仪表盘
+### 📊 Data Viz / Dashboard
 ```
-loading-tick (0.5s, 节拍) × N → complete-done (0.8s, 数据到位) → achievement (1.5s, 惊艳落点)
+loading-tick (0.5s, beat) × N → complete-done (0.8s, data lands) → achievement (1.5s, stunning closer)
 ```
 
-### 🎯 表单提交流程
+### 🎯 Form Submission Flow
 ```
 click-soft (0.5s) → loading-tick ×2 (1.0s) → success-chime (1.0s)
 ```
-失败分支：`error-tone (0.7s)`。
+Failure branch: `error-tone (0.7s)`.
 
-### 🪄 Magic Transform 场景
+### 🪄 Magic Transform Scene
 ```
 whoosh-fast (0.6s) → transform (1.0s) → sparkle (0.8s)
 ```
-适合：元素变形、效果前后对比、"AI 重写"等演示。
+Best for: element morphs, before/after comparisons, "AI rewrite" demos.
 
 ---
 
-## 使用规范
+## Usage Conventions
 
-### 音量建议（来自 apple-gallery-showcase.md 音频双轨制）
-- **SFX 主轨**：`1.0`（不做衰减）
-- **BGM 背景轨**：`0.4 ~ 0.5`（SFX 明显穿透）
-- **多 SFX 叠加**：用 `amix=inputs=N:duration=longest:normalize=0` 保留动态范围
+### Volume Guidance (from the dual-track audio doctrine in apple-gallery-showcase.md)
+- **SFX main track**: `1.0` (no attenuation)
+- **BGM background track**: `0.4 ~ 0.5` (so SFX clearly pierces through)
+- **Multiple SFX stacked**: use `amix=inputs=N:duration=longest:normalize=0` to preserve dynamic range
 
-### ffmpeg 拼接模板
+### ffmpeg Composition Templates
 ```bash
-# 单 SFX 对齐时间点：
+# Single SFX aligned to a time point:
 ffmpeg -i video.mp4 -itsoffset 2.5 -i sfx/ui/click.mp3 \
   -filter_complex "[0:a][1:a]amix=inputs=2:duration=longest:normalize=0[a]" \
   -map 0:v -map "[a]" output.mp4
 
-# 多 SFX + BGM：
+# Multi-SFX + BGM:
 ffmpeg -i video.mp4 \
   -itsoffset 1.0 -i sfx/transition/whoosh-fast.mp3 \
   -itsoffset 1.6 -i sfx/impact/logo-reveal-v2.mp3 \
@@ -187,31 +187,31 @@ ffmpeg -i video.mp4 \
   -map 0:v -map "[a]" output.mp4
 ```
 
-### 选型决策树
-1. **有 tactile 动作**（打字/点击/滑动）→ `keyboard/` or `ui/`
-2. **元素进场/出场** → `transition/`
-3. **容器层操作**（卡片/模态） → `container/`
-4. **状态反馈**（成功/失败/通知） → `feedback/`
-5. **进度/时间流逝** → `progress/`
-6. **品牌落点/重要时刻** → `impact/`
-7. **AI 魔法/变换** → `magic/`
-8. **命令行/代码演示** → `terminal/`
+### Selection Decision Tree
+1. **Tactile action** (typing/click/swipe) → `keyboard/` or `ui/`
+2. **Element enter/exit** → `transition/`
+3. **Container-layer ops** (card/modal) → `container/`
+4. **State feedback** (success/failure/notification) → `feedback/`
+5. **Progress / time elapsing** → `progress/`
+6. **Brand landing / key moments** → `impact/`
+7. **AI magic / transform** → `magic/`
+8. **Terminal / code demo** → `terminal/`
 
-### 避免叠音堆积
-- 同一个时间点 `max 2 个 SFX` 并发
-- BGM 降到 0.3 以下时可以放 3 个
-- 品牌 impact 时清空其他 SFX（留空 0.2s 再落点）
+### Avoid Stacked Audio Pile-up
+- At any one time point, `max 2 concurrent SFX`
+- When BGM drops below 0.3, you can run 3
+- During a brand impact, clear other SFX (leave 0.2s of silence before the hit)
 
 ---
 
-## Prompt 撰写原则（供复用）
+## Prompt Writing Principles (For Reuse)
 
-参考风格：`apple keynote, tight, minimal, no reverb unless ambient, crisp, elegant`
+Reference style: `apple keynote, tight, minimal, no reverb unless ambient, crisp, elegant`
 
-**好 prompt 的三要素**：
-1. **声音物理描述**：什么物体、什么动作（"mechanical keyboard single key press"）
-2. **质感/风格限定**：apple-style / ios-style / cinematic / retro
-3. **反例排除**：no reverb / clean studio / minimal
+**Three components of a good prompt**:
+1. **Sound physics description**: what object, what action ("mechanical keyboard single key press")
+2. **Texture/style constraint**: apple-style / ios-style / cinematic / retro
+3. **Anti-example exclusion**: no reverb / clean studio / minimal
 
 ❌ "click sound"
 ✅ "crisp ui button click, clean modern interface sound, apple-style, high pitched"
@@ -221,6 +221,6 @@ ffmpeg -i video.mp4 \
 
 ---
 
-## 详见
-- 音频双轨制与 ffmpeg 拼接：`apple-gallery-showcase.md`
-- 原始生成脚本：`/tmp/gen_sfx_batch.sh`（一次性批量生成器）
+## See Also
+- Dual-track audio doctrine and ffmpeg composition: `apple-gallery-showcase.md`
+- Original generation script: `/tmp/gen_sfx_batch.sh` (one-shot batch generator)

--- a/references/slide-decks.md
+++ b/references/slide-decks.md
@@ -1,268 +1,268 @@
-# Slide Decks：HTML幻灯片制作规范
+# Slide Decks: HTML Slide Production Conventions
 
-做幻灯片是设计工作的高频场景。这份文档说明怎么做好HTML幻灯片——从架构选型、单页设计，到 PDF/PPTX 导出的完整路径。
+Making slide decks is a high-frequency design task. This document explains how to make HTML slide decks well — from architecture choice and per-page design through to the full PDF/PPTX export path.
 
-**本 skill 的能力覆盖**：
-- **HTML 演示版（基础产物，永远默认必做）** → 每页独立 HTML + `assets/deck_index.html` 聚合，浏览器里键盘翻页、全屏演讲
-- HTML → PDF 导出 → `scripts/export_deck_pdf.mjs` / `scripts/export_deck_stage_pdf.mjs`
-- HTML → 可编辑 PPTX 导出 → `references/editable-pptx.md` + `scripts/html2pptx.js` + `scripts/export_deck_pptx.mjs`（要求 HTML 按 4 条硬约束写）
+**Capabilities this skill covers**:
+- **HTML presentation version (the base artifact — always the default, always required)** → one HTML file per slide + `assets/deck_index.html` aggregator, keyboard navigation in the browser, full-screen presenting
+- HTML → PDF export → `scripts/export_deck_pdf.mjs` / `scripts/export_deck_stage_pdf.mjs`
+- HTML → editable PPTX export → `references/editable-pptx.md` + `scripts/html2pptx.js` + `scripts/export_deck_pptx.mjs` (requires HTML to be written to the 4 hard constraints)
 
-> **⚠️ HTML 是基础，PDF/PPTX 是衍生物。** 不管最终交付什么格式，都**必须**先做 HTML 聚合演示版（`index.html` + `slides/*.html`），它是幻灯片作品的「源」。PDF/PPTX 是从 HTML 一行命令导出的快照。
+> **⚠️ HTML is the base, PDF/PPTX are derivatives.** No matter what the final delivery format is, you **must** first make the HTML aggregated presentation (`index.html` + `slides/*.html`) — it's the "source" of the slide deck. PDF/PPTX are one-line-command snapshots exported from the HTML.
 >
-> **为什么 HTML 优先**：
-> - 演讲/演示现场最好用（投影仪 / 共享屏幕直接全屏，键盘翻页，不依赖 Keynote/PPT 软件）
-> - 开发过程中每页可单独双击打开验证，不用每次重新跑导出
-> - 是 PDF/PPTX 导出的唯一上游（避免「导出后才发现要改 HTML 又要重出」的死循环）
-> - 交付物可以是「HTML + PDF」或「HTML + PPTX」双份，接收方爱用哪个用哪个
+> **Why HTML first**:
+> - Best for live presenting (projector / shared screen full-screens directly, keyboard navigation, no dependency on Keynote/PPT software)
+> - During development you can double-click each page on its own to verify, no need to re-run export each time
+> - It is the only upstream of the PDF/PPTX export (avoiding the "after export I discover I have to change the HTML and re-export" loop)
+> - The deliverable can be "HTML + PDF" or "HTML + PPTX" in pairs — the recipient uses whichever they prefer
 >
-> 2026-04-22 moxt brochure 实测：做完 13 页 HTML + index.html 聚合后，`export_deck_pdf.mjs` 一行导出 PDF，零改动。HTML 版本身就是可直接浏览器演讲的交付物。
+> 2026-04-22 moxt brochure verification: after finishing 13 pages of HTML + index.html aggregation, one line of `export_deck_pdf.mjs` exported the PDF with zero modifications. The HTML version itself is a deliverable that can be presented directly in the browser.
 
 ---
 
-## 🛑 开工前先确认交付格式（最硬的 checkpoint）
+## 🛑 Confirm Delivery Format Before You Start (the hardest checkpoint)
 
-**这个决策比「单文件还是多文件」更先。** 2026-04-20 期权私董会项目实测：**不在动手前确认交付格式 = 2-3 小时返工。**
+**This decision comes even earlier than "single file or multi-file".** Verified in the 2026-04-20 options-roundtable project: **failing to confirm delivery format before starting = 2-3 hours of rework.**
 
-### 决策树（HTML-first 架构）
+### Decision Tree (HTML-first architecture)
 
-所有交付都从同一套 HTML 聚合页（`index.html` + `slides/*.html`）开始。交付格式只决定 **HTML 的写法约束** 和 **导出命令**：
+Every delivery starts from the same HTML aggregation page (`index.html` + `slides/*.html`). The delivery format only determines the **constraints on how to write the HTML** and the **export command**:
 
 ```
-【永远默认 · 必做】 HTML 聚合演示版（index.html + slides/*.html）
+[Always default · always required] HTML aggregated presentation (index.html + slides/*.html)
    │
-   ├── 只要浏览器演讲 / 本地 HTML 存档   → 到这里已经完成，HTML 视觉自由度最大
+   ├── Just need browser presenting / local HTML archive   → done here, maximum HTML visual freedom
    │
-   ├── 还要 PDF（打印 / 发群 / 存档）     → 跑 export_deck_pdf.mjs 一键出
-   │                                          HTML 写法自由，视觉无约束
+   ├── Also need PDF (print / send / archive)              → run export_deck_pdf.mjs, one-shot
+   │                                                          HTML free-form, no visual constraint
    │
-   └── 还要可编辑 PPTX（同事要改文字）    → 从第一行 HTML 就按 4 条硬约束写
-                                              跑 export_deck_pptx.mjs 一键出
-                                              牺牲渐变 / web component / 复杂 SVG
+   └── Also need editable PPTX (colleagues will edit text) → write HTML to the 4 hard constraints from line 1
+                                                              run export_deck_pptx.mjs, one-shot
+                                                              sacrifice gradients / web component / complex SVG
 ```
 
-### 开工话术（抄走即用）
+### Kickoff Script (copy and use)
 
-> 不管最后交付是 HTML、PDF 还是 PPTX，我都会先做一个可在浏览器里切换和演讲的 HTML 聚合版（`index.html` 加键盘翻页）——这是永远的默认基础产物。在此之上再问你要不要额外出 PDF / PPTX 的快照。
+> Regardless of whether the final delivery is HTML, PDF, or PPTX, I'll first make an HTML aggregated version (`index.html` plus keyboard navigation) that you can switch through and present in the browser — this is always the default base artifact. On top of that, I'll then ask whether you also want a PDF / PPTX snapshot.
 >
-> 你需要哪个导出格式？
-> - **只要 HTML**（演讲/存档）→ 视觉完全自由
-> - **还要 PDF** → 同上，加一条导出命令
-> - **还要可编辑 PPTX**（同事会在 PPT 里改文字）→ 我必须从第一行 HTML 就按 4 条硬约束写，会牺牲一些视觉能力（无渐变、无 web component、无复杂 SVG）。
+> Which export format do you need?
+> - **HTML only** (presenting/archive) → fully free visually
+> - **Also PDF** → same as above, plus one export command
+> - **Also editable PPTX** (a colleague will edit text inside PPT) → I have to write the HTML to the 4 hard constraints from the very first line, which sacrifices some visual capabilities (no gradients, no web components, no complex SVG).
 
-### 为什么「要 PPTX 就得从头走 4 条硬约束」
+### Why "if you want PPTX you have to go through the 4 hard constraints from the start"
 
-PPTX 可编辑的前提是 `html2pptx.js` 能把 DOM 逐元素翻译为 PowerPoint 对象。它需要 **4 条硬约束**：
+For PPTX to be editable, `html2pptx.js` has to translate the DOM into PowerPoint objects element-by-element. That requires **4 hard constraints**:
 
-1. body 固定 960pt × 540pt（匹配 `LAYOUT_WIDE`，13.333″ × 7.5″，不是 1920×1080px）
-2. 所有文字包在 `<p>`/`<h1>`-`<h6>` 里（禁止 div 直接放文字，禁止用 `<span>` 承载主文字）
-3. `<p>`/`<h*>` 自身不能有 background/border/shadow（放外层 div）
-4. `<div>` 不能用 `background-image`（用 `<img>` 标签）
-5. 不用 CSS gradient、不用 web component、不用复杂 SVG 装饰
+1. body fixed at 960pt × 540pt (matches `LAYOUT_WIDE`, 13.333″ × 7.5″, not 1920×1080px)
+2. All text wrapped in `<p>`/`<h1>`-`<h6>` (no text directly in a div, no `<span>` carrying the main text)
+3. `<p>`/`<h*>` cannot have background/border/shadow on themselves (put it on the outer div)
+4. `<div>` cannot use `background-image` (use an `<img>` tag)
+5. No CSS gradient, no web component, no complex SVG decoration
 
-**本 skill 默认的 HTML 视觉自由度高**——大量 span、嵌套 flex、复杂 SVG、web component（如 `<deck-stage>`）、CSS 渐变——**几乎没有一条能天然过 html2pptx 的约束**（实测视觉驱动的 HTML 直接上 html2pptx，pass 率 < 30%）。
+**This skill's default HTML has high visual freedom** — lots of spans, nested flex, complex SVG, web components (like `<deck-stage>`), CSS gradients — **almost none of which naturally passes html2pptx's constraints** (in practice, visual-driven HTML sent straight through html2pptx has a pass rate < 30%).
 
-### 两条真实路径的代价对比（2026-04-20 真实踩坑）
+### Cost Comparison of the Two Real Paths (2026-04-20 real pitfall)
 
-| 路径 | 做法 | 结果 | 代价 |
+| Path | Approach | Result | Cost |
 |------|------|------|------|
-| ❌ **先自由写 HTML，事后补救 PPTX** | 单文件 deck-stage + 大量 SVG/span 装饰 | 要可编辑 PPTX 只剩两条路：<br>A. 手写 pptxgenjs 几百行 hardcode 坐标<br>B. 重写 17 页 HTML 成 Path A 格式 | 2-3 小时返工，且手写版**维护成本永续**（HTML 改一个字，PPTX 要再人肉同步） |
-| ✅ **从第一步按 Path A 约束写** | 每页独立 HTML + 4 条硬约束 + 960×540pt | 一条命令导出 100% 可编辑 PPTX，同时也能浏览器全屏演讲（Path A HTML 就是浏览器可播放的标准 HTML） | 写 HTML 时多花 5 分钟想「文字怎么包进 `<p>`」，零返工 |
+| ❌ **Write HTML freely first, retrofit PPTX later** | Single-file deck-stage + heavy SVG/span decoration | Only two paths left to get editable PPTX:<br>A. Hand-write hundreds of lines of pptxgenjs with hardcoded coordinates<br>B. Rewrite 17 pages of HTML into Path A format | 2-3 hours of rework, and the hand-written version has **perpetual maintenance cost** (change one word in the HTML and you have to manually re-sync the PPTX) |
+| ✅ **Write to Path A constraints from step one** | Per-page independent HTML + 4 hard constraints + 960×540pt | One command exports a 100% editable PPTX, and the same HTML can be full-screen presented in the browser (Path A HTML is just standard browser-playable HTML) | 5 extra minutes thinking "how do I wrap this text in a `<p>`" while writing HTML, zero rework |
 
-### 混合交付怎么办
+### What about mixed delivery
 
-用户说「我要 HTML 演讲 **和** 可编辑 PPTX」——**这不是混合**，是 PPTX 需求覆盖 HTML 需求。按 Path A 写出来的 HTML 本身就能浏览器全屏演讲（加个 `deck_index.html` 拼接器就行）。**没有额外代价。**
+The user says "I want both HTML presenting **and** editable PPTX" — **this isn't mixed**, it's PPTX requirements subsuming HTML requirements. HTML written to Path A is itself browser-presentable full-screen (just add a `deck_index.html` aggregator). **No extra cost.**
 
-用户说「我要 PPTX **和** 动画 / web component」——**这是真矛盾**。告诉用户：要可编辑 PPTX 就得牺牲这些视觉能力。让他做取舍，不要偷偷做手写 pptxgenjs 方案（会变成永续维护债）。
+The user says "I want PPTX **and** animation / web components" — **this is a real conflict**. Tell the user: for editable PPTX you have to sacrifice those visual capabilities. Make them choose — don't quietly take the hand-written pptxgenjs path (which becomes permanent maintenance debt).
 
-### 事后才知道要 PPTX 怎么办（紧急补救）
+### What to Do if PPTX Need Surfaces After the Fact (emergency fallback)
 
-极个别情况：HTML 已经写好了才发现要 PPTX。推荐走 **fallback 流程**（完整说明见 `references/editable-pptx.md` 末尾「Fallback：已有视觉稿但用户坚持要 editable PPTX」）：
+Rare case: the HTML is already written and only then you learn PPTX is needed. Take the **fallback flow** (full explanation at the end of `references/editable-pptx.md` under "Fallback: Visual Mock Already Exists but the User Insists on Editable PPTX"):
 
-1. **首选：改出 PDF**（视觉 100% 保留，跨平台，接收方能看能印）—— 如果接收方实际需求是「演讲/存档」，PDF 就是最佳交付物
-2. **次选：AI 以视觉稿为蓝本，重写一版 editable HTML** → 导出 editable PPTX —— 保留色彩/布局/文案的设计决策，牺牲渐变、web component、复杂 SVG 等视觉能力
-3. **不推荐：手写 pptxgenjs 重建**——位置、字体、对齐都要手调，维护成本高，且后续 HTML 改一个字都得再人肉同步一次
+1. **First choice: ship a PDF** (visual preserved 100%, cross-platform, recipient can view and print) — if the recipient's actual need is "present/archive", PDF is the best deliverable
+2. **Second choice: AI uses the visual mock as a blueprint and rewrites an editable HTML** → exports an editable PPTX — preserves the design decisions for color / layout / copy, sacrifices visual capabilities like gradients, web components, complex SVG
+3. **Not recommended: hand-write pptxgenjs to rebuild** — position, font, alignment all need manual tweaking, high maintenance cost, and each future word change in the HTML still has to be manually re-synced
 
-永远把选择告诉用户，让他决定。**永远不要第一反应就开始手写 pptxgenjs**——那是最后的兜底手段。
+Always tell the user the choices and let them decide. **Never make the first response be "let's hand-write pptxgenjs"** — that's the last-resort fallback.
 
 ---
 
-## 🛑 批量制作前：先做 2 页 showcase 定 grammar
+## 🛑 Before Mass Producing: Build 2 Showcase Pages to Fix the Grammar
 
-**只要 deck ≥ 5 页，绝对不能从第 1 页直接写到最后一页。** 2026-04-22 moxt brochure 实战验证的正确顺序：
+**Whenever a deck has ≥ 5 pages, absolutely do not write page 1 straight through to the last page.** The correct order verified in the 2026-04-22 moxt brochure run:
 
-1. 选 **2 个视觉差异最大的页面类型**先做 showcase（如「封面」+「情绪/引用页」，或「封面」+「产品展示页」）
-2. 截图让用户确认 grammar（masthead / 字体 / 色 / 间距 / 结构 / 中英双语比例）
-3. 方向通过了再批量推剩下 N-2 页，每页复用已建立的 grammar
-4. 全部完成后一起合成 HTML 聚合 + PDF / PPTX 衍生物
+1. Pick **the 2 page types with the largest visual difference** and make them as showcase first (e.g. "cover" + "mood/quote page", or "cover" + "product showcase page")
+2. Screenshot them and have the user confirm the grammar (masthead / fonts / colors / spacing / structure / bilingual ratio)
+3. Once the direction is approved, batch out the remaining N-2 pages, each reusing the established grammar
+4. After all pages are done, compose them together into the HTML aggregation + PDF / PPTX derivatives
 
-**为什么**：直接写 13 页到底 → 用户说「方向不对」= 返工 13 次。先做 2 页 showcase → 方向错 = 返工 2 次。视觉 grammar 一旦确立，后续 N 页的决策空间大幅收窄，只剩「内容怎么放进去」。
+**Why**: writing 13 pages straight through → user says "wrong direction" = 13 pages of rework. Build 2 showcase pages first → wrong direction = 2 pages of rework. Once the visual grammar is set, the decision space for the remaining N pages collapses sharply, leaving only "how does the content fit in".
 
-**showcase 页选择原则**：选视觉结构最不一样的两页。这两页过了 = 其他中间态都能过。
+**Principle for picking showcase pages**: pick the two with the most different visual structure. If those two pass = all the intermediate ones will pass.
 
-| Deck 类型 | 推荐 showcase 页组合 |
+| Deck type | Recommended showcase pair |
 |-----------|---------------------|
-| B2B brochure / 产品宣发 | 封面 + 内容页（理念/情感页） |
-| 品牌发布 | 封面 + 产品特色页 |
-| 数据报告 | 数据大图页 + 分析结论页 |
-| 教程课件 | 章节封页 + 具体知识点页 |
+| B2B brochure / product launch | Cover + content page (philosophy / emotion page) |
+| Brand launch | Cover + product feature page |
+| Data report | Big-number data page + analysis/conclusion page |
+| Lesson / courseware | Chapter cover + specific knowledge point page |
 
 ---
 
-## 📐 出版物 grammar 模板（moxt 实测可复用）
+## 📐 Publication Grammar Template (moxt-verified, reusable)
 
-适合 B2B brochure / 产品宣发 / 长报告类 deck。每页复用这套结构 = 13 页视觉完全一致、0 返工。
+Suitable for B2B brochures / product launches / long-form report decks. Reusing this structure across every page = 13 pages visually consistent, zero rework.
 
-### 每页骨架
+### Per-page skeleton
 
 ```
-┌─ masthead（顶部 strip + 横线）────────────┐
+┌─ masthead (top strip + horizontal rule) ──────────┐
 │  [logo 22-28px] · A Product Brochure                Issue · Date · URL │
 ├──────────────────────────────────────────┤
 │                                          │
-│  ── kicker（绿色短横 + uppercase 标签）   │
+│  ── kicker (green short dash + uppercase label) │
 │  CHAPTER XX · SECTION NAME                 │
 │                                          │
-│  H1（中文 Noto Serif SC 900）             │
-│  重点词单独上品牌主色                      │
+│  H1 (Chinese Noto Serif SC 900)           │
+│  Key word in brand primary color          │
 │                                          │
-│  English subtitle (Lora italic，副标题)   │
-│  ─────────── 分隔线 ──────────            │
+│  English subtitle (Lora italic)           │
+│  ─────────── divider rule ──────────      │
 │                                          │
-│  [具体内容：双栏 60/40 / 2x2 grid / 列表] │
+│  [actual content: 60/40 two-column / 2x2 grid / list] │
 │                                          │
 ├──────────────────────────────────────────┤
 │ section name                     XX / total │
 └──────────────────────────────────────────┘
 ```
 
-### 样式约定（直接抄走）
+### Style conventions (copy and use)
 
-- **H1**：中文 Noto Serif SC 900，字号 80-140px 看信息量，重点词单独上品牌主色（不要全文堆色）
-- **英文副**：Lora italic 26-46px，品牌签名词（如 "AI team"）粗体 + 主色斜体
-- **正文**：Noto Serif SC 17-21px，line-height 1.75-1.85
-- **accent 高亮**：正文里用主色加粗标注关键词，每页不超过 3 处（过多就失去锚点作用）
-- **背景**：暖米底 #FAFAFA + 极淡 radial-gradient noise（`rgba(33,33,33,0.015)`）增加纸感
+- **H1**: Chinese Noto Serif SC 900, font size 80-140px based on information density; key words colored in the brand primary (don't smear color across the whole text)
+- **English subtitle**: Lora italic 26-46px; brand signature phrases (e.g. "AI team") bold + primary-color italic
+- **Body**: Noto Serif SC 17-21px, line-height 1.75-1.85
+- **Accent highlight**: in body text, bold + primary-color the key words; no more than 3 per page (more and the anchoring effect is lost)
+- **Background**: warm off-white #FAFAFA + an extremely faint radial-gradient noise (`rgba(33,33,33,0.015)`) for paper feel
 
-### 视觉主角必须差异化
+### The visual lead must differ across pages
 
-13 页如果全是「文字 + 一张截图」就太单调。**每页的视觉主角类型轮换**：
+If all 13 pages are "text + one screenshot" it's monotonous. **Rotate the type of visual lead per page**:
 
-| 视觉类型 | 适合的 section |
+| Visual type | Suitable section |
 |---------|---------------|
-| 封面排版（大字 + masthead + pillar） | 首页 / 篇章封 |
-| 单角色 portrait（超大单只 momo 等） | 介绍单个概念/角色 |
-| 多角色合影 / 头像卡并排 | 团队 / 用户案例 |
-| 时间轴卡片递进 | 展示「长期关系」「演进」 |
-| 知识图谱 / 连接节点图 | 展示「协作」「流动」 |
-| Before/After 对比卡 + 中间箭头 | 展示「改变」「差异」 |
-| 产品 UI 截图 + 描边设备框 | 具体功能展示 |
-| 大引号 big-quote（半页大字） | 情绪页 / 问题页 / 引文页 |
-| 真人头像 + 引言卡（2×2 或 1×4） | 用户见证 / 使用场景 |
-| 大字封底 + URL 椭圆按钮 | CTA / 结尾 |
+| Cover typography (big type + masthead + pillar) | Front page / chapter cover |
+| Single-character portrait (one giant momo etc.) | Introducing a single concept / character |
+| Group shot / avatar cards side by side | Team / customer cases |
+| Timeline cards progressing | Showing "long-term relationship" / "evolution" |
+| Knowledge graph / connection node diagram | Showing "collaboration" / "flow" |
+| Before/After comparison cards + arrow in between | Showing "change" / "difference" |
+| Product UI screenshot + outlined device frame | Specific feature showcase |
+| Big-quote (half-page big text) | Emotion page / question page / quote page |
+| Real-person avatar + quote card (2×2 or 1×4) | User testimonial / use-case scene |
+| Big-type closing + URL pill button | CTA / closing |
 
 ---
 
-## ⚠️ 常见踩坑（moxt 实战总结）
+## ⚠️ Common Pitfalls (moxt practical takeaways)
 
-### 1. Emoji 在 Chromium / Playwright 导出时不渲染
+### 1. Emojis don't render under Chromium / Playwright export
 
-Chromium 默认不带彩色 emoji 字体，`page.pdf()` 或 `page.screenshot()` 时 emoji 显示为空方框。
+Chromium doesn't ship with a color emoji font by default — `page.pdf()` or `page.screenshot()` renders emojis as empty boxes.
 
-**对策**：用 Unicode 文字符号（`✦` `✓` `✕` `→` `·` `—`）替代，或直接改纯文字（「Email · 23」而不是「📧 23 emails」）。
+**Mitigation**: use Unicode text symbols (`✦` `✓` `✕` `→` `·` `—`) instead, or just plain text ("Email · 23" instead of "📧 23 emails").
 
-### 2. `export_deck_pdf.mjs` 报错 `Cannot find package 'playwright'`
+### 2. `export_deck_pdf.mjs` errors with `Cannot find package 'playwright'`
 
-原因：ESM 模块解析从脚本所在位置向上找 `node_modules`。脚本在 `~/.claude/skills/huashu-design/scripts/`，那里没依赖。
+Cause: ESM module resolution walks upward from the script's location to find `node_modules`. The script lives at `~/.claude/skills/huashu-design/scripts/`, which has no dependencies.
 
-**对策**：把脚本复制到 deck 项目目录（例如 `brochure/build-pdf.mjs`），在项目根跑 `npm install playwright pdf-lib`，然后 `node build-pdf.mjs --slides slides --out output/deck.pdf`。
+**Mitigation**: copy the script into the deck project directory (e.g. `brochure/build-pdf.mjs`), run `npm install playwright pdf-lib` at the project root, then `node build-pdf.mjs --slides slides --out output/deck.pdf`.
 
-### 3. Google Fonts 没加载完就截图 → 中文显示为系统默认黑体
+### 3. Google Fonts haven't loaded by the time of screenshot → Chinese falls back to the system default
 
-Playwright 截图/PDF 前至少 `wait-for-timeout=3500` 让 webfont 下载并 paint。或者把字体 self-host 到 `shared/fonts/` 减少网络依赖。
+Before Playwright takes a screenshot/PDF, give it at least `wait-for-timeout=3500` so the webfont can download and paint. Or self-host the fonts under `shared/fonts/` to reduce network dependency.
 
-### 4. 信息密度失衡：内容页塞太多
+### 4. Information density imbalance: cramming too much into a content page
 
-moxt philosophy 页第一版用 2×2 = 4 段 + 底部 3 信条 = 7 块内容，挤压且重复。改成 1×3 = 3 段后呼吸感立刻回来。
+The first version of the moxt philosophy page used 2×2 = 4 sections + 3 closing tenets at the bottom = 7 chunks of content, cramped and repetitive. Switching to 1×3 = 3 sections immediately restored breathing room.
 
-**对策**：每页控制在「1 个核心信息 + 3-4 个辅助点 + 1 个视觉主角」，超过就拆到新页。**少即是多**——观众一页看 10 秒，给他 1 个记忆点比 4 个记忆点更容易记住。
+**Mitigation**: keep each page to "1 core message + 3-4 supporting points + 1 visual lead"; if it exceeds that, split into a new page. **Better empty than padded** — the audience looks at a page for 10 seconds, giving them 1 memory anchor is easier to retain than 4.
 
 ---
 
-## 🛑 先定架构：单文件 还是 多文件？
+## 🛑 First Decide the Architecture: Single File or Multi-File?
 
-**这个选择是做幻灯片的第一步，错了会反复踩坑。先读完这一节再动手。**
+**This choice is the first step of making slides — get it wrong and you'll trip repeatedly. Finish reading this section before you start.**
 
-### 两种架构对比
+### Comparison of the two architectures
 
-| 维度 | 单文件 + `deck_stage.js` | **多文件 + `deck_index.html` 拼接器** |
+| Dimension | Single file + `deck_stage.js` | **Multi-file + `deck_index.html` aggregator** |
 |------|--------------------------|--------------------------------------|
-| 代码结构 | 一个 HTML，所有 slide 是 `<section>` | 每页独立 HTML，`index.html` 用 iframe 拼接 |
-| CSS 作用域 | ❌ 全局，一页的样式可能影响所有页 | ✅ 天然隔离，iframe 各自一片天 |
-| 验证粒度 | ❌ 要 JS goTo 才能切到某页 | ✅ 单页文件双击就能在浏览器看 |
-| 并行开发 | ❌ 一个文件，多 agent 改会冲突 | ✅ 多 agent 可并行做不同页，零冲突 merge |
-| 调试难度 | ❌ 一处 CSS 出错，全 deck 翻车 | ✅ 一页出错只影响自己 |
-| 内嵌交互 | ✅ 跨页共享状态很简单 | 🟡 iframe 间需 postMessage |
-| 打印 PDF | ✅ 内置 | ✅ 拼接器 beforeprint 遍历 iframe |
-| 键盘导航 | ✅ 内置 | ✅ 拼接器内置 |
+| Code structure | One HTML; every slide is a `<section>` | One HTML per slide; `index.html` aggregates via iframes |
+| CSS scope | ❌ Global — one page's style can affect every page | ✅ Naturally isolated — each iframe is its own world |
+| Verification grain | ❌ Have to JS `goTo` to switch to a slide | ✅ Double-click a single file and view in browser |
+| Parallel development | ❌ One file — multiple agents editing collides | ✅ Multiple agents can work different pages in parallel, zero merge conflicts |
+| Debugging difficulty | ❌ One CSS error flips the whole deck | ✅ A broken page only breaks itself |
+| Embedded interaction | ✅ Sharing state across slides is easy | 🟡 iframes need postMessage |
+| Print PDF | ✅ Built-in | ✅ Aggregator iterates iframes on beforeprint |
+| Keyboard navigation | ✅ Built-in | ✅ Built into the aggregator |
 
-### 选哪个？（决策树）
+### Which to pick? (decision tree)
 
 ```
-│ 问：deck 预计有多少页？
-├── ≤10 页、需要 in-deck 动画或跨页交互、pitch deck → 单文件
-└── ≥10 页、学术讲座、课件、长 deck、多 agent 并行 → 多文件（推荐）
+│ Question: how many slides do you expect?
+├── ≤ 10 pages, need in-deck animation or cross-page interaction, pitch deck → single file
+└── ≥ 10 pages, lecture, lesson, long deck, multi-agent in parallel  → multi-file (recommended)
 ```
 
-**默认走多文件路径**。它不是「备选」，是**长 deck 和团队协作的主路径**。原因：单文件架构的每一个优势（键盘导航、打印、scale）多文件都有，而多文件的作用域隔离和可验证性是单文件补不回来的。
+**Default to the multi-file path.** It is not a "backup", it is **the main path for long decks and team collaboration**. Reason: every advantage of the single-file architecture (keyboard navigation, printing, scaling) the multi-file architecture also has, while the scope isolation and verifiability of the multi-file architecture are things the single-file one can never recover.
 
-### 为什么这条规则这么硬？（真实事故记录）
+### Why this rule is so strict (real incident record)
 
-单文件架构曾经在 AI心理学讲座 deck 制作中连踩四坑：
+The single-file architecture once tripped four pitfalls back-to-back while producing the "AI Psychology Lecture" deck:
 
-1. **CSS 特异性覆盖**：`.emotion-slide { display: grid }` (特异性 10) 干翻 `deck-stage > section { display: none }` (特异性 2)，导致所有页同时渲染叠加。
-2. **Shadow DOM slot 规则被外层 CSS 压制**：`::slotted(section) { display: none }` 挡不住 outer rule 的覆盖，sections 不肯隐藏。
-3. **localStorage + hash 导航竞态**：刷新后不是跳到 hash 位置，而是停在 localStorage 记录的旧位置。
-4. **验证成本高**：必须 `page.evaluate(d => d.goTo(n))` 才能截某页，比直接 `goto(file://.../slides/05-X.html)` 慢一倍，还常报错。
+1. **CSS specificity override**: `.emotion-slide { display: grid }` (specificity 10) defeated `deck-stage > section { display: none }` (specificity 2), causing every page to render simultaneously, stacked.
+2. **Shadow DOM slot rules suppressed by outer CSS**: `::slotted(section) { display: none }` couldn't hold off an outer-rule override; sections refused to hide.
+3. **localStorage + hash navigation race**: after a refresh, instead of jumping to the hash position, it stayed at the old position recorded in localStorage.
+4. **Verification cost was high**: had to `page.evaluate(d => d.goTo(n))` to screenshot a slide, twice as slow as `goto(file://.../slides/05-X.html)` directly, and often errored.
 
-全部根因是**单一全局命名空间**——多文件架构从物理层面把这些问题消除了。
+The root cause for all of them is **a single global namespace** — the multi-file architecture eliminates these problems at the physical layer.
 
 ---
 
-## 路径 A（默认）：多文件架构
+## Path A (default): Multi-file architecture
 
-### 目录结构
+### Directory layout
 
 ```
-我的Deck/
-├── index.html              # 从 assets/deck_index.html 复制来，改 MANIFEST
+My Deck/
+├── index.html              # copied from assets/deck_index.html, MANIFEST updated
 ├── shared/
-│   ├── tokens.css          # 共享设计 token（色板/字号/常用 chrome）
-│   └── fonts.html          # <link> 引入 Google Fonts（每页 include）
+│   ├── tokens.css          # shared design tokens (palette / type scale / common chrome)
+│   └── fonts.html          # Google Fonts <link>s (each page includes)
 └── slides/
-    ├── 01-cover.html       # 每个文件都是完整 1920×1080 HTML
+    ├── 01-cover.html       # each file is a complete 1920×1080 HTML
     ├── 02-agenda.html
     ├── 03-problem.html
     └── ...
 ```
 
-### 每张 slide 的模板骨架
+### Per-slide template skeleton
 
 ```html
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <title>P05 · Chapter Title</title>
 <link href="https://fonts.googleapis.com/css2?family=..." rel="stylesheet">
 <link rel="stylesheet" href="../shared/tokens.css">
 <style>
-  /* 这一页独有的样式。用任何 class 名都不会污染别的页。*/
+  /* Styles unique to this slide. Any class name is safe — it won't pollute other slides. */
   body { padding: 120px; }
   .my-thing { ... }
 </style>
 </head>
 <body>
-  <!-- 1920×1080 的内容（由 body 的 width/height 在 tokens.css 里锁定）-->
+  <!-- 1920×1080 content (body width/height locked in tokens.css) -->
   <div class="page-header">...</div>
   <div>...</div>
   <div class="page-footer">...</div>
@@ -270,62 +270,62 @@ moxt philosophy 页第一版用 2×2 = 4 段 + 底部 3 信条 = 7 块内容，�
 </html>
 ```
 
-**关键约束**：
-- `<body>` 就是画布，直接在上面布局。不要包 `<section>` 或其他 wrapper。
-- `width: 1920px; height: 1080px` 由 `shared/tokens.css` 里的 `body` 规则锁定。
-- 引 `shared/tokens.css` 共享设计 token（色板、字号、page-header/footer 等）。
-- 字体 `<link>` 每页自己写（fonts 单独 import 不贵，且保证每页独立可打开）。
+**Key constraints**:
+- `<body>` is the canvas — lay out directly on it. Don't wrap with `<section>` or other wrappers.
+- `width: 1920px; height: 1080px` is locked by the `body` rule in `shared/tokens.css`.
+- Reference `shared/tokens.css` for shared design tokens (palette, type scale, page-header/footer, etc.).
+- Each page writes its own font `<link>` (importing fonts independently isn't expensive, and it guarantees every page is independently openable).
 
-### 拼接器：`deck_index.html`
+### Aggregator: `deck_index.html`
 
-**直接从 `assets/deck_index.html` 复制**。你只需要改一处——`window.DECK_MANIFEST` 数组，按顺序列出所有 slide 文件名和人类可读标签：
+**Copy it directly from `assets/deck_index.html`.** You only need to change one thing — the `window.DECK_MANIFEST` array, listing every slide file in order with a human-readable label:
 
 ```js
 window.DECK_MANIFEST = [
-  { file: "slides/01-cover.html",    label: "封面" },
-  { file: "slides/02-agenda.html",   label: "目录" },
-  { file: "slides/03-problem.html",  label: "问题陈述" },
+  { file: "slides/01-cover.html",    label: "Cover" },
+  { file: "slides/02-agenda.html",   label: "Agenda" },
+  { file: "slides/03-problem.html",  label: "Problem Statement" },
   // ...
 ];
 ```
 
-拼接器已内置：键盘导航（←/→/Home/End/数字键/P 打印）、scale + letterbox、右下计数器、localStorage 记忆、hash 跳页、打印模式（遍历 iframe 按页输出 PDF）。
+The aggregator already has built-in: keyboard navigation (←/→/Home/End/number keys/P print), scale + letterbox, bottom-right counter, localStorage memory, hash jump, print mode (iterates iframes to output PDF page by page).
 
-### 单页验证（这是多文件架构的杀手级优势）
+### Per-page verification (the killer advantage of multi-file)
 
-每张 slide 都是独立 HTML。**做完一张就在浏览器双击打开看**：
+Every slide is an independent HTML. **After finishing one, just double-click it open in the browser**:
 
 ```bash
 open slides/05-personas.html
 ```
 
-Playwright 截图也是直接 `goto(file://.../slides/05-personas.html)`，不需要 JS 跳页，也不会被别的页的 CSS 干扰。这让「改一点验一点」的工作流成本接近零。
+Playwright screenshots also `goto(file://.../slides/05-personas.html)` directly — no JS navigation, no interference from other pages' CSS. This drives the cost of "tweak one thing, verify one thing" to near zero.
 
-### 并行开发
+### Parallel development
 
-把每张 slide 的任务拆给不同 agent，同时跑——HTML 文件彼此独立，merge 时没有冲突。长 deck 用这种并行方式能把制作时间压到 1/N。
+Hand out each slide as a task to a different agent and run them in parallel — the HTML files are independent of each other and merge with no conflicts. For long decks, this kind of parallelism cuts the production time to 1/N.
 
-### `shared/tokens.css` 该放什么
+### What to put in `shared/tokens.css`
 
-只放**真正跨页共用**的东西：
+Only **things actually shared across pages**:
 
-- CSS 变量（色板、字号阶、间距阶）
-- `body { width: 1920px; height: 1080px; }` 这样的 canvas 锁定
-- `.page-header` / `.page-footer` 这种每页都用一模一样的 chrome
+- CSS variables (palette, type scale, spacing scale)
+- Canvas locking like `body { width: 1920px; height: 1080px; }`
+- Chrome that every page uses identically — `.page-header` / `.page-footer`
 
-**不要**把单页的布局 class 塞进来——那会退化回单文件架构的全局污染问题。
+**Do not** put per-page layout classes here — that degrades back into the single-file architecture's global pollution problem.
 
 ---
 
-## 路径 B（小 deck）：单文件 + `deck_stage.js`
+## Path B (small decks): Single file + `deck_stage.js`
 
-适用于 ≤10 页、需要跨页共享状态（比如一个 React tweaks 面板要操控所有页）、或者做 pitch deck demo 这种要求极度紧凑的场景。
+For decks ≤ 10 pages, or that need cross-page shared state (e.g. one React tweaks panel controlling all pages), or pitch-deck demos that demand maximum compactness.
 
-### 基本用法
+### Basic usage
 
-1. 从 `assets/deck_stage.js` 读取内容，嵌入 HTML 的 `<script>`（或 `<script src="deck_stage.js">`）
-2. 在 body 里用 `<deck-stage>` 包 slide
-3. 🛑 **script 标签必须放在 `</deck-stage>` 之后**（见下方硬约束）
+1. Read the contents of `assets/deck_stage.js` and embed in the HTML's `<script>` (or `<script src="deck_stage.js">`)
+2. Wrap slides with `<deck-stage>` inside body
+3. 🛑 **The script tag must come after `</deck-stage>`** (see the hard constraint below)
 
 ```html
 <body>
@@ -339,90 +339,90 @@ Playwright 截图也是直接 `goto(file://.../slides/05-personas.html)`，不�
     </section>
   </deck-stage>
 
-  <!-- ✅ 正确：script 在 deck-stage 之后 -->
+  <!-- ✅ Correct: script comes after deck-stage -->
   <script src="deck_stage.js"></script>
 
 </body>
 ```
 
-### 🛑 Script 位置硬约束（2026-04-20 真实踩坑）
+### 🛑 Script Position Hard Constraint (2026-04-20 real pitfall)
 
-**不能把 `<script src="deck_stage.js">` 放在 `<head>` 里。** 即使它在 `<head>` 里能定义 `customElements`，parser 在解析到 `<deck-stage>` 开始标签时就会触发 `connectedCallback`——此时子 `<section>` 还没被 parse，`_collectSlides()` 拿到空数组，counter 显示 `1 / 0`，所有页同时叠加渲染。
+**You cannot put `<script src="deck_stage.js">` in the `<head>`.** Even if it can define `customElements` from `<head>`, the parser triggers `connectedCallback` the moment it parses the `<deck-stage>` start tag — at that point the child `<section>`s haven't been parsed yet, `_collectSlides()` gets an empty array, the counter shows `1 / 0`, and every page renders stacked together.
 
-**三条合规写法**（任选其一）：
+**Three compliant ways to write it** (any one is fine):
 
 ```html
-<!-- ✅ 最推荐：script 在 </deck-stage> 之后 -->
+<!-- ✅ Most recommended: script after </deck-stage> -->
 </deck-stage>
 <script src="deck_stage.js"></script>
 
-<!-- ✅ 也可：script 在 head 但加 defer -->
+<!-- ✅ Also fine: script in head but with defer -->
 <head><script src="deck_stage.js" defer></script></head>
 
-<!-- ✅ 也可：module 脚本天然 defer -->
+<!-- ✅ Also fine: module scripts defer naturally -->
 <head><script src="deck_stage.js" type="module"></script></head>
 ```
 
-`deck_stage.js` 本身已内置 `DOMContentLoaded` 延迟收集防御，即使 script 放 head 也不会彻底炸掉——但 `defer` 或放 body 底部仍然是更干净的做法，避免依赖防御分支。
+`deck_stage.js` itself has a built-in `DOMContentLoaded`-delayed collection defense, so even putting the script in head won't blow up completely — but `defer` or bottom-of-body is still the cleaner approach, avoiding reliance on the defensive branch.
 
-### ⚠️ 单文件架构的 CSS 陷阱（务必阅读）
+### ⚠️ The Single-File Architecture's CSS Trap (must read)
 
-单文件架构最常见的坑——**`display` 属性被单页样式偷走**。
+The most common pitfall of the single-file architecture — **the `display` property gets stolen by per-page styles**.
 
-常见错误姿势 1（直接写 display: flex 到 section）：
+Common wrong posture 1 (writing display: flex straight on section):
 
 ```css
-/* ❌ 外部 CSS 特异性 2，覆盖了 shadow DOM 的 ::slotted(section){display:none}（也是 2）*/
+/* ❌ Outer CSS specificity 2 overrides the shadow DOM's ::slotted(section){display:none} (also 2) */
 deck-stage > section {
-  display: flex;            /* 所有页会同时叠加渲染！ */
+  display: flex;            /* every page renders simultaneously, stacked! */
   flex-direction: column;
   padding: 80px;
   ...
 }
 ```
 
-常见错误姿势 2（section 有特异性更高的 class）：
+Common wrong posture 2 (section has a higher-specificity class):
 
 ```css
-.emotion-slide { display: grid; }   /* 特异性: 10，更糟 */
+.emotion-slide { display: grid; }   /* specificity: 10, worse */
 ```
 
-两种都会让 **所有 slide 同时叠加渲染**——counter 可能显示 `1 / 10` 假装正常，但视觉上第一页盖着第二页盖着第三页。
+Both make **every slide render simultaneously, stacked** — the counter may say `1 / 10` and look fine, but visually slide 1 is on top of slide 2 on top of slide 3.
 
-### ✅ Starter CSS（开工直接 copy，不踩坑）
+### ✅ Starter CSS (copy at kickoff, no pitfalls)
 
-**section 自身**只管「可见/不可见」；**layout（flex/grid 等）写到 `.active` 上**：
+**section itself** only handles "visible/invisible"; **layout (flex/grid etc.) is written on `.active`**:
 
 ```css
-/* section 只定义非 display 的通用样式 */
+/* section defines only non-display generic styles */
 deck-stage > section {
   background: var(--paper);
   padding: 80px 120px;
   overflow: hidden;
   position: relative;
-  /* ⚠️ 不要在这里写 display! */
+  /* ⚠️ Do not write display here! */
 }
 
-/* 锁死「非激活即隐藏」——特异性+权重双保险 */
+/* Lock "non-active is hidden" — specificity + weight, double-safe */
 deck-stage > section:not(.active) {
   display: none !important;
 }
 
-/* 激活页才写需要的 display + layout */
+/* Active page writes the needed display + layout */
 deck-stage > section.active {
   display: flex;
   flex-direction: column;
   justify-content: center;
 }
 
-/* 打印模式：所有页都要显示，覆盖 :not(.active) */
+/* Print mode: all pages must show, overriding :not(.active) */
 @media print {
   deck-stage > section { display: flex !important; }
   deck-stage > section:not(.active) { display: flex !important; }
 }
 ```
 
-替代方案：**把单页的 flex/grid 写到内部 wrapper `<div>` 上**，section 本身永远只是 `display: block/none` 的切换器。这是最干净的做法：
+Alternative: **write the per-page flex/grid onto an inner wrapper `<div>`**, so the section itself is forever just a `display: block/none` switch. This is the cleanest approach:
 
 ```html
 <deck-stage>
@@ -432,11 +432,11 @@ deck-stage > section.active {
 </deck-stage>
 ```
 
-### 自定义尺寸
+### Custom dimensions
 
 ```html
 <deck-stage width="1080" height="1920">
-  <!-- 9:16 竖版 -->
+  <!-- 9:16 portrait -->
 </deck-stage>
 ```
 
@@ -444,161 +444,161 @@ deck-stage > section.active {
 
 ## Slide Labels
 
-Deck_stage 和 deck_index 都会给每页打标签（计数器显示）。给它们**更有意义**的 label：
+Both deck_stage and deck_index label every page (the counter shows it). Give them **more meaningful** labels:
 
-**多文件**：在 `MANIFEST` 里写 `{ file, label: "04 问题陈述" }`
-**单文件**：在 section 上加 `<section data-screen-label="04 Problem Statement">`
+**Multi-file**: in `MANIFEST` write `{ file, label: "04 Problem Statement" }`
+**Single-file**: add to the section `<section data-screen-label="04 Problem Statement">`
 
-**关键：Slide 编号从 1 开始，不要从 0**。
+**Key: slide numbering starts at 1, not 0**.
 
-用户说"slide 5"时，他指的是第 5 张，永远不是数组位置 `[4]`。人类不说 0-indexed。
+When the user says "slide 5", they mean the 5th slide — never the array position `[4]`. Humans don't speak 0-indexed.
 
 ---
 
 ## Speaker Notes
 
-**默认不加**，只在用户明确要求时才加。
+**Don't add them by default** — only when the user explicitly asks.
 
-加了 speaker notes 你就可以把 slide 上的文字减少到最小，focus on impactful visuals——notes 承载完整 script。
+Once you add speaker notes, you can cut the on-slide text to a minimum and focus on impactful visuals — the notes carry the full script.
 
-### 格式
+### Format
 
-**多文件**：在 `index.html` 的 `<head>` 里写：
+**Multi-file**: in `index.html`'s `<head>`, write:
 
 ```html
 <script type="application/json" id="speaker-notes">
 [
-  "第1张的 script...",
-  "第2张的 script...",
+  "Script for slide 1...",
+  "Script for slide 2...",
   "..."
 ]
 </script>
 ```
 
-**单文件**：同上位置。
+**Single-file**: same location.
 
-### Notes 写作要点
+### Speaker Notes Writing Principles
 
-- **完整**：不是提纲，是真要讲的话
-- **对话式**：像平时说话，不是书面语
-- **对应**：数组第 N 个对应第 N 张 slide
-- **长度**：200-400 字最佳
-- **情绪线**：标注重音、停顿、强调点
+- **Complete**: not an outline — the actual words you'll say
+- **Conversational**: spoken language, not written
+- **Aligned**: the Nth entry corresponds to the Nth slide
+- **Length**: 200-400 words is the sweet spot
+- **Emotional line**: mark stresses, pauses, emphases
 
 ---
 
-## Slide 设计模式
+## Slide Design Patterns
 
-### 1. 建立一个系统（必做）
+### 1. Establish a system (mandatory)
 
-探索完 design context 后，**先口头说你要用的系统**：
+After exploring the design context, **state the system you're going to use, out loud first**:
 
 ```markdown
-Deck系统：
-- 背景色：最多2种（90% 白 + 10% 深色 section divider）
-- 字型：display 用 Instrument Serif，body 用 Geist Sans
-- 节奏：section divider 用 full-bleed 彩色 + 白字，普通 slide 白底
-- 图像：hero slide 用 full-bleed 照片，data slide 用 chart
+Deck system:
+- Background colors: at most 2 (90% white + 10% dark section divider)
+- Type: display uses Instrument Serif, body uses Geist Sans
+- Rhythm: section dividers use full-bleed color + white type; normal slides are white background
+- Imagery: hero slides use full-bleed photo, data slides use chart
 
-我按这个系统做，有问题告诉我。
+I'll proceed under this system — flag anything off.
 ```
 
-用户确认后再往下做。
+Proceed only after the user confirms.
 
-### 2. 常用 slide layouts
+### 2. Common slide layouts
 
-- **Title slide**：纯色背景 + 巨大标题 + 副标题 + 作者/日期
-- **Section divider**：彩色背景 + 章节号 + 章节标题
-- **Content slide**：白底 + 标题 + 1-3 bullet points
-- **Data slide**：标题 + 大图表/数字 + 简短说明
-- **Image slide**：full-bleed 照片 + 底部小 caption
-- **Quote slide**：留白 + 巨大 quote + attribution
-- **Two-column**：左右对比（vs / before-after / problem-solution）
+- **Title slide**: solid background + giant title + subtitle + author/date
+- **Section divider**: colored background + section number + section title
+- **Content slide**: white background + title + 1-3 bullet points
+- **Data slide**: title + big chart/number + brief explanation
+- **Image slide**: full-bleed photo + small bottom caption
+- **Quote slide**: whitespace + giant quote + attribution
+- **Two-column**: left/right comparison (vs / before-after / problem-solution)
 
-一个 deck 里最多用 4-5 种 layout。
+Use at most 4-5 layouts in one deck.
 
-### 3. Scale（再次强调）
+### 3. Scale (saying it again)
 
-- 正文最小 **24px**，理想 28-36px
-- 标题 **60-120px**
-- Hero 字 **180-240px**
-- 幻灯片是给 10 米外看的，字要够大
+- Body minimum **24px**, ideal 28-36px
+- Title **60-120px**
+- Hero type **180-240px**
+- Slides are seen from 10 meters away — the type must be big enough
 
-### 4. 视觉节奏
+### 4. Visual rhythm
 
-Deck 需要 **intentional variety**：
+A deck needs **intentional variety**:
 
-- 颜色节奏：大部分白底 + 偶尔彩色 section divider + 偶尔 dark 片段
-- 密度节奏：几张 text-heavy 的 + 几张 image-heavy 的 + 几张 quote 留白
-- 字号节奏：正常标题 + 偶尔巨型 hero 文字
+- Color rhythm: mostly white background + occasional colored section divider + occasional dark stretch
+- Density rhythm: a few text-heavy + a few image-heavy + a few quote whitespace
+- Type-size rhythm: normal titles + the occasional giant hero text
 
-**不要每张 slide 长一样**——那是 PPT 模板，不是设计。
+**Don't make every slide look the same** — that's a PPT template, not design.
 
-### 5. 空间呼吸（数据密集页必读）
+### 5. Breathing room (must read for data-dense pages)
 
-**新手最容易踩的坑**：把所有能放的信息都塞进一页。
+**The pitfall beginners stomp on most**: cramming every fact you have into one page.
 
-信息密度 ≠ 有效信息传达。学术/演讲类 deck 尤其要克制：
+Information density ≠ effective information transfer. Academic/lecture decks especially need restraint:
 
-- 列表/矩阵页：不要把 N 个元素都画成同一大小。用 **主次分层**——今天要聊的 5 个放大做主角，剩下 16 个缩小做背景 hint。
-- 大数字页：数字本身是视觉主角。周围的 caption 不要超过 3 行，否则观众眼球来回跳。
-- 引用页：引语和 attribution 之间要有留白隔开，不要贴在一起。
+- List / matrix page: don't draw every one of the N elements at the same size. Use **a primary/secondary hierarchy** — enlarge the 5 you're talking about today as the lead, shrink the remaining 16 as background hints.
+- Big-number page: the number itself is the visual lead. Surrounding captions should not exceed 3 lines, or the audience's eyes ping-pong.
+- Quote page: leave whitespace between the quote and the attribution; don't stick them together.
 
-对照「数据是不是主角」「文字有没有挤在一起」两条自我审查，改到留白让你有点不安为止。
-
----
-
-## 打印为 PDF
-
-**多文件**：`deck_index.html` 已处理 `beforeprint` 事件，按页输出 PDF。
-
-**单文件**：`deck_stage.js` 同样处理。
-
-打印样式已写好，不需要额外写 `@media print` CSS。
+Self-audit against "is the data the lead" and "is the text crammed together" — keep cutting until the whitespace makes you slightly uncomfortable.
 
 ---
 
-## 导出为 PPTX / PDF（自助脚本）
+## Printing to PDF
 
-HTML 优先是第一公民。但用户经常需要 PPTX/PDF 交付。提供两个通用脚本，**任何多文件 deck 都能用**，位于 `scripts/` 下：
+**Multi-file**: `deck_index.html` already handles `beforeprint` and outputs PDF page by page.
 
-### `export_deck_pdf.mjs` — 导出矢量 PDF（多文件架构）
+**Single-file**: `deck_stage.js` does the same.
+
+The print styles are already written — no need to add additional `@media print` CSS.
+
+---
+
+## Exporting to PPTX / PDF (self-service scripts)
+
+HTML-first is the first-class citizen. But users often need PPTX/PDF delivery. Two generic scripts are provided, **usable for any multi-file deck**, under `scripts/`:
+
+### `export_deck_pdf.mjs` — Export Vector PDF (multi-file architecture)
 
 ```bash
 node scripts/export_deck_pdf.mjs --slides <slides-dir> --out deck.pdf
 ```
 
-**特点**：
-- 文字**保留矢量**（可复制、可搜索）
-- 视觉 100% 保真（Playwright 内嵌 Chromium 渲染后打印）
-- **不需要改 HTML 任何一个字**
-- 每个 slide 独立 `page.pdf()`，再用 `pdf-lib` 合并
+**Properties**:
+- Text is **preserved as vectors** (selectable, searchable)
+- Visual fidelity is 100% (Playwright's embedded Chromium renders then prints)
+- **No HTML changes required**
+- Each slide runs its own `page.pdf()`, then merged with `pdf-lib`
 
-**依赖**：`npm install playwright pdf-lib`
+**Dependencies**: `npm install playwright pdf-lib`
 
-**限制**：PDF 不能再编辑文字——要改回到 HTML 改。
+**Limitation**: text in PDF can no longer be edited — go back to HTML to edit.
 
-### `export_deck_stage_pdf.mjs` — 单文件 deck-stage 架构专用 ⚠️
+### `export_deck_stage_pdf.mjs` — Single-file deck-stage architecture only ⚠️
 
-**什么时候用**：deck 是单 HTML 文件 + `<deck-stage>` web component 包裹 N 个 `<section>`（即路径 B 架构）。此时 `export_deck_pdf.mjs` 那套「每个 HTML 一次 `page.pdf()`」走不通，需要走这个专用脚本。
+**When to use**: the deck is a single HTML file + a `<deck-stage>` web component wrapping N `<section>`s (i.e. Path B architecture). In this case, the "one `page.pdf()` per HTML" approach of `export_deck_pdf.mjs` doesn't work — you need this dedicated script.
 
 ```bash
 node scripts/export_deck_stage_pdf.mjs --html deck.html --out deck.pdf
 ```
 
-**为什么不能复用 export_deck_pdf.mjs**（2026-04-20 真实踩坑记录）：
+**Why you can't reuse export_deck_pdf.mjs** (2026-04-20 real pitfall record):
 
-1. **Shadow DOM 赢过 `!important`**：deck-stage 的 shadow CSS 里有 `::slotted(section) { display: none }`（只 active 的那张 `display: block`）。即使在 light DOM 用 `@media print { deck-stage > section { display: block !important } }` 也压不住——`page.pdf()` 触发 print 媒体后 Chromium 最终渲染只有 active 那一张，结果**整个 PDF 只有 1 页**（当前 active slide 的重复）。
+1. **Shadow DOM wins over `!important`**: deck-stage's shadow CSS has `::slotted(section) { display: none }` (only the active one gets `display: block`). Even adding `@media print { deck-stage > section { display: block !important } }` in the light DOM can't override it — once `page.pdf()` triggers print media, Chromium's final render only contains the active slide, so **the entire PDF is just 1 page** (the current active slide, repeated).
 
-2. **循环 goto 每页还是只出 1 页**：直觉解法「对每个 `#slide-N` navigate 一次再 `page.pdf({pageRanges:'1'})`」也失败——因为 print CSS 在 shadow DOM 之外也有 `deck-stage > section { display: block }` 规则被 override 后，最终渲染永远是 section 列表的第一个（不是你 navigate 到的那一页）。结果 17 次循环得到 17 张 P01 封面。
+2. **Looping `goto` per page still produces just 1 page**: the intuitive fix "navigate to each `#slide-N` then `page.pdf({pageRanges:'1'})`" also fails — because once the print CSS's `deck-stage > section { display: block }` rule outside the shadow DOM gets overridden, the final render is always the first section in the list (not the one you navigated to). The result: 17 loops produce 17 P01 covers.
 
-3. **absolute 子元素跑到下一页**：即使成功让所有 section 渲染出来，section 本身若 `position: static`，其 absolute 定位的 `cover-footer`/`slide-footer` 会相对 initial containing block 定位——当 section 被 print 强制为 1080px 高度，absolute footer 可能被推到下一页（表现为 PDF 比 section 数量多 1 页，多出来的那页只含 footer 孤儿）。
+3. **Absolute children spill onto the next page**: even after successfully rendering all sections, if the section itself is `position: static`, its absolute-positioned `cover-footer`/`slide-footer` will be positioned relative to the initial containing block — when print forces the section to 1080px height, the absolute footer can be pushed onto the next page (the PDF ends up with one more page than there are sections, the extra page containing an orphaned footer).
 
-**修复策略**（脚本已实现）：
+**Fix strategy** (the script implements this):
 
 ```js
-// 打开 HTML 后，用 page.evaluate 把 section 从 deck-stage slot 中提出来，
-// 直接挂到 body 下一个普通 div 里，并内联 style 确保 position:relative + 固定尺寸
+// After opening the HTML, use page.evaluate to lift sections out of the deck-stage slot
+// and mount them under a plain div on body, inlining styles to ensure position:relative + fixed size
 await page.evaluate(() => {
   const stage = document.querySelector('deck-stage');
   const sections = Array.from(stage.querySelectorAll(':scope > section'));
@@ -614,7 +614,7 @@ await page.evaluate(() => {
     s.style.cssText = 'width:1920px!important;height:1080px!important;display:block!important;position:relative!important;overflow:hidden!important;page-break-after:always!important;break-after:page!important;background:#F7F4EF;margin:0!important;padding:0!important;';
     container.appendChild(s);
   });
-  // 最后一页禁分页，避免尾部空白页
+  // Disable page break on the last page to avoid a trailing blank page
   sections[sections.length - 1].style.pageBreakAfter = 'auto';
   sections[sections.length - 1].style.breakAfter = 'auto';
   document.body.appendChild(container);
@@ -623,104 +623,104 @@ await page.evaluate(() => {
 await page.pdf({ width: '1920px', height: '1080px', printBackground: true, preferCSSPageSize: true });
 ```
 
-**为什么这能 work**：
-- 把 section 从 shadow DOM slot 拔到 light DOM 的普通 div——彻底绕过 `::slotted(section) { display: none }` 规则
-- 内联 `position: relative` 让 absolute 子元素相对 section 定位，不会溢出
-- `page-break-after: always` 让浏览器 print 时每 section 独立一页
-- `:last-child` 不分页避免尾部空白页
+**Why this works**:
+- Lifting sections out of the shadow-DOM slot into a plain div in the light DOM completely bypasses the `::slotted(section) { display: none }` rule
+- Inline `position: relative` makes absolute children position relative to the section, so they don't overflow
+- `page-break-after: always` makes the browser put each section on its own page when printing
+- `:last-child` no-break avoids the trailing blank page
 
-**用 `mdls -name kMDItemNumberOfPages` 验证时注意**：macOS 的 Spotlight metadata 有缓存，PDF 重写后要跑 `mdimport file.pdf` 强制刷新，否则显示旧的页数。用 `pdfinfo` 或 `pdftoppm` 数文件数才是真数。
+**When verifying with `mdls -name kMDItemNumberOfPages`, note**: macOS Spotlight metadata is cached — after rewriting a PDF you must run `mdimport file.pdf` to force a refresh, otherwise it shows the old page count. The real count comes from `pdfinfo` or counting files from `pdftoppm`.
 
 ---
 
-### `export_deck_pptx.mjs` — 导出可编辑 PPTX
+### `export_deck_pptx.mjs` — Export Editable PPTX
 
 ```bash
-# 唯一模式：文本框原生可编辑（字体会回落到系统字体）
+# Sole mode: text frames natively editable (fonts fall back to system fonts)
 node scripts/export_deck_pptx.mjs --slides <dir> --out deck.pptx
 ```
 
-工作原理：`html2pptx` 逐元素读 computedStyle 把 DOM 翻译成 PowerPoint 对象（text frame / shape / picture）。文字变成真文本框，PPT 里双击即可编辑。
+How it works: `html2pptx` walks the DOM, reads computedStyle, and translates elements into PowerPoint objects (text frame / shape / picture). Text becomes real text frames — double-click to edit in PPT.
 
-**硬性约束**（HTML 必须满足，否则该页 skip，详细说明见 `references/editable-pptx.md`）：
-- 所有文字必须在 `<p>`/`<h1>`-`<h6>`/`<ul>`/`<ol>` 里（禁止裸文本 div）
-- `<p>`/`<h*>` 标签自身不能有 background/border/shadow（放外层 div）
-- 不用 `::before`/`::after` 插入装饰文字（伪元素提不出来）
-- inline 元素（span/em/strong）不能有 margin
-- 不用 CSS gradient（不可渲染）
-- div 不用 `background-image`（用 `<img>`）
+**Hard constraints** (HTML must meet them or the page is skipped; full explanation in `references/editable-pptx.md`):
+- All text must be inside `<p>`/`<h1>`-`<h6>`/`<ul>`/`<ol>` (no raw text in divs)
+- `<p>`/`<h*>` tags can't have background/border/shadow on themselves (put it on the outer div)
+- Don't insert decorative text with `::before`/`::after` (pseudo-elements can't be extracted)
+- Inline elements (span/em/strong) can't have margin
+- No CSS gradients (cannot be rendered)
+- divs cannot use `background-image` (use `<img>`)
 
-脚本已内置**自动预处理器**——把 "叶子 div 里的裸文本" 自动包成 `<p>`（保留 class）。这解决了最常见的违规（裸文本）。但其他违规（p 上有 border、span 上有 margin 等）仍需 HTML 源头合规。
+The script has a built-in **auto preprocessor** — it automatically wraps "raw text inside leaf divs" in `<p>` (keeping the class). This solves the most common violation (raw text). Other violations (border on p, margin on span, etc.) still require the HTML source to be compliant.
 
-**字体回落 caveat**：
-- Playwright 用 webfont 测量 text-box 尺寸；PowerPoint/Keynote 用本机字体渲染
-- 两者不同时会有**溢出或错位**——每页都要肉眼过
-- 建议目标机器装好 HTML 里用的字体，或 fallback 到 `system-ui`
+**Font fallback caveat**:
+- Playwright uses webfonts to measure text-box dimensions; PowerPoint/Keynote uses the local machine's fonts to render
+- When they differ, you get **overflow or misalignment** — eyeball every page
+- Either install the HTML's fonts on the target machine, or fall back to `system-ui`
 
-**视觉优先场景不要走这条路径** → 改用 `export_deck_pdf.mjs` 出 PDF。PDF 视觉 100% 保真、矢量、跨平台、文字可搜——是视觉优先 deck 的真正归宿，不是什么「不可编辑的妥协」。
+**Don't take this path for visual-priority scenarios** → use `export_deck_pdf.mjs` to ship a PDF instead. PDF is 100% visually faithful, vector, cross-platform, and its text is searchable — it's the true home of a visual-priority deck, not some "non-editable compromise".
 
-### 从一开始就让 HTML 对导出友好
+### Make the HTML Export-Friendly From the Start
 
-对性能最稳的 deck：**从写 HTML 时就按 editable 的 4 条硬约束写**。这样 `export_deck_pptx.mjs` 可以直接全部 pass。额外成本不大：
+For the steadiest deck performance: **write the HTML to the 4 editable hard constraints from day one**. That way `export_deck_pptx.mjs` will pass everything in one shot. The extra cost is small:
 
 ```html
-<!-- ❌ 不好 -->
-<div class="title">关键发现</div>
+<!-- ❌ Bad -->
+<div class="title">Key finding</div>
 
-<!-- ✅ 好（p 包裹，class 继承） -->
-<p class="title">关键发现</p>
+<!-- ✅ Good (wrapped in p, class inherited) -->
+<p class="title">Key finding</p>
 
-<!-- ❌ 不好（border 在 p 上） -->
+<!-- ❌ Bad (border on the p) -->
 <p class="stat" style="border-left: 3px solid red;">41%</p>
 
-<!-- ✅ 好（border 在外层 div） -->
+<!-- ✅ Good (border on the outer div) -->
 <div class="stat-wrap" style="border-left: 3px solid red;">
   <p class="stat">41%</p>
 </div>
 ```
 
-### 何时选哪个
+### Which to pick when
 
-| 场景 | 推荐 |
+| Scenario | Recommendation |
 |------|------|
-| 给主办方/档案存档 | **PDF**（通用、高保真、文字可搜） |
-| 发给协作者让他们微调文字 | **PPTX editable**（接受字体回落） |
-| 要现场演讲、不改内容 | **PDF**（矢量保真，跨平台） |
-| HTML 是首选呈现媒介 | 直接浏览器播放，导出只是备份 |
+| For the host / archival | **PDF** (universal, high-fidelity, searchable text) |
+| Sending to collaborators for them to tweak text | **PPTX editable** (accept font fallback) |
+| For live presenting, no content changes | **PDF** (vector fidelity, cross-platform) |
+| HTML is the primary presentation medium | Play in browser directly — export is just a backup |
 
-## 导出为可编辑 PPTX 的深度路径（仅长期项目）
+## The Deeper Editable-PPTX Path (for long-term projects only)
 
-如果你的 deck 会长期维护、反复修改、团队协作——建议**一开始就按 html2pptx 约束写 HTML**，这样 `export_deck_pptx.mjs` 可以直接全部 pass。详见 `references/editable-pptx.md`（4 条硬约束 + HTML 模板 + 常见错误速查 + 已有视觉稿的 fallback 流程）。
-
----
-
-## 常见问题
-
-**多文件：iframe 里的页打不开 / 白屏**
-→ 检查 `MANIFEST` 的 `file` 路径是否相对 `index.html` 正确。用浏览器 DevTools 看 iframe 的 src 能否直接访问。
-
-**多文件：某页样式和别页冲突**
-→ 不可能（iframe 隔离）。如果感觉冲突，那是缓存——Cmd+Shift+R 强刷。
-
-**单文件：多 slide 同时渲染叠加**
-→ CSS 特异性问题。看上面「单文件架构的 CSS 陷阱」一节。
-
-**单文件：缩放看起来不对**
-→ 检查是否所有 slide 直接挂在 `<deck-stage>` 下作为 `<section>`。中间不能包 `<div>`。
-
-**单文件：想跳到特定 slide**
-→ URL 加 hash：`index.html#slide-5` 跳到第 5 张。
-
-**两种架构都适用：字在不同屏幕下位置不一致**
-→ 用固定尺寸（1920×1080）和 `px` 单位，不要用 `vw`/`vh` 或 `%`。缩放统一处理。
+If your deck will be maintained long-term, edited repeatedly, with team collaboration — **write the HTML to the html2pptx constraints from the very start**, so `export_deck_pptx.mjs` passes everything in one go. See `references/editable-pptx.md` (4 hard constraints + HTML template + common-error quick reference + fallback flow for existing visual mocks).
 
 ---
 
-## 验证检查清单（做完 deck 必过）
+## Common Issues
 
-1. [ ] 浏览器直接打开 `index.html`（或主 HTML），检查首页无破图、字体已加载
-2. [ ] 按 → 键翻到每一页，没有空白页、没有布局错位
-3. [ ] 按 P 键打印预览，每页恰好一张 A4（或 1920×1080）且无裁切
-4. [ ] 随机选 3 页 Cmd+Shift+R 强刷，localStorage 记忆正常工作
-5. [ ] Playwright 批量截图（单页架构：遍历 `slides/*.html`；单文件架构：用 goTo 切换），人工肉眼过一遍
-6. [ ] 搜一下 `TODO` / `placeholder` 残留，确认都清理了
+**Multi-file: an iframe page won't open / shows blank**
+→ Check the `MANIFEST`'s `file` path is correct relative to `index.html`. Use DevTools to check the iframe's src is directly reachable.
+
+**Multi-file: a page's styles conflict with another page**
+→ Impossible (iframes isolate). If it feels like a conflict, it's the cache — Cmd+Shift+R hard refresh.
+
+**Single-file: multiple slides render stacked**
+→ CSS specificity issue. See "The Single-File Architecture's CSS Trap" above.
+
+**Single-file: scaling looks wrong**
+→ Check that every slide hangs directly under `<deck-stage>` as `<section>`. There must be no `<div>` in between.
+
+**Single-file: want to jump to a specific slide**
+→ Add a URL hash: `index.html#slide-5` jumps to slide 5.
+
+**Both architectures: text positions are inconsistent across screens**
+→ Use fixed dimensions (1920×1080) and `px` units, not `vw`/`vh` or `%`. Scaling is handled uniformly.
+
+---
+
+## Validation Checklist (must pass after finishing the deck)
+
+1. [ ] Open `index.html` (or the main HTML) directly in the browser — confirm the first page has no broken images and fonts have loaded
+2. [ ] Press → to advance through every slide — no blank pages, no layout breakage
+3. [ ] Press P for print preview — each page is exactly one A4 (or 1920×1080) with no clipping
+4. [ ] Hard refresh (Cmd+Shift+R) 3 random pages — localStorage memory still works
+5. [ ] Playwright batch screenshots (multi-file: iterate `slides/*.html`; single-file: switch via goTo) — eyeball every one
+6. [ ] Search for `TODO` / `placeholder` leftovers — confirm they're all cleaned up

--- a/references/tweaks-system.md
+++ b/references/tweaks-system.md
@@ -1,20 +1,20 @@
-# Tweaks：设计变体实时调参
+# Tweaks: Live Tuning of Design Variants
 
-Tweaks是这个skill里很核心的能力——让用户不改代码就能实时切换variations/调整参数。
+Tweaks is a core capability of this skill — it lets the user switch variations and tune parameters in real time without touching code.
 
-**跨 agent 环境适配**：某些 design-agent 原生环境（如 Claude.ai Artifacts）依赖 host 的 postMessage 把 tweak 值回写源码做持久化。本 skill 采用**纯前端 localStorage 方案**——效果一致（刷新保留状态），但持久化发生在浏览器 localStorage 而不是源码文件。这个方案在任何 agent 环境（Claude Code / Codex / Cursor / Trae / etc.）都能工作。
+**Cross-agent compatibility**: some native design-agent environments (like Claude.ai Artifacts) rely on the host's postMessage to write tweak values back to source for persistence. This skill uses a **pure-frontend localStorage approach** — the effect is the same (state survives a refresh), but persistence happens in the browser's localStorage instead of in the source file. This approach works in any agent environment (Claude Code / Codex / Cursor / Trae / etc.).
 
-## 何时加 Tweaks
+## When to Add Tweaks
 
-- 用户明确要求"能调参"/"多个版本切换"
-- 设计有多个variations需要对比时
-- 用户没明说，但你主观判断**加几个有启发性的tweaks能帮用户看到可能性**
+- The user explicitly asks for "tunable" / "multiple versions to switch between"
+- The design has multiple variations that need to be compared
+- The user didn't say so, but you judge that **a few illustrative tweaks would help the user see the possibility space**
 
-默认推荐：**每个设计都加2-3个tweaks**（颜色主题/字号/layout变体）即使用户没要求——让用户看到可能性空间是设计服务的一部分。
+Default recommendation: **add 2-3 tweaks to every design** (color theme / font size / layout variant) even if the user didn't ask — showing the user the space of possibilities is part of the design service.
 
-## 实现方式（纯前端版）
+## Implementation (pure-frontend version)
 
-### 基本结构
+### Basic structure
 
 ```jsx
 const TWEAK_DEFAULTS = {
@@ -53,9 +53,9 @@ function useTweaks() {
 }
 ```
 
-### Tweaks面板UI
+### Tweaks panel UI
 
-右下角浮动面板。可折叠：
+A floating panel in the bottom-right corner. Collapsible:
 
 ```jsx
 function TweaksPanel() {
@@ -92,9 +92,9 @@ function TweaksPanel() {
             }}>×</button>
           </div>
 
-          {/* 颜色 */}
+          {/* Color */}
           <label style={{ display: 'block', marginBottom: 12 }}>
-            <div style={{ marginBottom: 4, color: '#666' }}>主色</div>
+            <div style={{ marginBottom: 4, color: '#666' }}>Primary color</div>
             <input 
               type="color" 
               value={tweaks.primaryColor} 
@@ -103,9 +103,9 @@ function TweaksPanel() {
             />
           </label>
 
-          {/* 字号slider */}
+          {/* Font size slider */}
           <label style={{ display: 'block', marginBottom: 12 }}>
-            <div style={{ marginBottom: 4, color: '#666' }}>字号 ({tweaks.fontSize}px)</div>
+            <div style={{ marginBottom: 4, color: '#666' }}>Font size ({tweaks.fontSize}px)</div>
             <input 
               type="range" 
               min={12} max={24} step={1}
@@ -115,21 +115,21 @@ function TweaksPanel() {
             />
           </label>
 
-          {/* 密度选项 */}
+          {/* Density options */}
           <label style={{ display: 'block', marginBottom: 12 }}>
-            <div style={{ marginBottom: 4, color: '#666' }}>密度</div>
+            <div style={{ marginBottom: 4, color: '#666' }}>Density</div>
             <select 
               value={tweaks.density}
               onChange={e => update({ density: e.target.value })}
               style={{ width: '100%', padding: 6 }}
             >
-              <option value="compact">紧凑</option>
-              <option value="comfortable">舒适</option>
-              <option value="spacious">宽松</option>
+              <option value="compact">Compact</option>
+              <option value="comfortable">Comfortable</option>
+              <option value="spacious">Spacious</option>
             </select>
           </label>
 
-          {/* 暗黑模式toggle */}
+          {/* Dark mode toggle */}
           <label style={{ 
             display: 'flex', 
             alignItems: 'center',
@@ -141,7 +141,7 @@ function TweaksPanel() {
               checked={tweaks.dark}
               onChange={e => update({ dark: e.target.checked })}
             />
-            <span>暗黑模式</span>
+            <span>Dark mode</span>
           </label>
 
           <button onClick={reset} style={{
@@ -152,7 +152,7 @@ function TweaksPanel() {
             borderRadius: 6,
             cursor: 'pointer',
             fontSize: 12,
-          }}>重置</button>
+          }}>Reset</button>
         </div>
       ) : (
         <button 
@@ -174,9 +174,9 @@ function TweaksPanel() {
 }
 ```
 
-### 应用Tweaks
+### Applying tweaks
 
-在主组件里用Tweaks：
+Use Tweaks in the root component:
 
 ```jsx
 function App() {
@@ -189,14 +189,14 @@ function App() {
       background: tweaks.dark ? '#0A0A0A' : '#FAFAFA',
       color: tweaks.dark ? '#FAFAFA' : '#1A1A1A',
     }}>
-      {/* 你的内容 */}
+      {/* your content */}
       <TweaksPanel />
     </div>
   );
 }
 ```
 
-CSS里用变量：
+Use the variables in CSS:
 
 ```css
 button.cta {
@@ -206,74 +206,74 @@ button.cta {
 }
 ```
 
-## 典型 Tweak 选项
+## Typical Tweak Options
 
-给不同类型的设计加什么tweaks：
+What to add for different kinds of design:
 
-### 通用
-- 主色（color picker）
-- 字号（slider 12-24px）
-- 字型（select：display font vs body font）
-- 暗黑模式（toggle）
+### Generic
+- Primary color (color picker)
+- Font size (slider 12-24px)
+- Typeface (select: display font vs body font)
+- Dark mode (toggle)
 
-### 幻灯片deck
-- 主题（light/dark/brand）
-- 背景样式（solid/gradient/image）
-- 字体对比（更装饰 vs 更克制）
-- 信息密度（minimal/standard/dense）
+### Slide deck
+- Theme (light/dark/brand)
+- Background style (solid/gradient/image)
+- Type contrast (more decorative vs more restrained)
+- Information density (minimal/standard/dense)
 
-### 产品原型
-- 布局变体（layout A / B / C）
-- 交互速度（animation speed 0.5x-2x）
-- 数据量（mock数据条数 5/20/100）
-- 状态（empty/loading/success/error）
+### Product prototype
+- Layout variant (layout A / B / C)
+- Interaction speed (animation speed 0.5x-2x)
+- Data volume (mock data rows 5/20/100)
+- State (empty/loading/success/error)
 
-### 动画
-- 速度（0.5x-2x）
-- 循环（once/loop/ping-pong）
-- Easing（linear/easeOut/spring）
+### Animation
+- Speed (0.5x-2x)
+- Loop (once/loop/ping-pong)
+- Easing (linear/easeOut/spring)
 
 ### Landing page
-- Hero风格（image/gradient/pattern/solid）
-- CTA文案（几种变体）
-- 结构（single column / two column / sidebar）
+- Hero style (image/gradient/pattern/solid)
+- CTA copy (a few variants)
+- Structure (single column / two column / sidebar)
 
-## Tweaks设计原则
+## Tweaks Design Principles
 
-### 1. 有意义的选项，不是折腾人的
+### 1. Meaningful options, not busywork
 
-每个tweak必须展示**真实的设计选项**。别加那种谁都不会真切换的tweak（比如border-radius 0-50px的slider——用户调完发现所有中间值都丑）。
+Every tweak must expose **real design choices**. Don't add tweaks no one would actually toggle (e.g. a 0-50px border-radius slider — every intermediate value looks ugly).
 
-好的tweak暴露**离散的、有思考的variations**：
-- "圆角风格"：无圆角 / 微圆角 / 大圆角（三个选项）
-- 不是："圆角"：0-50px slider
+A good tweak exposes **discrete, considered variations**:
+- "Corner style": no corners / subtle corners / large corners (three options)
+- Not: "Corner radius": 0-50px slider
 
-### 2. 少即是多
+### 2. Better empty than padded
 
-一个设计的Tweaks面板**最多5-6个**选项。再多就变成"配置页面"，失去了快速探索variations的意义。
+A design's Tweaks panel should have at most **5-6 options**. Any more and it turns into a "config page" — it loses the point of quickly exploring variations.
 
-### 3. 默认值是完成设计
+### 3. The defaults are the finished design
 
-Tweaks是**锦上添花**。默认值必须本身就是一个完整、可发布的设计。用户关闭Tweaks面板后看到的就是产出。
+Tweaks are **icing on the cake**. The default values must themselves be a complete, shippable design. What the user sees with the Tweaks panel closed is the deliverable.
 
-### 4. 合理分组
+### 4. Group sensibly
 
-选项多时分组显示：
+When you have many options, group them:
 
 ```
----- 视觉 ----
-主色 | 字号 | 暗黑模式
+---- Visual ----
+Primary color | Font size | Dark mode
 
----- 布局 ----
-密度 | 侧栏位置
+---- Layout ----
+Density | Sidebar position
 
----- 内容 ----
-显示数据量 | 状态
+---- Content ----
+Data volume | State
 ```
 
-## 向前兼容源码级持久化 host
+## Forward Compatibility with Source-Level Persistence Hosts
 
-如果你以后想把设计上传到支持源码级 tweaks（如 Claude.ai Artifacts）的环境也能跑，保留 **EDITMODE 标记块**：
+If you later want the design to also run in an environment that supports source-level tweaks (such as Claude.ai Artifacts), keep the **EDITMODE marker block**:
 
 ```jsx
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
@@ -284,26 +284,26 @@ const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
 }/*EDITMODE-END*/;
 ```
 
-标记块在 localStorage 方案里**无作用**（只是个普通注释），但在支持源码回写的 host 里会被读取，实现源码级持久化。加上这个对当前环境无害，同时保持向前兼容。
+The marker block has **no effect** in the localStorage approach (it's just a comment), but in a host that supports source rewriting it will be read and used for source-level persistence. Adding it costs nothing in the current environment and preserves forward compatibility.
 
-## 常见问题
+## Common Issues
 
-**Tweaks面板挡住设计内容**
-→ 让它可关闭。默认关闭，显示一个小按钮，用户点了才展开。
+**The Tweaks panel covers the design content**
+→ Make it closable. Default to closed, show a small button, expand only when the user clicks.
 
-**用户切换tweaks后还要重复设置**
-→ 已经用localStorage。如果刷新后不持久，检查localStorage是否可用（无痕模式会失败，要catch）。
+**The user keeps having to re-set the tweaks after switching**
+→ localStorage is already in use. If it doesn't persist after a refresh, check that localStorage is available (incognito mode fails — wrap in try/catch).
 
-**多个HTML页面想共享tweaks**
-→ 给localStorage key加project name：`design-tweaks-[projectName]`。
+**Multiple HTML pages want to share tweaks**
+→ Add the project name to the localStorage key: `design-tweaks-[projectName]`.
 
-**我想让tweak之间有联动关系**
-→ 在`update`里加逻辑：
+**I want tweaks to be linked to each other**
+→ Add logic inside `update`:
 
 ```jsx
 const update = (patch) => {
   let next = { ...tweaks, ...patch };
-  // 联动：选dark mode时自动切换字体配色
+  // linkage: when dark mode is selected, swap the text color too
   if (patch.dark === true && !patch.textColor) {
     next.textColor = '#F0EEE6';
   }

--- a/references/verification.md
+++ b/references/verification.md
@@ -1,189 +1,189 @@
-# Verification：输出验证流程
+# Verification: Output Verification Workflow
 
-一些 design-agent 原生环境（如 Claude.ai Artifacts）有内置的 `fork_verifier_agent` 起 subagent 用 iframe 截图检查。大部分 agent 环境（Claude Code / Codex / Cursor / Trae / 等）里没有这个内置能力——用 Playwright 手动做就能覆盖相同的验证场景。
+Some design-agent native environments (like Claude.ai Artifacts) have a built-in `fork_verifier_agent` that spawns a subagent to screenshot through an iframe. Most agent environments (Claude Code / Codex / Cursor / Trae / etc.) don't have this built in — doing it manually with Playwright covers the same verification scenarios.
 
-## 验证清单
+## Verification Checklist
 
-每次产出HTML后，按这个清单做一遍：
+After every HTML output, walk through this list:
 
-### 1. 浏览器渲染检查（必做）
+### 1. Browser render check (mandatory)
 
-最基础：**HTML能不能打开**？在macOS上：
+Most basic: **does the HTML even open**? On macOS:
 
 ```bash
 open -a "Google Chrome" "/path/to/your/design.html"
 ```
 
-或者用Playwright截图（下一节）。
+Or screenshot with Playwright (next section).
 
-### 2. 控制台错误检查
+### 2. Console error check
 
-HTML文件里最常见的问题是JS报错导致白屏。用Playwright跑一遍：
+The most common HTML file problem is a JS error producing a white screen. Run Playwright once:
 
 ```bash
 python ~/.claude/skills/claude-design/scripts/verify.py path/to/design.html
 ```
 
-这个脚本会：
-1. 用headless chromium打开HTML
-2. 截图保存到项目目录
-3. 抓取控制台错误
-4. 报告status
+This script:
+1. Opens the HTML in headless Chromium
+2. Saves a screenshot to the project directory
+3. Captures console errors
+4. Reports status
 
-详见`scripts/verify.py`。
+See `scripts/verify.py` for details.
 
-### 3. 多视口检查
+### 3. Multi-viewport check
 
-如果是响应式设计，抓多个viewport：
+For responsive designs, capture multiple viewports:
 
 ```bash
 python verify.py design.html --viewports 1920x1080,1440x900,768x1024,375x667
 ```
 
-### 4. 交互检查
+### 4. Interaction check
 
-Tweaks、动画、按钮切换——默认的静态截图看不到。**建议让用户自己开浏览器点一遍**，或者用Playwright录屏：
+Tweaks, animations, button toggles — static screenshots can't see these. **Recommended: have the user open the browser and click through themselves**, or record video with Playwright:
 
 ```python
 page.video.record('interaction.mp4')
 ```
 
-### 5. 幻灯片逐页检查
+### 5. Per-slide check for slide decks
 
-Deck类HTML，一张张截：
+Deck-style HTML, capture each:
 
 ```bash
-python verify.py deck.html --slides 10  # 截前10张
+python verify.py deck.html --slides 10  # capture first 10
 ```
 
-生成 `deck-slide-01.png`、`deck-slide-02.png`... 方便快速浏览。
+Produces `deck-slide-01.png`, `deck-slide-02.png`... for quick browsing.
 
 ## Playwright Setup
 
-首次使用需要：
+First-time setup:
 
 ```bash
-# 如果还没装
+# If not installed
 npm install -g playwright
 npx playwright install chromium
 
-# 或者Python版
+# Or Python version
 pip install playwright
 playwright install chromium
 ```
 
-如果用户已经全局安装 Playwright，直接用即可。
+If the user already has Playwright installed globally, use it directly.
 
-## 截图最佳实践
+## Screenshot Best Practices
 
-### 截完整页面
+### Full page
 
 ```python
 page.screenshot(path='full.png', full_page=True)
 ```
 
-### 截viewport
+### Viewport only
 
 ```python
-page.screenshot(path='viewport.png')  # 默认只截可见区域
+page.screenshot(path='viewport.png')  # default: visible area only
 ```
 
-### 截特定元素
+### Specific element
 
 ```python
 element = page.query_selector('.hero-section')
 element.screenshot(path='hero.png')
 ```
 
-### 高清截图
+### Hi-res screenshot
 
 ```python
 page = browser.new_page(device_scale_factor=2)  # retina
 ```
 
-### 等动画结束再截
+### Wait for animation to finish before capturing
 
 ```python
-page.wait_for_timeout(2000)  # 等2秒让动画settle
+page.wait_for_timeout(2000)  # 2 seconds for animation to settle
 page.screenshot(...)
 ```
 
-## 把截图发给用户
+## Sending Screenshots to the User
 
-### 本地截图直接打开
+### Open the local screenshot directly
 
 ```bash
 open screenshot.png
 ```
 
-用户会在自己的 Preview/Figma/VSCode/浏览器 里看。
+The user views in their own Preview / Figma / VSCode / browser.
 
-### 上传图床分享链接
+### Upload to image host, share a link
 
-如果需要给远程协作者看（比如 Slack/飞书/微信），让用户用自己的图床工具或 MCP 上传：
+If you need to share with remote collaborators (e.g., Slack / Feishu / WeChat), have the user use their own image host tool or MCP to upload:
 
 ```bash
-python ~/Documents/写作/tools/upload_image.py screenshot.png
+python ~/Documents/writing/tools/upload_image.py screenshot.png
 ```
 
-返回ImgBB的永久链接，可以粘贴到任何地方。
+Returns an ImgBB permanent link that can be pasted anywhere.
 
-## 验证出错时
+## When Verification Fails
 
-### 页面白屏
+### Blank page
 
-控制台一定有错。先检查：
+There's definitely a console error. Check first:
 
-1. React+Babel script tag的integrity hash对不对（见`react-setup.md`）
-2. 是不是`const styles = {...}`命名冲突
-3. 跨文件的组件有没有export到`window`
-4. JSX语法错误（babel.min.js不报错，换babel.js非压缩版）
+1. React+Babel script tag integrity hashes (see `react-setup.md`)
+2. Whether `const styles = {...}` name collisions exist
+3. Whether cross-file components were exported to `window`
+4. JSX syntax errors (babel.min.js doesn't report errors — swap in the unminified babel.js)
 
-### 动画卡
+### Animation stutters
 
-- 用Chrome DevTools Performance tab录一段
-- 找layout thrashing（频繁的reflow）
-- 动效优先用`transform`和`opacity`（GPU加速）
+- Record a clip with Chrome DevTools Performance tab
+- Look for layout thrashing (frequent reflow)
+- Prefer `transform` and `opacity` for motion (GPU-accelerated)
 
-### 字体不对
+### Wrong font
 
-- 检查`@font-face`的url是否可访问
-- 检查fallback字体
-- 中文字体加载慢：先显示fallback，加载完再切换
+- Check whether the `@font-face` url is reachable
+- Check fallback fonts
+- Chinese fonts load slowly: show fallback first, switch after load
 
-### 布局错位
+### Layout broken
 
-- 检查`box-sizing: border-box`是否全局应用
-- 检查`*  margin: 0; padding: 0`reset
-- Chrome DevTools里打开gridlines看实际布局
+- Check whether `box-sizing: border-box` is applied globally
+- Check `*  margin: 0; padding: 0` reset
+- Open gridlines in Chrome DevTools to see actual layout
 
-## 验证=设计师的第二双眼
+## Verification = the Designer's Second Pair of Eyes
 
-**永远要自己过一遍**。AI写代码时经常出现：
+**Always go over it yourself**. When AI writes code, these things happen often:
 
-- 看起来对但interaction有bug
-- 静态截图好但scroll时错位
-- 宽屏好看但窄屏崩
-- Dark mode忘了测
-- Tweaks切换后某些组件没响应
+- Looks right but interaction has a bug
+- Static screenshot looks good but breaks while scrolling
+- Looks great on wide screens, collapses on narrow
+- Forgot to test dark mode
+- After toggling Tweaks, some components didn't respond
 
-**最后1分钟的验证可以省1小时的返工**。
+**The last 1 minute of verification saves 1 hour of rework**.
 
-## 常用验证脚本命令
+## Common Verification Script Commands
 
 ```bash
-# 基础：打开+截图+抓错
+# Basic: open + screenshot + capture errors
 python verify.py design.html
 
-# 多viewport
+# Multiple viewports
 python verify.py design.html --viewports 1920x1080,375x667
 
-# 多slide
+# Multiple slides
 python verify.py deck.html --slides 10
 
-# 输出到指定目录
+# Output to a specific directory
 python verify.py design.html --output ./screenshots/
 
-# headless=false，打开真实浏览器给你看
+# headless=false, show a real browser
 python verify.py design.html --show
 ```

--- a/references/video-export.md
+++ b/references/video-export.md
@@ -1,209 +1,209 @@
-# Video Export：HTML 动画导出为 MP4/GIF
+# Video Export: Exporting HTML Animations to MP4/GIF
 
-动画 HTML 完成后，用户常想「能导出视频吗」。这份指南给出完整流程。
+Once an animation HTML is done, users often ask "can you export this as a video?" This guide gives you the full pipeline.
 
-## 何时导出
+## When to Export
 
-**导出时机**：
-- 动画完整跑通、视觉验证过（Playwright 截图确认各时间点状态正确）
-- 用户在浏览器里看过至少一次，表示效果 OK
-- **不要**在动画 bug 没修完的阶段导出——导出到视频后改起来更贵
+**Timing**:
+- Animation runs end-to-end and is visually verified (Playwright screenshots confirm state at each time point)
+- The user has watched it in the browser at least once and signed off
+- **Do not** export while animation bugs remain — fixes get more expensive once it's video
 
-**用户可能说的触发语**：
-- 「能导出成视频吗」
-- 「转成 MP4」
-- 「做成 GIF」
-- 「60fps」
+**Likely trigger phrases from the user**:
+- "Can you export this as a video?"
+- "Convert to MP4"
+- "Make it a GIF"
+- "60fps"
 
-## 产出规格
+## Output Specs
 
-默认一次给三种格式，让用户选：
+By default, deliver three formats and let the user pick:
 
-| 格式 | 规格 | 适合场景 | 典型大小（30s） |
+| Format | Spec | Use case | Typical size (30s) |
 |---|---|---|---|
-| MP4 25fps | 1920×1080 · H.264 · CRF 18 | 公众号嵌入、视频号、YouTube | 1-2 MB |
-| MP4 60fps | 1920×1080 · minterpolate 插帧 · H.264 · CRF 18 | 高帧率展示、B站、作品集 | 1.5-3 MB |
-| GIF | 960×540 · 15fps · palette 优化 | Twitter/X、README、Slack 预览 | 2-4 MB |
+| MP4 25fps | 1920×1080 · H.264 · CRF 18 | WeChat articles, video accounts, YouTube | 1-2 MB |
+| MP4 60fps | 1920×1080 · minterpolate frame interpolation · H.264 · CRF 18 | High-frame-rate showcases, Bilibili, portfolios | 1.5-3 MB |
+| GIF | 960×540 · 15fps · palette optimized | Twitter/X, README, Slack previews | 2-4 MB |
 
-## 工具链
+## Toolchain
 
-两个脚本在 `scripts/`：
+Two scripts under `scripts/`:
 
 ### 1. `render-video.js` — HTML → MP4
 
-录一个 25fps 的 MP4 基础版本。依赖全局 playwright。
+Records a 25fps baseline MP4. Depends on globally installed playwright.
 
 ```bash
-NODE_PATH=$(npm root -g) node /path/to/claude-design/scripts/render-video.js <html文件>
+NODE_PATH=$(npm root -g) node /path/to/claude-design/scripts/render-video.js <html file>
 ```
 
-可选参数：
-- `--duration=30` 动画时长（秒）
-- `--width=1920 --height=1080` 分辨率
-- `--trim=2.2` 从视频开头裁掉的秒数（去掉 reload + 字体加载时间）
-- `--fontwait=1.5` 字体加载等待时间（秒），字体多时调高
+Optional flags:
+- `--duration=30` animation length (seconds)
+- `--width=1920 --height=1080` resolution
+- `--trim=2.2` seconds to trim from the start of the video (strips reload + font loading)
+- `--fontwait=1.5` font load wait (seconds); raise this when there are many fonts
 
-输出：与 HTML 同目录，同名 `.mp4`。
+Output: same directory as the HTML, same name with `.mp4`.
 
 ### 2. `add-music.sh` — MP4 + BGM → MP4
 
-给无声 MP4 混入背景音乐，按场景（mood）从内置 BGM 库里选，也可自带音频。自动匹配时长、加淡入淡出。
+Mixes BGM into a silent MP4. Pick from the bundled BGM library by scene (mood) or supply your own audio. Auto-matches duration and adds fades.
 
 ```bash
 bash add-music.sh <input.mp4> [--mood=<name>] [--music=<path>] [--out=<path>]
 ```
 
-**内置 BGM 库**（在 `assets/bgm-<mood>.mp3`）：
+**Bundled BGM library** (at `assets/bgm-<mood>.mp3`):
 
-| `--mood=` | 风格 | 适配场景 |
+| `--mood=` | Style | Scene |
 |-----------|------|---------|
-| `tech`（默认） | Apple Silicon / 苹果发布会，极简合成器+钢琴 | 产品发布、AI工具、Skill 宣传 |
-| `ad` | upbeat 现代电子，有 build + drop | 社交媒体广告、产品预告、促销片 |
-| `educational` | 温暖明亮、轻吉他/电钢琴，inviting | 科普、教程介绍、课程预告 |
-| `educational-alt` | 同类备选，换一首试试 | 同上 |
-| `tutorial` | lo-fi 环境音，几乎无存在感 | 软件演示、编程教程、长演示 |
-| `tutorial-alt` | 同类备选 | 同上 |
+| `tech` (default) | Apple Silicon / Apple keynote, minimal synth + piano | Product launches, AI tools, skill promos |
+| `ad` | Upbeat modern electronic, with build + drop | Social media ads, product teasers, promos |
+| `educational` | Warm, bright, soft guitar/electric piano, inviting | Explainers, tutorial intros, course teasers |
+| `educational-alt` | Sibling alternative, swap when you want variety | Same as above |
+| `tutorial` | Lo-fi ambient, almost imperceptible | Software demos, programming tutorials, long demos |
+| `tutorial-alt` | Sibling alternative | Same as above |
 
-**行为**：
-- 音乐按视频时长裁剪
-- 0.3s 淡入 + 1s 淡出（避免硬切）
-- 视频流 `-c:v copy` 不重编码，音频 AAC 192k
-- `--music=<path>` 优先级高于 `--mood`，可以直接指定任意外部音频
-- 传错 mood 名会列出所有可用选项，不会静默失败
+**Behavior**:
+- BGM is trimmed to video duration
+- 0.3s fade-in + 1s fade-out (no hard cuts)
+- Video stream `-c:v copy` (no re-encode); audio AAC 192k
+- `--music=<path>` takes precedence over `--mood`; pass any external audio
+- A wrong mood name lists all valid options — no silent failure
 
-**典型流水线**（动画导出三件套 + 配乐）：
+**Typical pipeline** (animation export triplet + BGM):
 ```bash
-node render-video.js animation.html                        # 录屏
-bash convert-formats.sh animation.mp4                      # 派生 60fps + GIF
-bash add-music.sh animation-60fps.mp4                      # 加默认 tech BGM
-# 或针对不同场景：
+node render-video.js animation.html                        # record
+bash convert-formats.sh animation.mp4                      # derive 60fps + GIF
+bash add-music.sh animation-60fps.mp4                      # add default tech BGM
+# Or per scene:
 bash add-music.sh tutorial-demo.mp4 --mood=tutorial
 bash add-music.sh product-promo.mp4 --mood=ad --out=promo-final.mp4
 ```
 
 ### 3. `convert-formats.sh` — MP4 → 60fps MP4 + GIF
 
-从已有 MP4 生成 60fps 版本和 GIF。
+Derive a 60fps version and a GIF from an existing MP4.
 
 ```bash
 bash /path/to/claude-design/scripts/convert-formats.sh <input.mp4> [gif_width] [--minterpolate]
 ```
 
-输出（与输入同目录）：
-- `<name>-60fps.mp4` — 默认用 `fps=60` 帧复制（兼容性广）；加 `--minterpolate` 启用高质量插帧
-- `<name>.gif` — palette 优化的 GIF（默认 960 宽，可改）
+Outputs (same directory as input):
+- `<name>-60fps.mp4` — defaults to `fps=60` frame duplication (broad compatibility); pass `--minterpolate` for high-quality motion interpolation
+- `<name>.gif` — palette-optimized GIF (default 960 wide, adjustable)
 
-**60fps 模式选择**：
+**Choosing a 60fps mode**:
 
-| 模式 | 命令 | 兼容性 | 使用场景 |
+| Mode | Command | Compatibility | Use case |
 |---|---|---|---|
-| 帧复制（默认）| `convert-formats.sh in.mp4` | QuickTime/Safari/Chrome/VLC 全通 | 通用交付、上传平台、社交媒体 |
-| minterpolate 插帧 | `convert-formats.sh in.mp4 --minterpolate` | macOS QuickTime/Safari 可能拒打 | B站等需要真插帧的展示场景，**交付前必须本地测**目标播放器 |
+| Frame duplication (default) | `convert-formats.sh in.mp4` | QuickTime/Safari/Chrome/VLC all play | General delivery, platform uploads, social media |
+| minterpolate interpolation | `convert-formats.sh in.mp4 --minterpolate` | macOS QuickTime/Safari may refuse to open | Bilibili and similar showcases that need true interpolation. **Before delivery, test the target player locally.** |
 
-为什么默认改成帧复制？minterpolate 输出的 H.264 elementary stream 有 known compat bug——之前默认 minterpolate 时多次踩到「macOS QuickTime 打不开」的问题。详见 `animation-pitfalls.md` §14。
+Why default to frame duplication? minterpolate's H.264 elementary stream has a known compat bug — we've hit "macOS QuickTime won't open it" repeatedly when minterpolate was the default. See `animation-pitfalls.md` §14.
 
-`gif_width` 参数：
-- 960（默认）—— 社交平台通用
-- 1280 —— 更清晰但文件更大
-- 600 —— Twitter/X 优先加载
+`gif_width` parameter:
+- 960 (default) — general-purpose social platforms
+- 1280 — sharper but larger file
+- 600 — Twitter/X priority loading
 
-## 完整流程（标准推荐）
+## Full Pipeline (Standard Recommendation)
 
-用户说「导出视频」后：
+After the user says "export as video":
 
 ```bash
-cd <项目目录>
+cd <project directory>
 
-# 假设 $SKILL 指向本 skill 的根目录（自行按安装位置替换）
+# Assume $SKILL points to the root of this skill (substitute your install path)
 
-# 1. 录 25fps 基础 MP4
+# 1. Record the 25fps baseline MP4
 NODE_PATH=$(npm root -g) node "$SKILL/scripts/render-video.js" my-animation.html
 
-# 2. 派生 60fps MP4 和 GIF
+# 2. Derive the 60fps MP4 and the GIF
 bash "$SKILL/scripts/convert-formats.sh" my-animation.mp4
 
-# 产出清单：
+# Deliverables:
 # my-animation.mp4         (25fps · 1-2 MB)
 # my-animation-60fps.mp4   (60fps · 1.5-3 MB)
 # my-animation.gif         (15fps · 2-4 MB)
 ```
 
-## 技术细节（排错用）
+## Technical Details (For Debugging)
 
-### Playwright recordVideo 的坑
+### Playwright recordVideo Gotchas
 
-- 帧率固定 25fps，无法直接录 60fps（Chromium headless 的 compositor 上限）
-- 从 context 创建就开始录，必须用 `trim` 裁掉前面的加载时间
-- 默认 webm 格式，需要 ffmpeg 转 H.264 MP4 才能通用播放
+- Frame rate is fixed at 25fps; you can't record 60fps directly (Chromium headless compositor ceiling)
+- Recording starts the moment the context is created — you must use `trim` to strip the leading load time
+- Default format is webm; you need ffmpeg to convert to H.264 MP4 for general playback
 
-`render-video.js` 已处理以上问题。
+`render-video.js` already handles all of this.
 
-### ffmpeg minterpolate 参数
+### ffmpeg minterpolate Parameters
 
-当前配置：`minterpolate=fps=60:mi_mode=mci:mc_mode=aobmc:me_mode=bidir:vsbmc=1`
+Current config: `minterpolate=fps=60:mi_mode=mci:mc_mode=aobmc:me_mode=bidir:vsbmc=1`
 
-- `mi_mode=mci` — motion compensation interpolation（运动补偿）
+- `mi_mode=mci` — motion compensation interpolation
 - `mc_mode=aobmc` — adaptive overlapped block motion compensation
-- `me_mode=bidir` — 双向运动估计
-- `vsbmc=1` — 可变 size block motion compensation
+- `me_mode=bidir` — bidirectional motion estimation
+- `vsbmc=1` — variable size block motion compensation
 
-对 CSS **transform 动画**（translate/scale/rotate）效果好。
-对**纯 fade** 可能产生轻微 ghosting——如果用户嫌弃，退化为简单帧复制：
+Works well on CSS **transform animations** (translate/scale/rotate).
+On **pure fades** it can produce slight ghosting — if the user dislikes it, fall back to plain frame duplication:
 
 ```bash
 ffmpeg -i input.mp4 -r 60 -c:v libx264 ... output.mp4
 ```
 
-### GIF palette 为何要两阶段
+### Why GIF Palette Needs Two Passes
 
-GIF 只能 256 色。一次 pass 的 GIF 会把全动画色彩压到 256 色通用 palette，对米色底+橙色这种细腻配色会糊。
+GIF is limited to 256 colors. A single-pass GIF compresses the whole animation's color into one generic 256-color palette, which smears subtle palettes like beige + orange.
 
-两阶段：
-1. `palettegen=stats_mode=diff` —— 先扫描全片，生成**针对此动画的 optimal palette**
-2. `paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle` —— 用这个 palette 编码，rectangle diff 只更新变化区域，大幅减小文件
+Two passes:
+1. `palettegen=stats_mode=diff` — scans the whole clip, generates the **optimal palette for this specific animation**
+2. `paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle` — encodes with that palette; rectangle diff only updates changed regions, shrinking the file substantially
 
-对 fade 过渡用 `dither=bayer` 比 `none` 更平滑，但文件大一点。
+For fade transitions, `dither=bayer` is smoother than `none` but produces a slightly larger file.
 
-## Pre-flight check（导出前）
+## Pre-flight Check (Before Export)
 
-导出前 30 秒自检：
+30-second self-check before export:
 
-- [ ] HTML 在浏览器里完整跑过一遍，无控制台错误
-- [ ] 动画第 0 帧是完整初始状态（不是空白加载中）
-- [ ] 动画最后一帧是稳定的收尾状态（不是半截）
-- [ ] 字体/图片/emoji 全部正常渲染（参考 `animation-pitfalls.md`）
-- [ ] Duration 参数与 HTML 里的实际动画时长匹配
-- [ ] HTML 中 Stage 检测 `window.__recording` 强制 loop=false（手写 Stage 必查；用 `assets/animations.jsx` 自带）
-- [ ] 结尾 Sprite 的 `fadeOut={0}`（视频末帧不淡出）
-- [ ] 含「Created by Huashu-Design」水印（仅动画场景必加；第三方品牌作品加「非官方出品 · 」前缀。详见 SKILL.md §「Skill 推广水印」）
+- [ ] HTML runs end-to-end in the browser with no console errors
+- [ ] Frame 0 of the animation is the full initial state (not a blank loading state)
+- [ ] The last frame is a stable closing state (not cut off)
+- [ ] Fonts/images/emoji all render correctly (see `animation-pitfalls.md`)
+- [ ] The duration flag matches the actual animation length in the HTML
+- [ ] Stage in the HTML detects `window.__recording` and forces loop=false (must verify on hand-written Stages; bundled with `assets/animations.jsx`)
+- [ ] The closing Sprite has `fadeOut={0}` (no fade-out on the last frame of the video)
+- [ ] "Created by Huashu-Design" watermark is present (mandatory for animation scenes only; for third-party brand work, prefix with "Unofficial · ". See SKILL.md §"Skill promo watermark")
 
-## 交付时附带的说明
+## Standard Delivery Notes
 
-导出完成后给用户的标准说明格式：
+Standard delivery message format after export:
 
 ```
-**完整交付**
+**Full delivery**
 
-| 文件 | 格式 | 规格 | 大小 |
+| File | Format | Spec | Size |
 |---|---|---|---|
 | foo.mp4 | MP4 | 1920×1080 · 25fps · H.264 | X MB |
-| foo-60fps.mp4 | MP4 | 1920×1080 · 60fps（运动插帧）· H.264 | X MB |
-| foo.gif | GIF | 960×540 · 15fps · palette 优化 | X MB |
+| foo-60fps.mp4 | MP4 | 1920×1080 · 60fps (motion interpolation) · H.264 | X MB |
+| foo.gif | GIF | 960×540 · 15fps · palette optimized | X MB |
 
-**说明**
-- 60fps 用 minterpolate 做运动估计插帧，transform 动画效果好
-- GIF 用 palette 优化，30s 动画可压到 3MB 左右
+**Notes**
+- 60fps uses minterpolate motion-estimated interpolation; great on transform animations
+- GIF uses palette optimization; a 30s animation compresses to about 3MB
 
-要换尺寸或帧率说一声。
+Let me know if you need a different size or frame rate.
 ```
 
-## 常见用户追加需求
+## Common Follow-up Requests
 
-| 用户说 | 应对 |
+| User says | Response |
 |---|---|
-| 「太大了」 | MP4：提高 CRF 到 23-28；GIF：降分辨率到 600 或 fps 到 10 |
-| 「GIF 太糊」 | 提高 `gif_width` 到 1280；或者建议用 MP4 代替（微信朋友圈也支持） |
-| 「要竖屏 9:16」 | 改 HTML 源的 `--width=1080 --height=1920`，重新录 |
-| 「加水印」 | ffmpeg 加 `-vf "drawtext=..."` 或 `overlay=` 一个 PNG |
-| 「要透明背景」 | MP4 不支持 alpha；用 WebM VP9 + alpha 或 APNG |
-| 「要无损」 | CRF 改 0 + preset veryslow（文件会大 10 倍） |
+| "Too big" | MP4: raise CRF to 23-28; GIF: drop resolution to 600 or fps to 10 |
+| "GIF looks blurry" | Raise `gif_width` to 1280; or suggest MP4 instead (WeChat Moments supports it too) |
+| "Need 9:16 portrait" | Change HTML source `--width=1080 --height=1920`, re-record |
+| "Add a watermark" | ffmpeg `-vf "drawtext=..."` or `overlay=` a PNG |
+| "Need transparent background" | MP4 doesn't support alpha; use WebM VP9 + alpha or APNG |
+| "Need lossless" | CRF 0 + preset veryslow (file gets 10× bigger) |

--- a/references/voiceover-pipeline.md
+++ b/references/voiceover-pipeline.md
@@ -1,60 +1,60 @@
-# Voiceover Pipeline · 解说驱动动画
+# Voiceover Pipeline · Narration-Driven Animation
 
-> 把动画从「无声画面 + 后期配音」升级为「**先有解说词，再按音频实测时长驱动画面**」的工作流。
-> 适用：5-20 分钟概念解说视频、教程视频、长篇知识科普。
+> Upgrade animations from "silent visuals + post-hoc dubbing" to a workflow where **the narration is written first, then visuals are driven by the audio's measured duration**.
+> Use for: 5-20 minute concept explainers, tutorial videos, long-form knowledge explainers.
 >
-> 配套 `references/animation-best-practices.md` 使用——本文件管 **怎么把解说和画面对上**，
-> animation-best-practices 管 **每一帧画面怎么动**。
+> Pairs with `references/animation-best-practices.md` — this file covers **how to sync narration with visuals**,
+> animation-best-practices covers **how each frame should move**.
 
 ---
 
-## 🛑 铁律 · 在写一行代码之前必读
+## 🛑 Ironclad Rules · Required Reading Before Writing a Single Line of Code
 
-> **强调多少遍都不够：解说动画的失败模式 #1 是做成了带配音的 PowerPoint。**
+> **You cannot say this enough: failure mode #1 of narrated animation is making a PowerPoint with voiceover.**
 
-### 第一条 · 整片是一个连续的运动叙事，不是一组独立场景
+### Rule 1 · The Whole Film Is One Continuous Motion Narrative, Not a Set of Independent Scenes
 
-PowerPoint 是 7 张幻灯片。我们做的是 **1 段持续 X 分钟的电影**。
+PowerPoint is 7 slides. What you're making is **1 film, X minutes long**.
 
-**身份切换**：
-- ❌ 你不是「在做 7 个 scene 的内容」
-- ✅ 你是「在屏幕上让一个或几个 hero element 演 X 分钟的戏」
+**Identity shift**:
+- ❌ You're not "making content for 7 scenes"
+- ✅ You're "letting one or a few hero elements perform an X-minute play on screen"
 
-**视觉骨架 = 一个或几个贯穿全片的 hero element**：
-- 它从 t=0 出现，到结束才离场
-- 每个 cue 是它的**状态变化**（位置 / 大小 / 颜色 / 透视 / 形态），不是「换一个新元素」
-- scene 边界在剧本里有，**在画面里不应该有**——观众看不出"这是第 3 个 scene"，只看到一段连续的运动
+**Visual skeleton = one or a few hero elements that persist through the whole film**:
+- They appear at t=0 and don't leave until the end
+- Each cue is a **state change** of the hero (position / size / color / perspective / form), not "swap in a new element"
+- Scene boundaries exist in the script, **but should not exist in the visuals** — viewers shouldn't be able to tell "this is the 3rd scene"; they should see one continuous motion
 
-**反例（本 skill v1 实战踩坑 · 2026-05-10）**：
-- 7 个 `<Scene>` 各自独立 layout，scene 切换 = 整页 opacity 1→0 切到下一页
-- 每个 cue = `opacity: p, transform: translateY((1-p)*30px)`（fade-up 单调使用）
-- 结果：观众看完第一反应「像一页页 keynote」，整片质感归零
+**Anti-example (skill v1 lessons learned · 2026-05-10)**:
+- 7 `<Scene>` blocks each with an independent layout; scene change = whole page opacity 1→0 cutting to the next
+- Each cue = `opacity: p, transform: translateY((1-p)*30px)` (monotonic fade-up overuse)
+- Result: viewers' first reaction "this looks like one keynote slide after another"; the whole film's quality zeroed out
 
-**正确模式**：
-- 选定 1-2 个 hero element（如本文章 demo 应选「md」「html」两个字符作为骨架）
-- 这两个字符**从片头到片尾**一直在屏幕上
-- 每段「scene」实际是 hero element 的一次状态变化
-  - opening：两字符在屏幕中央对峙
-  - md-side：md 变大变粗占据画面，html 退到角落小字；数据围绕 md 涌入
-  - html-side：html 反转为主角；md 退到角落
-  - the-real-question：两字符回到中央，但中间出现「≠」分隔
-  - the-split：两字符向两侧推开，中间空白展开
-  - activity-proof：两字符在 timeline 上交替闪烁
-  - closing：两字符落地为最终答案位置
-- 这样整片是「md 和 html 在屏幕上演了 X 分钟」，不是 7 张独立 PPT
+**Correct pattern**:
+- Pick 1-2 hero elements (e.g. for this article's demo, "md" and "html" as the two skeletal characters)
+- These two characters **stay on screen from opening to closing**
+- Each "scene" is really a state transition of the hero element
+  - opening: the two characters face off center screen
+  - md-side: md scales up and bolds to dominate the frame, html retreats to a corner as tiny text; data flows around md
+  - html-side: html flips to hero; md retreats to a corner
+  - the-real-question: both return to center, but a "≠" separator appears between them
+  - the-split: both push apart, whitespace opens in the middle
+  - activity-proof: they alternately blink along a timeline
+  - closing: both settle into their final answer positions
+- The whole film becomes "md and html performed for X minutes on screen", not 7 isolated PPT slides
 
-**最小实现骨架**（直接抄改）：
+**Minimum implementation skeleton** (copy and adapt):
 
 ```jsx
-// ── Step 1: 定义 hero 在每个 scene 的目标状态（位置/大小/不透明度）──
+// ── Step 1: Define the hero's target state per scene (position/scale/opacity) ──
 const HERO_KEYS = {
   opening:    { md: { x: 50, y: 35, scale: 1.0, opacity: 1 }, html: { x: 50, y: 65, scale: 1.0, opacity: 1 } },
   'md-side':  { md: { x: 78, y: 50, scale: 1.6, opacity: 1 }, html: { x: 92, y: 8,  scale: 0.25, opacity: 0.4 } },
   'html-side':{ md: { x: 8,  y: 8,  scale: 0.25, opacity: 0.4 }, html: { x: 22, y: 50, scale: 1.6, opacity: 1 } },
-  // ... 每段一个 entry，连贯的运动从前一段的 final → 本段的 from
+  // ... one entry per segment; continuous motion runs from previous segment's final → current segment's from
 };
 
-// ── Step 2: easing + lerp 工具 ──
+// ── Step 2: easing + lerp helpers ──
 const expoOut = t => t === 1 ? 1 : 1 - Math.pow(2, -10 * t);
 const lerp = (a, b, t) => a + (b - a) * t;
 const lerpPos = (from, to, t) => ({
@@ -63,7 +63,7 @@ const lerpPos = (from, to, t) => ({
   opacity: lerp(from.opacity ?? 1, to.opacity ?? 1, t),
 });
 
-// ── Step 3: HeroAnchor 组件 —— 直接挂在 <NarrationStage> 子级，不放进 <Scene> ──
+// ── Step 3: HeroAnchor component — mounted directly under <NarrationStage>, NOT inside a <Scene> ──
 const HeroAnchor = () => {
   const { time, scene, timeline } = useNarration();
   if (!scene) return null;
@@ -72,13 +72,13 @@ const HeroAnchor = () => {
   const from = HERO_KEYS[prevId];
   const to   = HERO_KEYS[scene.id];
 
-  // 段内前 ~45% 时间用于从 prev 状态 morph 到本段状态，剩余 hold
+  // First ~45% of segment time used to morph from prev state to current state, hold the rest
   const transitionDur = Math.min(2.0, scene.duration * 0.45);
   const t = expoOut(Math.min(1, (time - scene.start) / transitionDur));
   const md   = lerpPos(from.md,   to.md,   t);
   const html = lerpPos(from.html, to.html, t);
 
-  // 加 subtle breathing 让任意一帧都有运动（对应铁律第三条）
+  // Add subtle breathing so every frame has motion (per Rule 3)
   const breath = 1 + Math.sin(time * 0.6) * 0.012;
 
   const renderHero = (label, pos, color) => (
@@ -95,11 +95,11 @@ const HeroAnchor = () => {
   </>;
 };
 
-// ── Step 4: 主组件 —— hero 在 NarrationStage 子级，scene 内辅助元素另外管 ──
+// ── Step 4: Main component — hero under NarrationStage, scene-local helpers managed separately ──
 const App = () => (
   <NarrationStage timeline={TIMELINE} audioSrc="_narration/voiceover.mp3" width={1920} height={1080}>
-    <HeroAnchor />  {/* ← 跨 scene 持续存在，整片视觉骨架 */}
-    {/* scene 内辅助元素用 useSceneFade 控制软淡入淡出，不要硬切 */}
+    <HeroAnchor />  {/* ← persists across scenes, the full-film visual skeleton */}
+    {/* Scene-local helpers use useSceneFade for soft fade in/out — never hard cuts */}
     <MdSideAux />
     <HtmlSideAux />
     {/* ... */}
@@ -107,114 +107,114 @@ const App = () => (
 );
 ```
 
-**完整可运行参考**：`demos/md-html-narration/md-html-demo.html`（3 分 21 秒，7 段，21 cue，已实战验证）
+**Full runnable reference**: `demos/md-html-narration/md-html-demo.html` (3min 21s, 7 segments, 21 cues, battle-tested)
 
-### 第二条 · 场景之间不能「硬切」
+### Rule 2 · No "Hard Cuts" Between Scenes
 
-| 错误模式（PowerPoint slop） | 正确模式（电影感） |
+| Wrong pattern (PowerPoint slop) | Right pattern (cinematic) |
 |---|---|
-| scene A 整体 `opacity 1→0` 同时 scene B `opacity 0→1` | scene A 的核心元素 **morph 进** B（位置/大小/颜色平滑变换） |
-| 每个 scene 独立 layout，元素出现/消失 | 元素在屏幕上**持续存在**，只是位置和形态在变 |
-| `keepMounted=false`，scene 切换瞬间组件被卸载 | hero 用 `keepMounted=true`，跨 scene 共享 DOM 节点 |
-| 字幕条/数据卡片各自 fade in fade out | 字幕条作为画面唯一的"非 hero" 入场，hold 后**配合 hero 的运动一起退出** |
+| Scene A whole `opacity 1→0` while scene B `opacity 0→1` | Scene A's core elements **morph into** B (smooth position/scale/color transition) |
+| Each scene has its own layout; elements appear/disappear | Elements **persist on screen**, only position and form change |
+| `keepMounted=false`, component unmounts the instant scenes switch | Hero uses `keepMounted=true`, sharing DOM nodes across scenes |
+| Subtitle bars/data cards each fade in and out independently | The subtitle bar is the only "non-hero" entrance; after holding, it **exits with the hero's motion** |
 
-实现层面：
-- **共享元素跨 scene** → 把 hero 提到 `<NarrationStage>` 直接子级，**不放在任何 `<Scene>` 里**
-- 用 `useNarration()` hook 在 hero 里读 `time`、`scene`、`isCueTriggered`，自己根据当前时间决定形态
-- `<Scene>` 只用来管那些只在该段出现的辅助元素（数据卡、引用块等），并且**这些辅助元素也不要硬切**——出场用 expoOut + stagger，退场用 fade overlap 跟下一段叠
+Implementation:
+- **Cross-scene shared elements** → lift hero to a direct child of `<NarrationStage>`, **not inside any `<Scene>`**
+- Inside the hero, use `useNarration()` to read `time`, `scene`, `isCueTriggered` and decide its form from the current time
+- `<Scene>` is only for helpers that exist solely in that segment (data cards, quote blocks, etc.), and **those helpers must not hard-cut either** — entrance uses expoOut + stagger; exit overlaps with the next segment's entrance via fade
 
-### 第三条 · 每一帧画面都必须有运动
+### Rule 3 · Every Frame Must Have Motion
 
-**自检方法**：在录制中**任意截一帧**（不是 cue 触发那一秒）。
-- 如果画面看起来「**完全静止**」→ 错。回去加底层运动（background drift / hero subtle scale / camera pan / parallax）
-- 永远有一个**底层运动**在跑（即使不是焦点）：
-  - hero element 的 `scale: 1 ↔ 1.02` 5 秒呼吸循环
-  - 背景 `translateX: 0 ↔ -20px` 缓慢漂移
-  - 数据卡片入场后保留 `translateY` 微抖（Perlin noise）
-- 一个完全静止的画面 = PowerPoint slop
+**Self-check**: grab **any random frame** during recording (not the second a cue fires).
+- If the frame looks **completely static** → wrong. Go add base-layer motion (background drift / hero subtle scale / camera pan / parallax)
+- Always have a **base-layer motion** running (even if it's not the focus):
+  - hero element `scale: 1 ↔ 1.02` 5-second breathing loop
+  - background `translateX: 0 ↔ -20px` slow drift
+  - data cards retain micro `translateY` jitter after entering (Perlin noise)
+- A perfectly still frame = PowerPoint slop
 
-### 第四条 · Easing / Stagger / Hold 是底线
+### Rule 4 · Easing / Stagger / Hold Are the Floor
 
-| 项 | 必须 | 禁止 |
+| Item | Required | Forbidden |
 |---|---|---|
-| Easing | `expoOut` 主轴（`cubic-bezier(0.16, 1, 0.3, 1)`），`overshoot` 强调，`spring` 落位 | `linear`、`ease`、CSS 默认 |
-| 多元素入场 | 30ms stagger（每个晚 30ms 进） | 一刀切全部出现 |
-| 关键 cue 前 | hold 0.3-0.5s 让观众"看见"（前一段元素先静止 0.3s，再触发 cue） | 一段说完无缝切下一段 |
-| 收尾 | 戛然而止，最后一帧 hold 1s | fade to black |
+| Easing | `expoOut` on main axis (`cubic-bezier(0.16, 1, 0.3, 1)`), `overshoot` for emphasis, `spring` for settling | `linear`, `ease`, CSS defaults |
+| Multi-element entrance | 30ms stagger (each one 30ms later) | All in at once |
+| Before a key cue | Hold 0.3-0.5s so viewers "see" it (previous segment's element holds still 0.3s, then cue fires) | One segment finishes, next starts seamlessly |
+| Closing | Cut hard, last frame holds 1s | Fade to black |
 
-详细规则参考 `animation-best-practices.md` 的 §1-§4。
+See `animation-best-practices.md` §1-§4 for detailed rules.
 
-### 自检 · 第一观众反应
+### Self-check · First-Viewer Reaction
 
-做完拿给一个没看过的人看（或自己 24 小时后再看），**他们的第一反应**是什么？
+After you finish, show it to someone who hasn't seen it (or rewatch 24 hours later). What's their **first reaction**?
 
-| 反应 | 评级 | 行动 |
+| Reaction | Rating | Action |
 |---|---|---|
-| 「这是带配音的 PPT」 | 失败 | 回去重做 |
-| 「画面跟着声音在切换」 | 不及格 | 缺连续叙事，hero element 不存在或没贯穿 |
-| 「这个东西在动」 | 合格 | 但没记忆点 |
-| 「我想看完」 | 良 | 节奏对了 |
-| 「这一段我想截图」 | great | 你做到了 |
+| "This is a PPT with voiceover" | Fail | Redo it |
+| "The visuals switch with the audio" | Not passing | No continuous narrative; hero element missing or not threaded |
+| "This thing moves" | Pass | But forgettable |
+| "I want to keep watching" | Good | Pacing works |
+| "I want to screenshot this segment" | Great | You did it |
 
 ---
 
-## 工作流（高层）
+## Workflow (High Level)
 
 ```
                 ┌──────────────────────────┐
-                │  解说稿 .md（## scene + │
-                │  [[cue:xx]] 标关键句）   │
+                │  Narration .md (## scene │
+                │  + [[cue:xx]] markers)   │
                 └──────────────┬───────────┘
                                │
                   narrate-pipeline.mjs
                                │
                                ▼
             ┌──────────────────────────────┐
-            │ voiceover.mp3 (拼接的整段)  │
-            │ timeline.json (实测时长)    │
+            │ voiceover.mp3 (concatenated) │
+            │ timeline.json (measured)     │
             └──────────────┬───────────────┘
                            │
               ┌────────────┴────────────┐
               ▼                         ▼
     ┌─────────────────┐      ┌──────────────────┐
-    │ HTML 动画       │      │ 录制 MP4 + 混音  │
+    │ HTML animation  │      │ Record MP4 + mix │
     │ (NarrationStage)│      │ render-narration │
-    │ 实播带 audio 同步│      │ → 最终发布 MP4   │
+    │ Live audio sync │      │ → final MP4      │
     └─────────────────┘      └──────────────────┘
-       交付形态 1                交付形态 2
+       Delivery form 1          Delivery form 2
 ```
 
-## 解说稿格式
+## Narration Script Format
 
-放在项目目录下任意位置，文件名建议 `script.md`：
+Place anywhere under the project directory; recommended filename `script.md`:
 
 ```markdown
 ---
-title: 什么是 LLM
-voice: S_JSdgdWk22   # 可选，覆盖 .env 默认音色
-speed: 1.0           # 可选，0.5-2.0
-gap: 0.4             # 段间静音秒数，默认 0.3
+title: What Is an LLM
+voice: S_JSdgdWk22   # optional, overrides the default voice from .env
+speed: 1.0           # optional, 0.5-2.0
+gap: 0.4             # silence between segments in seconds, default 0.3
 ---
 
 ## intro
-大家好，今天我们 5 分钟讲清楚 LLM 是什么。
+Hi everyone, today we'll explain LLMs in 5 minutes.
 
 ## what-is
-LLM 全称 Large Language Model，[[cue:bigmodel]]它是一个有几千亿参数的神经网络。
-本质是一个文字接龙的预测器。
+LLM stands for Large Language Model. [[cue:bigmodel]]It is a neural network with hundreds of billions of parameters.
+At its core, it's a next-token predictor for text.
 
 ## demo
-比如你输入「今天天气」，[[cue:input]]模型会预测下一个字最可能是什么。
-[[cue:predict]]也许是「真好」，也许是「不错」。
+For example, if you type "today's weather", [[cue:input]]the model predicts what the next character is most likely to be.
+[[cue:predict]]Maybe "is great", maybe "is nice".
 ```
 
-**规则**：
-- 段标题 `## scene-id` 是英文/数字 + 连字符（如 `## what-is`、`## scene-1`）
-- `[[cue:xx]]` 标在**关键句中间**——脚本运行时会在该位置切割文本，cue 之后那一刻就是画面的触发点
-- cue id 在动画 HTML 里用 `<Cue id="xx">` 监听
-- 写解说时**关注节奏 + 短句**，长句 TTS 出来会平淡
+**Rules**:
+- Segment heading `## scene-id` is English/digit + hyphen (e.g. `## what-is`, `## scene-1`)
+- `[[cue:xx]]` is placed **in the middle of a key sentence** — the script splits the text at that point, and the moment right after the cue marker is the visual trigger
+- The cue id is watched in the animation HTML via `<Cue id="xx">`
+- When writing narration, **focus on rhythm + short sentences** — TTS flattens long sentences
 
-## timeline.json schema
+## timeline.json Schema
 
 ```ts
 {
@@ -222,31 +222,31 @@ LLM 全称 Large Language Model，[[cue:bigmodel]]它是一个有几千亿参数
   voice: string | null,
   speed: number,
   gap: number,
-  totalDuration: number,        // 整段 voiceover.mp3 的实测秒数
-  voiceover: 'voiceover.mp3',   // 相对 timeline.json 的路径
+  totalDuration: number,        // measured duration of the full voiceover.mp3 in seconds
+  voiceover: 'voiceover.mp3',   // path relative to timeline.json
   scenes: [
     {
       id: string,
-      start: number,            // 该段在整段音频里的开始时间
+      start: number,            // start time of this segment in the full track
       end: number,
       duration: number,
-      audio: 'audio/<id>.mp3',  // 该段单独音频（合并前的子段已 concat）
-      text: string,             // 已剥离 [[cue:xx]] 标记的整段文本
-      // chunks 是字幕显示的源——每个 chunk 是被 cue 切开的子段，含 TTS 实测时间窗
+      audio: 'audio/<id>.mp3',  // this segment's standalone audio (sub-segments already concatenated)
+      text: string,             // full segment text with [[cue:xx]] markers stripped
+      // chunks is the source for subtitles — each chunk is a cue-split sub-segment with its TTS-measured window
       chunks: [
         {
-          text: string,            // 子段文本
-          start: number,           // 段内相对时间
+          text: string,            // sub-segment text
+          start: number,           // segment-relative time
           end: number,
-          absoluteStart: number,   // 整轨绝对时间（对齐 voiceover.mp3）
+          absoluteStart: number,   // absolute time on the full track (aligns with voiceover.mp3)
           absoluteEnd: number,
         }
       ],
       cues: [
         {
           id: string,
-          offset: number,       // 段内相对时间
-          absoluteTime: number, // 整段时间轴上的绝对时间
+          offset: number,       // segment-relative time
+          absoluteTime: number, // absolute time on the full timeline
         }
       ]
     }
@@ -254,48 +254,48 @@ LLM 全称 Large Language Model，[[cue:bigmodel]]它是一个有几千亿参数
 }
 ```
 
-`absoluteTime` 和 `absoluteStart/End` 都是**真实测出来的**——pipeline 把段内文本按 cue 切成子段分别 TTS，时间 = 累加前面子段的实测时长。**不是按字符数线性估算的近似值**。
+`absoluteTime` and `absoluteStart/End` are **all actually measured** — the pipeline splits each segment's text at the cue boundaries, runs TTS on each sub-segment, and accumulates measured durations. **Not character-count linear estimates.**
 
-## 字幕（Subtitles）
+## Subtitles
 
-> **字幕是默认带的**——长解说视频没字幕，留存率会显著下降。NarrationStage 提供 `<Subtitles />` 开箱即用。
+> **Subtitles are on by default** — long narrated videos without subtitles see a measurable drop in retention. NarrationStage ships `<Subtitles />` out of the box.
 
-### 用法（一行）
+### Usage (one line)
 
 ```jsx
 const { NarrationStage, Subtitles } = NarrationStageLib;
 <NarrationStage timeline={TIMELINE} audioSrc="...">
-  {/* 你的 hero / scene 内容 */}
-  <Subtitles />  {/* ← 自动从 timeline.scenes[].chunks 取活动文本 */}
+  {/* your hero / scene content */}
+  <Subtitles />  {/* ← auto-pulls active text from timeline.scenes[].chunks */}
 </NarrationStage>
 ```
 
-### 视觉规则（B 站风 · 反 PowerPoint）
+### Visual Rules (Bilibili style · anti-PowerPoint)
 
-| 项 | 规则 | 反例 |
+| Item | Rule | Anti-example |
 |---|---|---|
-| 背景 | **无背景**（不要黑色横条不要 backdrop-blur）| 半透明黑底 + blur = 字幕条压住画面 = PPT 感 |
-| 字色 | **浅底用深墨 `#1a1a1a` + 白光晕**；深底用白字 + 黑光晕 | 浅底白字+黑描边 = 字糊 |
-| 字号 | 32px（1080p 视频）| <24px 看不清，>40px 抢主视觉 |
-| 字体 | `PingFang SC` / `Noto Sans SC`（无衬线，B 站标准）| 衬线字体 = 像电影字幕 |
-| 位置 | bottom: 90px（不贴边）| 贴底边显得廉价 |
-| 单行长度 | **≤ 12-13 字**（中英混合时英文按 0.5 字算）| >15 字一行手机端读不完 |
-| 切句规则 | **绝不跨句号截断**：先按 `。！？` 切句，每句再按 `，、；：` 合并到 ≤maxLen | 按字数硬切，把「这是好的」切成「这是好」+「的」 |
+| Background | **No background** (no black bar, no backdrop-blur) | Semi-transparent black + blur = subtitle bar smothers the frame = PPT vibe |
+| Text color | **Dark ink `#1a1a1a` + white halo on light backgrounds**; white text + black halo on dark | White text + black outline on light backgrounds = blurry |
+| Font size | 32px (1080p video) | <24px is unreadable, >40px hijacks the main visual |
+| Font | `PingFang SC` / `Noto Sans SC` (sans-serif, Bilibili standard) | Serif fonts = looks like a movie subtitle |
+| Position | bottom: 90px (not flush) | Flush bottom looks cheap |
+| Line length | **≤ 12-13 characters** (mixed CN/EN counts English at 0.5 char) | >15 chars per line is unreadable on mobile |
+| Line breaking | **Never break across periods**: split by `。！？` first, then merge clauses by `，、；：` to ≤maxLen | Hard char-count cuts that split "this is good" into "this is" + "good" |
 
-`<Subtitles />` 默认按以上规则跑，不需要传 props。深底场景：`<Subtitles color="#fff" haloColor="rgba(0,0,0,0.85)" />`。
+`<Subtitles />` runs the rules above by default; no props needed. Dark scenes: `<Subtitles color="#fff" haloColor="rgba(0,0,0,0.85)" />`.
 
-### 切句算法（已在 narration_stage.jsx 内置）
+### Line-Breaking Algorithm (Already in narration_stage.jsx)
 
 ```js
 splitChunkToLines(text, maxLen = 13)
-// 1. 强标点切句（。！？\n）
-// 2. 每句 ≤ maxLen 直接保留
-// 3. 否则按弱标点（，、；：）切片，合并到 ≤ maxLen
-// 4. 兜底硬切（罕见）
-// 中英混合：英文/数字按 0.5 字算视觉宽度
+// 1. Hard-punctuation split (。！？\n)
+// 2. Sentences ≤ maxLen kept as-is
+// 3. Otherwise split by weak punctuation (，、；：) and merge to ≤ maxLen
+// 4. Fallback hard cut (rare)
+// Mixed CN/EN: English/digits count as 0.5 visual width
 ```
 
-如果 chunk 切完后某行明显太长或太短，**改解说稿里 cue 位置**（cue 把段切得更细），不要在前端调切句逻辑。
+If a line looks clearly too long or too short after chunking, **change the cue position in the narration script** (cue splits the segment more finely). Don't tweak the front-end line-break logic.
 
 ## NarrationStage API
 
@@ -304,16 +304,16 @@ import 'assets/narration_stage.jsx';
 const { NarrationStage, Scene, Cue, useNarration } = NarrationStageLib;
 
 <NarrationStage
-  timeline={TIMELINE}                  // timeline.json 内容
-  audioSrc="_narration/voiceover.mp3"  // 相对当前 HTML 的路径
+  timeline={TIMELINE}                  // contents of timeline.json
+  audioSrc="_narration/voiceover.mp3"  // path relative to the current HTML
   width={1920} height={1080}
   background="#f5f1e8"
-  controls={true}                      // 实播时显示底部播放条
+  controls={true}                      // show bottom playback bar in live mode
 >
-  {/* hero element：跨 scene 持续存在 —— 直接放在 NarrationStage 子级 */}
+  {/* hero element: persists across scenes — direct child of NarrationStage */}
   <HeroAnchor />
 
-  {/* scene 内辅助元素：只在该段出现 */}
+  {/* scene-local helper: only appears in this segment */}
   <Scene id="intro">
     <Cue id="bigmodel">{(triggered, progress) => (
       <SomeElement style={{ opacity: progress }} />
@@ -322,36 +322,36 @@ const { NarrationStage, Scene, Cue, useNarration } = NarrationStageLib;
 </NarrationStage>
 ```
 
-**Hooks**：
-- `useNarration()` 返回 `{ time, scene, sceneTime, isCueTriggered, cueProgress }`
-- 在自定义组件里直接读，不需要传 props
+**Hooks**:
+- `useNarration()` returns `{ time, scene, sceneTime, isCueTriggered, cueProgress }`
+- Read directly in custom components; no props needed
 
-**Scene 组件**：
-- 默认只在 `scene.id === id` 时挂载
-- 加 `keepMounted` 持续挂载（跨 scene 动画连续时用）
+**Scene component**:
+- By default only mounts when `scene.id === id`
+- Add `keepMounted` to mount continuously (use for cross-scene continuous animations)
 
-**Cue 组件**：
-- children 必须是 `(triggered, progress) => ReactNode`
-- progress 是 cue 触发后 0→1 的渐进值（默认 0.6s ramp）
+**Cue component**:
+- children must be `(triggered, progress) => ReactNode`
+- progress is the 0→1 ramp after the cue fires (default 0.6s ramp)
 
-## 时间源（双轨）
+## Time Source (Dual Track)
 
-NarrationStage 自动检测 `window.__recording`：
-- **实播模式**（默认）：跟随 audio 元素的 currentTime，用户暂停/拖动 seek 都能同步
-- **录视频模式**（render-video.js 设置 `window.__recording = true`）：rAF wall-clock 自驱动从 0 开始，暴露 `window.__seek(t)` 给 render-video.js 复位
+NarrationStage auto-detects `window.__recording`:
+- **Live mode** (default): follows the audio element's currentTime; pause/seek by the user stays in sync
+- **Recording mode** (render-video.js sets `window.__recording = true`): rAF wall-clock self-driven from 0, exposes `window.__seek(t)` for render-video.js to reset
 
-## 三个脚本
+## The Three Scripts
 
-| 脚本 | 输入 | 输出 |
+| Script | Input | Output |
 |---|---|---|
-| `scripts/tts-doubao.mjs` | 单段文本 | 单个 mp3 + 实测时长 |
-| `scripts/narrate-pipeline.mjs` | 解说稿 .md | voiceover.mp3 + timeline.json |
-| `scripts/mix-voiceover.sh` | 视频 + voiceover.mp3 [+ BGM] | 带音频的 MP4 |
-| `scripts/render-narration.sh` | 解说 HTML + timeline.json | 最终 MP4（录制 + 混音一条龙）|
+| `scripts/tts-doubao.mjs` | single-segment text | one mp3 + measured duration |
+| `scripts/narrate-pipeline.mjs` | narration .md | voiceover.mp3 + timeline.json |
+| `scripts/mix-voiceover.sh` | video + voiceover.mp3 [+ BGM] | MP4 with audio |
+| `scripts/render-narration.sh` | narration HTML + timeline.json | final MP4 (record + mix in one shot) |
 
-## .env 配置
+## .env Configuration
 
-skill 根目录下 `.env`（已 gitignore）：
+`.env` in the skill root (gitignored):
 
 ```
 DOUBAO_TTS_API_KEY=<your_key>
@@ -360,38 +360,38 @@ DOUBAO_TTS_CLUSTER=volcano_icl
 DOUBAO_TTS_ENDPOINT=https://openspeech.bytedance.com/api/v1/tts
 ```
 
-参考 `.env.example` 模板。豆包语音克隆音色 ID 在火山引擎控制台获取。
+See `.env.example` template. The Doubao voice clone ID is obtained from the Volcano Engine console.
 
-## 标准工作流（10 步）
+## Standard Workflow (10 Steps)
 
-1. **写解说稿**：解说稿是源代码。先把整段口播写完整，标段标题 `## scene-id`，关键句前加 `[[cue:xx]]`
-2. **跑 narrate-pipeline**：`node scripts/narrate-pipeline.mjs --script script.md --out-dir _narration`
-3. **听整段 voiceover.mp3**：节奏不对回去改稿。**这一步决定整片质量上限**
-4. **🛑 设计前先回答铁律**：hero element 是什么？它在每段是什么状态？跨场景怎么 morph？答不上不要写代码
-5. **写动画 HTML**：用 NarrationStage + 一个或几个 hero element 跨 scene 演戏
-6. **实播预览**：浏览器打开 HTML，点 ▶ Play，听画面+解说同步
-7. **第一观众自检**：用上面「自检 · 第一观众反应」表打分。失败回到 Step 4 重做
-8. **录视频**：`bash scripts/render-narration.sh demo.html --timeline=_narration/timeline.json`（自动录无声 MP4 + 混入 voiceover）
-9. **可选 BGM**：在 render-narration 加 `--bgm-mood=educational`（或 tech / tutorial 等）
-10. **交付**：浏览器 HTML（实时演示用）+ 最终 MP4（发布用）
+1. **Write the narration**: the narration is the source code. Write the full voiceover, mark segment headings `## scene-id`, prepend `[[cue:xx]]` to key sentences
+2. **Run narrate-pipeline**: `node scripts/narrate-pipeline.mjs --script script.md --out-dir _narration`
+3. **Listen to the full voiceover.mp3**: if the pacing is off, rewrite. **This step sets the upper bound on the final quality.**
+4. **🛑 Before designing, answer the ironclad rules**: what is the hero element? What's its state in each segment? How does it morph across scenes? If you can't answer, don't write code
+5. **Write the animation HTML**: use NarrationStage + one or a few hero elements performing across scenes
+6. **Live preview**: open the HTML in browser, hit ▶ Play, listen for visual + narration sync
+7. **First-viewer self-check**: score with the "Self-check · First-Viewer Reaction" table above. If it fails, go back to Step 4
+8. **Record video**: `bash scripts/render-narration.sh demo.html --timeline=_narration/timeline.json` (auto-records silent MP4 + mixes in voiceover)
+9. **Optional BGM**: add `--bgm-mood=educational` to render-narration (or tech / tutorial etc.)
+10. **Deliver**: browser HTML (for live demos) + final MP4 (for publishing)
 
-## 异常处理
+## Troubleshooting
 
-| 问题 | 解决 |
+| Problem | Fix |
 |---|---|
-| TTS API 报错 | 检查 .env 里 `DOUBAO_TTS_API_KEY` 是否正确 |
-| 某段音频明显比脚本长/短 | 该段文本里有奇怪标点或 emoji，TTS 解析异常 → 改稿 |
-| cue absoluteTime 不准 | 段内子段拼接时 ffmpeg 有问题 → 检查 mp3 编码一致性 |
-| 录视频结果有黑屏 | render-video.js 没拿到 `window.__ready` 信号 → 检查 NarrationStage 是否正常挂载 |
-| 录视频画面卡顿 | 动画里有重 layout（大量 box-shadow / blur）→ 简化或预合成 |
-| 实播音画不同步 | audio 元素加载延迟 → 加 `preload="auto"` 或本地预加载 |
+| TTS API error | Check `DOUBAO_TTS_API_KEY` in .env |
+| A segment is noticeably longer/shorter than the script | The segment text has odd punctuation or emoji breaking TTS parsing → rewrite |
+| cue absoluteTime is off | ffmpeg has a problem concatenating sub-segments → check mp3 encoding consistency |
+| Black screen in recording | render-video.js never received the `window.__ready` signal → check NarrationStage mounts properly |
+| Recording stutters | Heavy layout in the animation (lots of box-shadow / blur) → simplify or pre-composite |
+| Live audio/video out of sync | audio element loads late → add `preload="auto"` or preload locally |
 
-## 何时不用这套 pipeline
+## When Not to Use This Pipeline
 
-- **<60s 短动画**：直接做无声动画 + 后期配音（add-music.sh + 一段单独 TTS）即可，不需要 timeline 驱动
-- **纯 BGM 视频**：用 `add-music.sh` 加预设 BGM
-- **真人录音替换 TTS**：把 `voiceover.mp3` 替换成真人录音，timeline 自己手写或用 ffprobe 测段时长 + 工具脚本生成 → 流程其余部分通用
+- **<60s short animations**: just make a silent animation + post-hoc dubbing (add-music.sh + one standalone TTS), no timeline driving needed
+- **Pure BGM video**: use `add-music.sh` with a preset BGM
+- **Human voiceover replacing TTS**: replace `voiceover.mp3` with the human recording; handwrite the timeline yourself or use ffprobe to measure segment durations + a helper script → the rest of the flow works the same
 
 ---
 
-**最后一次提醒**：写代码前回到铁律。**别做带配音的 PowerPoint**。
+**One last reminder**: before writing code, return to the ironclad rules. **Don't make a PowerPoint with voiceover.**

--- a/references/workflow.md
+++ b/references/workflow.md
@@ -1,216 +1,216 @@
-# Workflow：从接到任务到交付
+# Workflow: From Task Intake to Delivery
 
-你是用户的junior designer。用户是manager。按这个流程工作，能产出好设计的概率会显著提升。
+You are the user's junior designer. The user is the manager. Following this workflow significantly raises the probability of shipping good design.
 
-## 问问题的艺术
+## The Art of Asking Questions
 
-大多数情况下，开工前要问至少10个问题。不是走过场，是真的要把需求摸清。
+In most cases, ask at least 10 questions before starting. This isn't going through the motions — really nail down the requirements.
 
-**什么时候必须问**：新任务、模糊任务、没有design context、用户只说了一句模糊的要求。
+**When you must ask**: new task, vague task, no design context, the user gave only a one-line vague request.
 
-**什么时候可以不问**：小修小补、follow-up任务、用户已经给了明确PRD+截图+上下文。
+**When you can skip**: small tweaks, follow-up tasks, the user already provided a clear PRD + screenshots + context.
 
-**怎么问**：大部分 agent 环境没有结构化问题 UI，在对话里用 markdown 清单问即可。**一次性把问题列完让用户批量答**，不要一来一回一个个问——那会浪费用户时间、打断用户思路。
+**How to ask**: most agent environments lack a structured question UI, so ask via a markdown checklist in the conversation. **List all questions at once so the user can answer in a batch** — don't ping-pong one at a time, that wastes the user's time and breaks their train of thought.
 
-## 必问清单
+## Required Question Checklist
 
-每个设计任务都必须问清这5类问题：
+Every design task must clarify these 5 categories:
 
-### 1. Design Context（最重要）
+### 1. Design Context (most important)
 
-- 有没有现成的design system、UI kit、组件库？在哪？
-- 有没有品牌指南、色彩规范、字体规范？
-- 有没有可以参考的现有产品/页面截图？
-- 有没有codebase可以读？
+- Is there an existing design system, UI kit, or component library? Where?
+- Brand guidelines, color spec, typography spec?
+- Any existing product/page screenshots to reference?
+- Any codebase to read?
 
-**如果用户说"没有"**：
-- 帮他找——翻项目目录、看有没有参考品牌
-- 还没有？明确说："我会基于通用直觉做，但这通常做不出符合你品牌的作品。你考虑下是否先提供一些参考？"
-- 实在要做，就按`references/design-context.md`的fallback策略办
+**If the user says "no"**:
+- Help them find it — browse the project directory, check for reference brands
+- Still nothing? Say plainly: "I'll work from generic intuition, but that usually won't produce something on-brand for you. Want to provide some references first?"
+- If they insist, follow the fallback strategy in `references/design-context.md`
 
-### 2. Variations维度
+### 2. Variations dimensions
 
-- 想要几种variations？（推荐3+）
-- 在哪些维度上变？视觉/交互/色彩/布局/文案/动画？
-- 希望variations都"接近预期"还是"一张地图，从保守到疯狂"？
+- How many variations? (3+ recommended)
+- Along which dimensions? Visual / interaction / color / layout / copy / animation?
+- Do you want variations that are all "close to expected" or "a map, from conservative to wild"?
 
-### 3. Fidelity和Scope
+### 3. Fidelity and Scope
 
-- 多高保真？线框图 / 半成品 / 真实data的full hi-fi？
-- 覆盖多少flow？一屏 / 一个flow / 整个产品？
-- 有没有具体的「必须包含」元素？
+- How hi-fi? Wireframe / half-built / full hi-fi with real data?
+- How much of the flow? One screen / one flow / the whole product?
+- Any specific "must include" elements?
 
 ### 4. Tweaks
 
-- 希望能实时调整哪些参数？（颜色/字号/间距/layout/文案/feature flag）
-- 用户自己要不要在做完后继续调？
+- Which parameters should be adjustable live? (color / font size / spacing / layout / copy / feature flag)
+- Will the user want to keep tweaking after you finish?
 
-### 5. 问题专属（至少4个）
+### 5. Task-specific (at least 4)
 
-针对具体任务问4+个细节。例如：
+Ask 4+ task-specific details. Examples:
 
-**做landing page**：
-- 目标转化动作是什么？
-- 主要受众？
-- 竞品参考？
-- 文案谁提供？
+**Landing page**:
+- What's the target conversion action?
+- Primary audience?
+- Competitor references?
+- Who provides the copy?
 
-**做iOS App onboarding**：
-- 几步？
-- 需要用户做什么？
-- 跳过路径？
-- 目标留存率？
+**iOS App onboarding**:
+- How many steps?
+- What does the user need to do?
+- Skip path?
+- Target retention?
 
-**做动画**：
-- 时长？
-- 最终用途（视频素材/官网/社交）？
-- 节奏（快/慢/分段）？
-- 必须出现的关键帧？
+**Animation**:
+- Duration?
+- Final use (video asset / website / social)?
+- Pacing (fast / slow / segmented)?
+- Required key frames?
 
-## 问题模板示例
+## Question Template Example
 
-遇到新任务时，可以抄这个结构在对话里问：
+When facing a new task, you can lift this structure to ask in conversation:
 
 ```markdown
-开始前想跟你对齐几个问题，一次列齐你批量回答就行：
+Before I start, a few alignment questions — list them all and answer in a batch:
 
 **Design Context**
-1. 有设计系统/UI kit/品牌规范吗？如果有在哪？
-2. 有可以参考的现有产品或竞品截图吗？
-3. 项目里有codebase可以读吗？
+1. Design system / UI kit / brand spec? If so, where?
+2. Existing product or competitor screenshots to reference?
+3. A codebase I can read in this project?
 
 **Variations**
-4. 想要几种variations？在哪些维度上变（视觉/交互/色彩/...）？
-5. 希望都是"接近答案"还是从保守到疯狂的一张地图？
+4. How many variations? Which dimensions vary (visual / interaction / color / ...)?
+5. Do you want them all "close to the answer" or a map from conservative to wild?
 
 **Fidelity**
-6. 保真度：线框 / 半成品 / 带真数据full hi-fi？
-7. Scope：一屏 / 一整个flow / 整个产品？
+6. Fidelity: wireframe / half-built / full hi-fi with real data?
+7. Scope: one screen / one full flow / the whole product?
 
 **Tweaks**
-8. 希望做完后能实时调哪些参数？
+8. Which parameters should be live-tunable when I'm done?
 
-**具体任务**
-9. [任务专属问题1]
-10. [任务专属问题2]
+**Task-specific**
+9. [task-specific question 1]
+10. [task-specific question 2]
 ...
 ```
 
-## Junior Designer模式
+## Junior Designer Mode
 
-这是整个workflow最重要的环节。**不要接到任务就闷头冲**。步骤：
+This is the most important step of the entire workflow. **Don't take the task and dive headfirst**. Steps:
 
-### Pass 1：Assumptions + Placeholders（5-15分钟）
+### Pass 1: Assumptions + Placeholders (5-15 minutes)
 
-HTML文件头部先写你的**assumptions+reasoning comments**，像junior给manager汇报：
+At the top of the HTML file, write your **assumptions + reasoning comments**, like a junior reporting to a manager:
 
 ```html
 <!--
-我的假设：
-- 这是给XX受众看的
-- 整体tone我理解为XX（基于用户说的"专业但不严肃"）
-- 主要flow是A→B→C
-- 色彩我想用品牌蓝+暖灰，不确定你想不想要accent色
+My assumptions:
+- This is for audience XX
+- I read the overall tone as XX (based on the user's "professional but not stiff")
+- The main flow is A → B → C
+- I'm thinking brand blue + warm gray; not sure if you want an accent color
 
-未解的问题：
-- 第3步的数据从哪里来？先用placeholder
-- 背景图用抽象几何还是真照片？先占位
+Open questions:
+- Where does the data in step 3 come from? Using a placeholder for now
+- Background: abstract geometry or real photo? Placeholder for now
 
-如果你看到这里觉得方向不对，现在是成本最低的时候改。
+If you read this and the direction's wrong, now is the cheapest time to change it.
 -->
 
-<!-- 然后是带placeholder的结构 -->
+<!-- Then the structure with placeholders -->
 <section class="hero">
-  <h1>[主标题位 - 等用户提供]</h1>
-  <p>[副标题位]</p>
-  <div class="cta-placeholder">[CTA按钮]</div>
+  <h1>[Headline slot — pending user content]</h1>
+  <p>[Subheadline slot]</p>
+  <div class="cta-placeholder">[CTA button]</div>
 </section>
 ```
 
-**保存 → show用户 → 等反馈再走下一步**。
+**Save → show user → wait for feedback before the next step**.
 
-### Pass 2：真实组件+Variations（主力工作量）
+### Pass 2: Real Components + Variations (the bulk of the work)
 
-用户批准方向后，开始填充。这时：
-- 写React组件替换placeholder
-- 做variations（用design_canvas或Tweaks）
-- 如果是幻灯片/动画，用starter components起手
+Once the user approves the direction, start filling in. At this point:
+- Write React components to replace placeholders
+- Make variations (use design_canvas or Tweaks)
+- For slide decks / animations, start from the starter components
 
-**做到一半再show一次**——不要等全做完。设计方向错了，晚show等于白做。
+**Show again at the halfway point** — don't wait until it's all done. If the design direction is wrong, showing late means wasted work.
 
-### Pass 3：细节打磨
+### Pass 3: Detail Polish
 
-用户满意整体后，打磨：
-- 字号/间距/对比度微调
-- 动画timing
-- 边界case
-- Tweaks面板完善
+Once the user's happy with the overall direction, polish:
+- Font size / spacing / contrast tweaks
+- Animation timing
+- Edge cases
+- Tweaks panel refinement
 
-### Pass 4：验证+交付
+### Pass 4: Verify + Deliver
 
-- 用Playwright截图（见`references/verification.md`）
-- 打开浏览器肉眼确认
-- 总结**极简**：只说caveats和next steps
+- Take Playwright screenshots (see `references/verification.md`)
+- Open in a browser and eyeball it
+- Summary stays **minimal**: only caveats and next steps
 
-## Variations的深度逻辑
+## The Deeper Logic of Variations
 
-给variations不是给用户制造选择困难，是**探索可能性空间**。让用户mix and match出最终版本。
+Variations aren't about creating choice paralysis — they're about **exploring the possibility space**. Let the user mix and match into the final version.
 
-### 好的variations长什么样
+### What good variations look like
 
-- **维度明确**：每个variation在不同维度上变（A vs B只换配色，C vs D只换layout）
-- **有梯度**：从「by-the-book保守版」到「大胆novel版」逐级递进
-- **有记号**：每个variation有短label说明它在探索什么
+- **Clear dimensions**: each variation varies on a different dimension (A vs B swaps only color, C vs D swaps only layout)
+- **A gradient**: from "by-the-book conservative" to "bold and novel", stepping up
+- **Labeled**: each variation has a short label saying what it's exploring
 
-### 实现方式
+### How to implement
 
-**纯视觉对比**（静态）：
-→ 用`assets/design_canvas.jsx`，网格布局并排展示。每个cell带label。
+**Pure visual comparison** (static):
+→ Use `assets/design_canvas.jsx`, grid layout side by side. Each cell has a label.
 
-**多选项/交互差异**：
-→ 做完整原型，用Tweaks切换。例如做登录页，"布局"是tweak的一个选项：
-- 左文案右表单
-- 顶部logo+中央表单
-- 背景全屏图+浮层表单
+**Multiple options / interactive diffs**:
+→ Build the full prototype, switch via Tweaks. For example, on a login page "layout" becomes a tweak option:
+- Copy on left, form on right
+- Logo on top, form centered
+- Full-bleed background image with floating form
 
-用户开关Tweaks就能切换，不需要打开多个HTML文件。
+The user toggles Tweaks to switch — no need to open multiple HTML files.
 
-### 探索矩阵思考
+### Exploration matrix thinking
 
-每次设计，脑内过一遍这些维度，挑2-3个来给variations：
+Each time you design, mentally run through these dimensions and pick 2-3 for variations:
 
-- 视觉：minimal / editorial / brutalist / organic / futuristic / retro
-- 色彩：monochrome / dual-tone / vibrant / pastel / high-contrast
-- 字型：sans-only / sans+serif对比 / 全衬线 / 等宽
-- Layout：对称 / 非对称 / 不规则grid / full-bleed / 窄栏
-- Density：稀疏呼吸 / 中等 / 信息密集
-- 交互：极简hover / 丰富micro-interaction / 夸张大动画
-- 材质：flat / 有阴影层次 / 纹理 / noise / 渐变
+- Visual: minimal / editorial / brutalist / organic / futuristic / retro
+- Color: monochrome / dual-tone / vibrant / pastel / high-contrast
+- Type: sans-only / sans + serif contrast / all serif / mono
+- Layout: symmetric / asymmetric / irregular grid / full-bleed / narrow column
+- Density: airy / medium / information-dense
+- Interaction: minimal hover / rich micro-interactions / large dramatic animation
+- Material: flat / layered shadow / texture / noise / gradient
 
-## 遇到不确定的情况
+## When You Hit Uncertainty
 
-- **不知道怎么做**：坦白说你不确定，问用户，或先做个placeholder继续。**不要编**。
-- **用户的描述矛盾**：指出矛盾，让用户选一个方向。
-- **任务太大一次吃不下**：拆成steps，先做第一步让用户看，再推进。
-- **用户要求的效果技术上很难**：说清技术边界，提供替代方案。
+- **Don't know how**: be honest, ask the user, or drop in a placeholder and continue. **Don't make things up**.
+- **Contradictory user description**: call out the contradiction, let the user pick a direction.
+- **Task too big to chew in one bite**: split into steps, ship step one for review before moving on.
+- **What the user wants is technically very hard**: state the technical bounds, offer alternatives.
 
-## 总结规则
+## Summary Rules
 
-交付时，summary **极短**：
+When delivering, the summary stays **very short**:
 
 ```markdown
-✅ 幻灯片已完成（10张），带Tweaks可切换"夜/日模式"。
+✅ Slide deck done (10 slides), with Tweaks to toggle "night / day mode".
 
-注意：
-- 第4页的数据是假的，等你提供真数据我替换
-- 动画用了CSS transition，不需要JS
+Notes:
+- Slide 4's data is fake — swap when you give me the real numbers
+- Animation uses CSS transitions, no JS needed
 
-下一步建议：先你浏览器打开看一遍，有问题告诉我哪页哪处。
+Next: open it in your browser first, then tell me which slide and which spot needs work.
 ```
 
-不要：
-- 罗列每一页的内容
-- 重复讲你用了什么技术
-- 夸自己设计多好
+Don't:
+- List the contents of every slide
+- Recap which tech you used
+- Praise your own design
 
-Caveats + next steps，结束。
+Caveats + next steps, done.

--- a/scripts/export_deck_pdf.mjs
+++ b/scripts/export_deck_pdf.mjs
@@ -1,23 +1,23 @@
 #!/usr/bin/env node
 /**
- * export_deck_pdf.mjs — 把多文件 slide deck 导出为单个矢量 PDF
+ * export_deck_pdf.mjs — export a multi-file slide deck as a single vector PDF
  *
- * 用法：
+ * Usage:
  *   node export_deck_pdf.mjs --slides <dir> --out <file.pdf> [--width 1920] [--height 1080]
  *
- * 特点：
- *   - 文字保留矢量（可复制、可搜索）
- *   - 背景/图形 1:1 保真（Playwright 内嵌 Chromium 渲染）
- *   - 不需要对 HTML 做任何改造
- *   - 视觉损失 = 0（PDF 就是浏览器打印出来的）
+ * Properties:
+ *   - Text stays vector (copyable, searchable)
+ *   - Backgrounds/graphics are 1:1 faithful (rendered by Playwright's embedded Chromium)
+ *   - No changes needed to the HTML
+ *   - Zero visual loss (the PDF is exactly what the browser prints)
  *
- * trade-off：
- *   - PDF 不可再编辑文字（要改回到 HTML 改）
+ * Trade-off:
+ *   - PDF text is not re-editable (edits go back to the HTML)
  *
- * 依赖：playwright pdf-lib
+ * Dependencies: playwright pdf-lib
  *   npm install playwright pdf-lib
  *
- * 会按文件名排序（01-xxx.html → 02-xxx.html → ...）
+ * Sorted by filename (01-xxx.html → 02-xxx.html → ...)
  */
 
 import { chromium } from 'playwright';
@@ -33,7 +33,7 @@ function parseArgs() {
     args[k] = a[i + 1];
   }
   if (!args.slides || !args.out) {
-    console.error('用法: node export_deck_pdf.mjs --slides <dir> --out <file.pdf> [--width 1920] [--height 1080]');
+    console.error('Usage: node export_deck_pdf.mjs --slides <dir> --out <file.pdf> [--width 1920] [--height 1080]');
     process.exit(1);
   }
   args.width = parseInt(args.width);

--- a/scripts/export_deck_pptx.mjs
+++ b/scripts/export_deck_pptx.mjs
@@ -1,28 +1,28 @@
 #!/usr/bin/env node
 /**
- * export_deck_pptx.mjs — 把多文件 slide deck 导出为可编辑 PPTX
+ * export_deck_pptx.mjs — export a multi-file slide deck as an editable PPTX
  *
- * 用法：
+ * Usage:
  *   node export_deck_pptx.mjs --slides <dir> --out <file.pptx>
  *
- * 行为：
- *   - 调用 scripts/html2pptx.js 把 HTML DOM 逐元素翻译成 PowerPoint 原生对象
- *   - 文字是真文本框，PPT 里直接双击能编辑
- *   - body 尺寸 960pt × 540pt（LAYOUT_WIDE，13.333″ × 7.5″）
+ * Behavior:
+ *   - Calls scripts/html2pptx.js to translate the HTML DOM element-by-element into native PowerPoint objects
+ *   - Text becomes real text frames — double-click to edit inside PowerPoint
+ *   - Body size 960pt × 540pt (LAYOUT_WIDE, 13.333″ × 7.5″)
  *
- * ⚠️ HTML 必须符合 4 条硬约束（见 references/editable-pptx.md）：
- *   1. 文字包在 <p>/<h1>-<h6> 里（div 不能直接放文字）
- *   2. 不用 CSS 渐变
- *   3. <p>/<h*> 不能有 background/border/shadow（放外层 div）
- *   4. div 不能 background-image（用 <img>）
+ * ⚠️ The HTML must satisfy the 4 hard constraints (see references/editable-pptx.md):
+ *   1. Text must be wrapped in <p> / <h1>-<h6> (a div cannot directly contain text)
+ *   2. No CSS gradients
+ *   3. <p> / <h*> cannot carry background / border / shadow (put those on an outer div)
+ *   4. div cannot use background-image (use <img>)
  *
- * 视觉驱动的 HTML 几乎无法 pass —— 必须从写 HTML 的第一行就按约束写。
- * 视觉自由度优先的场景（动画、web component、CSS 渐变、复杂 SVG）
- * 应改用 export_deck_pdf.mjs / export_deck_stage_pdf.mjs 导出 PDF。
+ * Visually-driven HTML almost never passes — you must write the HTML against these constraints from line 1.
+ * For scenarios that prioritize visual freedom (animations, web components, CSS gradients, complex SVG),
+ * use export_deck_pdf.mjs / export_deck_stage_pdf.mjs to produce a PDF instead.
  *
- * 依赖：npm install playwright pptxgenjs sharp
+ * Dependencies: npm install playwright pptxgenjs sharp
  *
- * 按文件名排序（01-xxx.html → 02-xxx.html → ...）。
+ * Sorted by filename (01-xxx.html → 02-xxx.html → ...).
  */
 
 import pptxgen from 'pptxgenjs';
@@ -40,10 +40,10 @@ function parseArgs() {
     args[k] = a[i + 1];
   }
   if (!args.slides || !args.out) {
-    console.error('用法: node export_deck_pptx.mjs --slides <dir> --out <file.pptx>');
+    console.error('Usage: node export_deck_pptx.mjs --slides <dir> --out <file.pptx>');
     console.error('');
-    console.error('⚠️ HTML 必须符合 4 条硬约束（见 references/editable-pptx.md）。');
-    console.error('   视觉自由度优先的场景请改用 export_deck_pdf.mjs 导出 PDF。');
+    console.error('⚠️ The HTML must satisfy the 4 hard constraints (see references/editable-pptx.md).');
+    console.error('   For visual-freedom-first scenarios, use export_deck_pdf.mjs to produce a PDF instead.');
     process.exit(1);
   }
   return args;
@@ -70,13 +70,13 @@ async function main() {
   try {
     html2pptx = require(path.join(__dirname, 'html2pptx.js'));
   } catch (e) {
-    console.error(`✗ 加载 html2pptx.js 失败：${e.message}`);
-    console.error(`  依赖缺失时请跑：npm install playwright pptxgenjs sharp`);
+    console.error(`✗ Failed to load html2pptx.js: ${e.message}`);
+    console.error(`  If dependencies are missing, run: npm install playwright pptxgenjs sharp`);
     process.exit(1);
   }
 
   const pres = new pptxgen();
-  pres.layout = 'LAYOUT_WIDE';  // 13.333 × 7.5 inch，对应 HTML body 960 × 540 pt
+  pres.layout = 'LAYOUT_WIDE';  // 13.333 × 7.5 inch — matches the HTML body's 960 × 540 pt
 
   const errors = [];
   for (let i = 0; i < files.length; i++) {
@@ -92,16 +92,16 @@ async function main() {
   }
 
   if (errors.length) {
-    console.error(`\n⚠️ ${errors.length} 张 slide 转换失败。常见原因：HTML 不符合 4 条硬约束。`);
-    console.error(`  详见 references/editable-pptx.md 的「常见错误速查」。`);
+    console.error(`\n⚠️ ${errors.length} slide(s) failed to convert. Common cause: HTML doesn't satisfy the 4 hard constraints.`);
+    console.error(`  See the "Common errors quick reference" in references/editable-pptx.md.`);
     if (errors.length === files.length) {
-      console.error(`✗ 全部失败，不生成 PPTX。`);
+      console.error(`✗ All failed — no PPTX produced.`);
       process.exit(1);
     }
   }
 
   await pres.writeFile({ fileName: outFile });
-  console.log(`\n✓ Wrote ${outFile}  (${files.length - errors.length}/${files.length} slides, 可编辑 PPTX)`);
+  console.log(`\n✓ Wrote ${outFile}  (${files.length - errors.length}/${files.length} slides, editable PPTX)`);
 }
 
 main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/export_deck_stage_pdf.mjs
+++ b/scripts/export_deck_stage_pdf.mjs
@@ -1,31 +1,31 @@
 #!/usr/bin/env node
 /**
- * export_deck_stage_pdf.mjs — 单文件 <deck-stage> 架构专用 PDF 导出
+ * export_deck_stage_pdf.mjs — PDF export for the single-file <deck-stage> architecture
  *
- * 用法：
+ * Usage:
  *   node export_deck_stage_pdf.mjs --html <deck.html> --out <file.pdf> [--width 1920] [--height 1080]
  *
- * 什么时候用这个脚本？
- *   - 你的 deck 是**单 HTML 文件**，所有 slide 是 `<section>`，外层用 `<deck-stage>` 包裹
- *   - 此时 `export_deck_pdf.mjs`（多文件专用）用不上
+ * When to use this script:
+ *   - Your deck is a **single HTML file** where all slides are `<section>` elements wrapped in `<deck-stage>`
+ *   - In that case `export_deck_pdf.mjs` (multi-file only) doesn't apply
  *
- * 为什么不能直接 `page.pdf()`（2026-04-20 踩坑记录）：
- *   1. deck-stage 的 shadow CSS `::slotted(section) { display: none }` 让只有 active slide 可见
- *   2. print 媒体下外层 `!important` 压不住 shadow DOM 规则
- *   3. 结果：PDF 永远只有 1 页（active 那张）
+ * Why a direct `page.pdf()` doesn't work (pitfall logged 2026-04-20):
+ *   1. deck-stage's shadow CSS `::slotted(section) { display: none }` only shows the active slide
+ *   2. Outer `!important` rules cannot override shadow DOM rules under the print media
+ *   3. Result: PDF always has only 1 page (the active one)
  *
- * 解决方案：
- *   打开 HTML 后，用 page.evaluate 把所有 section 从 deck-stage slot 拔出来，
- *   挂到 body 下一个普通 div，内联 style 强制 position:relative + 固定尺寸，
- *   每个 section 加 page-break-after: always，最后一个改 auto 避免尾部空白页。
+ * Solution:
+ *   After opening the HTML, use page.evaluate to pull every section out of the deck-stage slot,
+ *   reparent them under a plain <div> at the body level, force position:relative + fixed dimensions via inline style,
+ *   add page-break-after: always to each section, and change the last one to auto to avoid a trailing blank page.
  *
- * 依赖：playwright
+ * Dependencies: playwright
  *   npm install playwright
  *
- * 输出特点：
- *   - 文字保留矢量（可复制、可搜索）
- *   - 视觉 1:1 保真
- *   - 字体必须能被 Chromium 加载（本地字体或 Google Fonts）
+ * Output properties:
+ *   - Text stays vector (copyable, searchable)
+ *   - 1:1 visual fidelity
+ *   - Fonts must be loadable by Chromium (local fonts or Google Fonts)
  */
 
 import { chromium } from 'playwright';
@@ -40,7 +40,7 @@ function parseArgs() {
     args[k] = a[i + 1];
   }
   if (!args.html || !args.out) {
-    console.error('用法: node export_deck_stage_pdf.mjs --html <deck.html> --out <file.pdf> [--width 1920] [--height 1080]');
+    console.error('Usage: node export_deck_stage_pdf.mjs --html <deck.html> --out <file.pdf> [--width 1920] [--height 1080]');
     process.exit(1);
   }
   args.width = parseInt(args.width);
@@ -65,16 +65,16 @@ async function main() {
   const page = await ctx.newPage();
 
   await page.goto('file://' + htmlAbs, { waitUntil: 'networkidle' });
-  await page.waitForTimeout(2500);  // 等 Google Fonts + deck-stage init
+  await page.waitForTimeout(2500);  // Wait for Google Fonts + deck-stage init
 
-  // 核心修复：把 section 从 shadow DOM slot 拔出来摊平
+  // Core fix: pull <section>s out of the shadow DOM slot and flatten them
   const sectionCount = await page.evaluate(({ W, H }) => {
     const stage = document.querySelector('deck-stage');
-    if (!stage) throw new Error('<deck-stage> not found — 这个脚本只适用于单文件 deck-stage 架构');
+    if (!stage) throw new Error('<deck-stage> not found — this script only works with the single-file deck-stage architecture');
     const sections = Array.from(stage.querySelectorAll(':scope > section'));
     if (!sections.length) throw new Error('No <section> found inside <deck-stage>');
 
-    // 注入打印样式
+    // Inject print stylesheet
     const style = document.createElement('style');
     style.textContent = `
       @page { size: ${W}px ${H}px; margin: 0; }
@@ -83,11 +83,11 @@ async function main() {
     `;
     document.head.appendChild(style);
 
-    // 摊平到 body 下
+    // Flatten under body
     const container = document.createElement('div');
     container.id = 'print-container';
     sections.forEach(s => {
-      // 内联 style 拿到最高优先级；确保 position:relative 让 absolute 子元素正确约束
+      // Inline style for highest priority; ensure position:relative so absolute children are constrained correctly
       s.style.cssText = `
         width: ${W}px !important;
         height: ${H}px !important;
@@ -101,7 +101,7 @@ async function main() {
       `;
       container.appendChild(s);
     });
-    // 最后一页不分页，避免尾部空白页
+    // No page-break on the last page — avoids a trailing blank page
     const last = sections[sections.length - 1];
     last.style.pageBreakAfter = 'auto';
     last.style.breakAfter = 'auto';
@@ -124,7 +124,7 @@ async function main() {
   const stat = await fs.stat(outFile);
   const kb = (stat.size / 1024).toFixed(0);
   console.log(`\n✓ Wrote ${outFile}  (${kb} KB, ${sectionCount} pages, vector)`);
-  console.log(`  验证页数：mdimport "${outFile}" && pdfinfo "${outFile}" | grep Pages`);
+  console.log(`  Verify page count: mdimport "${outFile}" && pdfinfo "${outFile}" | grep Pages`);
 }
 
 main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/mix-voiceover.sh
+++ b/scripts/mix-voiceover.sh
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
-# mix-voiceover.sh · Mix voiceover (人声主轨) + optional BGM into an MP4
+# mix-voiceover.sh · Mix voiceover (primary voice track) + optional BGM into an MP4
 #
 # Usage:
 #   bash mix-voiceover.sh <video.mp4> --voiceover=<voice.mp3> [options]
 #
 # Required:
-#   --voiceover=<path>    Path to voiceover mp3 (人声主轨, 来自 narrate-pipeline.mjs)
+#   --voiceover=<path>    Path to voiceover mp3 (primary voice track, from narrate-pipeline.mjs)
 #
 # Optional:
 #   --bgm=<path>          BGM mp3 path (overrides --bgm-mood)
 #   --bgm-mood=<name>     Pick a preset BGM from assets/ (educational / tech / tutorial / ...)
-#   --bgm-volume=<0-1>    BGM 静态音量, 默认 0.18 (相对人声)
-#   --no-ducking          关闭 sidechain ducking（默认开启：人声响时 BGM 自动让路）
-#   --voice-volume=<0-2>  人声音量倍率, 默认 1.0
-#   --out=<path>          输出路径, 默认 <input>-voiced.mp4
+#   --bgm-volume=<0-1>    BGM static volume, default 0.18 (relative to voice)
+#   --no-ducking          Disable sidechain ducking (on by default: BGM steps aside when voice plays)
+#   --voice-volume=<0-2>  Voice volume multiplier, default 1.0
+#   --out=<path>          Output path, default <input>-voiced.mp4
 #
 # Behavior:
-#   - 视频流 stream copy（不重编码，快）
-#   - 人声始终是主轨，必带；BGM 可选
-#   - 默认开 ducking：人声响时 BGM 压到约 -10dB，人声停时回升
-#   - 输出长度 = 视频长度（人声/BGM 较短就尾静音；较长就截断）
+#   - Video stream is copied (no re-encode, fast)
+#   - Voice is always the primary track and is required; BGM is optional
+#   - Ducking is on by default: BGM is pushed to ~-10dB while voice is active, restored when voice stops
+#   - Output length = video length (shorter audio is padded with silence; longer audio is truncated)
 #
 # Examples:
 #   bash mix-voiceover.sh anim.mp4 --voiceover=narration/voiceover.mp3
@@ -50,7 +50,7 @@ for arg in "$@"; do
     --voice-volume=*) VOICE_VOLUME="${arg#*=}" ;;
     --no-ducking)     DUCKING="0" ;;
     --out=*)          OUTPUT="${arg#*=}" ;;
-    -*)               echo "未知参数：$arg" >&2; exit 1 ;;
+    -*)               echo "Unknown argument: $arg" >&2; exit 1 ;;
     *)                INPUT="$arg" ;;
   esac
 done
@@ -60,47 +60,47 @@ if [ -z "$INPUT" ] || [ ! -f "$INPUT" ]; then
   exit 1
 fi
 if [ -z "$VOICEOVER" ] || [ ! -f "$VOICEOVER" ]; then
-  echo "✗ 缺 --voiceover=<path>" >&2
+  echo "✗ Missing --voiceover=<path>" >&2
   exit 1
 fi
 
-# 解析 BGM 来源
+# Resolve BGM source
 if [ -z "$BGM" ] && [ -n "$BGM_MOOD" ]; then
   BGM="$ASSETS_DIR/bgm-${BGM_MOOD}.mp3"
 fi
 if [ -n "$BGM" ] && [ ! -f "$BGM" ]; then
-  echo "✗ BGM 文件不存在: $BGM" >&2
-  echo "  可用 mood: $(ls "$ASSETS_DIR" 2>/dev/null | grep -E '^bgm-.*\.mp3$' | sed 's/^bgm-//;s/\.mp3$//' | tr '\n' ' ')" >&2
+  echo "✗ BGM file not found: $BGM" >&2
+  echo "  Available moods: $(ls "$ASSETS_DIR" 2>/dev/null | grep -E '^bgm-.*\.mp3$' | sed 's/^bgm-//;s/\.mp3$//' | tr '\n' ' ')" >&2
   exit 1
 fi
 
-# 输出路径
+# Output path
 if [ -z "$OUTPUT" ]; then
   base="${INPUT%.*}"
   OUTPUT="${base}-voiced.mp4"
 fi
 
 echo "─ mix-voiceover ──────────────"
-echo "  视频:     $INPUT"
-echo "  人声:     $VOICEOVER (vol=$VOICE_VOLUME)"
+echo "  Video:    $INPUT"
+echo "  Voice:    $VOICEOVER (vol=$VOICE_VOLUME)"
 if [ -n "$BGM" ]; then
   echo "  BGM:      $BGM (vol=$BGM_VOLUME, ducking=$DUCKING)"
 else
-  echo "  BGM:      （无）"
+  echo "  BGM:      (none)"
 fi
-echo "  输出:     $OUTPUT"
+echo "  Output:   $OUTPUT"
 echo "──────────────────────────────"
 
 # ── ffmpeg filter graph ─────────────────────────────────────
 if [ -z "$BGM" ]; then
-  # 仅人声
+  # Voice only
   ffmpeg -y -i "$INPUT" -i "$VOICEOVER" \
     -filter_complex "[1:a]volume=${VOICE_VOLUME}[a]" \
     -map 0:v -map "[a]" \
     -c:v copy -c:a aac -b:a 192k -shortest \
     "$OUTPUT"
 elif [ "$DUCKING" = "1" ]; then
-  # 人声 + BGM + sidechain ducking
+  # Voice + BGM + sidechain ducking
   ffmpeg -y -i "$INPUT" -i "$VOICEOVER" -i "$BGM" \
     -filter_complex "
       [1:a]volume=${VOICE_VOLUME}[voice];
@@ -112,7 +112,7 @@ elif [ "$DUCKING" = "1" ]; then
     -c:v copy -c:a aac -b:a 192k -shortest \
     "$OUTPUT"
 else
-  # 人声 + BGM 静态混合
+  # Voice + BGM (static mix)
   ffmpeg -y -i "$INPUT" -i "$VOICEOVER" -i "$BGM" \
     -filter_complex "
       [1:a]volume=${VOICE_VOLUME}[voice];
@@ -124,4 +124,4 @@ else
     "$OUTPUT"
 fi
 
-echo "✓ 完成：$OUTPUT"
+echo "✓ Done: $OUTPUT"

--- a/scripts/narrate-pipeline.mjs
+++ b/scripts/narrate-pipeline.mjs
@@ -1,36 +1,36 @@
 #!/usr/bin/env node
 /**
- * narrate-pipeline.mjs · L2 长解说总指挥
+ * narrate-pipeline.mjs · long-form narration conductor (L2)
  *
- * 输入：markdown 解说稿（## scene-id 分段，[[cue:id]] 标关键句）
- * 输出：voiceover.mp3（拼接好的整段人声）+ timeline.json（每段 start/end + cues 绝对时间）
+ * Input: markdown narration script (## scene-id segments, [[cue:id]] marks key lines)
+ * Output: voiceover.mp3 (full concatenated voice track) + timeline.json (per-segment start/end + absolute cue times)
  *
- * 用法：
+ * Usage:
  *   node scripts/narrate-pipeline.mjs --script demo.md --out-dir _narration_demo
  *
- * 解说稿格式：
+ * Narration-script format:
  *   ---
- *   title: 什么是 LLM
- *   voice: S_JSdgdWk22   # 可选，不填走 .env
- *   speed: 1.0           # 可选
- *   gap: 0.3             # 段间静音秒数，默认 0.3
+ *   title: What is an LLM
+ *   voice: S_JSdgdWk22   # optional; falls back to .env if omitted
+ *   speed: 1.0           # optional
+ *   gap: 0.3             # silence between segments in seconds, default 0.3
  *   ---
  *
  *   ## intro
- *   大家好，我是花叔。今天我们 5 分钟讲清楚 LLM 是什么。
+ *   Hi everyone. Today we'll explain what an LLM is in five minutes.
  *
  *   ## what-is
- *   LLM 全称 Large Language Model，[[cue:bigmodel]]它是一个有几千亿参数的神经网络。
- *   本质是一个文字接龙的预测器。
+ *   LLM stands for Large Language Model, [[cue:bigmodel]]a neural network with hundreds of billions of parameters.
+ *   At its core, it's a text-completion predictor.
  *
- * 输出文件结构（out-dir 下）：
+ * Output file structure (under out-dir):
  *   audio/
  *     intro.mp3
  *     what-is.mp3
- *   voiceover.mp3       拼接全部 scene 的整段人声
- *   timeline.json       schema 见 references/voiceover-pipeline.md
+ *   voiceover.mp3       full concatenated voice track across all scenes
+ *   timeline.json       schema in references/voiceover-pipeline.md
  *
- * 依赖：tts-doubao.mjs、ffmpeg、ffprobe
+ * Dependencies: tts-doubao.mjs, ffmpeg, ffprobe
  */
 
 import fs from 'node:fs';
@@ -55,12 +55,12 @@ function parseArgs(argv) {
 
 function usage() {
   console.error(`
-narrate-pipeline.mjs · L2 长解说总指挥
+narrate-pipeline.mjs · long-form narration conductor (L2)
 
-  --script <path>     解说稿 .md 文件（必填）
-  --out-dir <path>    输出目录（必填）
+  --script <path>     narration .md file (required)
+  --out-dir <path>    output directory (required)
 
-输出：<out-dir>/voiceover.mp3 + <out-dir>/timeline.json
+Outputs: <out-dir>/voiceover.mp3 + <out-dir>/timeline.json
 `.trim());
   process.exit(1);
 }
@@ -116,7 +116,7 @@ function splitByCues(text) {
   }
   const tail = text.slice(lastIdx).trim();
   chunks.push({ text: tail });
-  // 过滤空文本块（cue 紧贴段首/段尾时）
+  // Filter empty text chunks (when a cue sits right at the start or end of a segment)
   return chunks.filter((c) => c.text.length > 0 || c.cueAfter);
 }
 
@@ -142,7 +142,7 @@ function callTTS(text, outPath, opts) {
 }
 
 function ffmpegConcat(inputs, output) {
-  // 用 concat demuxer 合并相同编码的 mp3
+  // Use the concat demuxer to merge mp3s that share the same encoding
   const listFile = output + '.list';
   fs.writeFileSync(
     listFile,
@@ -176,7 +176,7 @@ async function main() {
   const md = fs.readFileSync(scriptPath, 'utf8');
   const { meta, scenes } = parseScript(md);
   if (scenes.length === 0) {
-    console.error('错：解说稿没有 ## scene 段，至少一段。');
+    console.error('Error: the script has no ## scene segments — at least one is required.');
     process.exit(1);
   }
 
@@ -186,7 +186,7 @@ async function main() {
 
   console.error(`[narrate] script=${path.basename(scriptPath)} scenes=${scenes.length} voice=${voice || '(env)'} speed=${speed} gap=${gap}s`);
 
-  // 段间静音文件（共用一个）
+  // Shared silence file used between segments
   const gapFile = path.join(tmpDir, 'gap.mp3');
   if (gap > 0) makeSilence(gap, gapFile);
 
@@ -209,13 +209,13 @@ async function main() {
     const chunks = splitByCues(scene.raw);
     const chunkFiles = [];
     const cueRecords = [];
-    const chunkRecords = []; // 每个 chunk 的实测 start/end 段内时间，用于字幕显示
+    const chunkRecords = []; // Measured start/end of each chunk within the segment — used for subtitles
     let sceneInternalCursor = 0;
 
     for (let j = 0; j < chunks.length; j++) {
       const chunk = chunks[j];
       if (!chunk.text) {
-        // 空文本块（cue 紧贴），跳过 TTS 但仍记录 cue 位置
+        // Empty text chunk (cue sits adjacent) — skip TTS but still record the cue position
         if (chunk.cueAfter) {
           cueRecords.push({
             id: chunk.cueAfter,
@@ -235,7 +235,7 @@ async function main() {
         end: sceneInternalCursor,
         duration: result.duration,
       });
-      console.error(`  chunk ${j}: ${result.duration.toFixed(2)}s · ${chunk.text.length} 字 · ${chunk.text.slice(0, 30)}${chunk.text.length > 30 ? '…' : ''}`);
+      console.error(`  chunk ${j}: ${result.duration.toFixed(2)}s · ${chunk.text.length} chars · ${chunk.text.slice(0, 30)}${chunk.text.length > 30 ? '…' : ''}`);
       if (chunk.cueAfter) {
         cueRecords.push({
           id: chunk.cueAfter,
@@ -244,7 +244,7 @@ async function main() {
       }
     }
 
-    // 合并段内子段
+    // Merge chunks within a segment
     const sceneAudio = path.join(audioDir, `${scene.id}.mp3`);
     if (chunkFiles.length === 1) {
       fs.copyFileSync(chunkFiles[0], sceneAudio);
@@ -253,7 +253,7 @@ async function main() {
     }
     const sceneDuration = getDuration(sceneAudio);
 
-    // 拼接到总轨：先加 gap（除了第一段），再加 scene
+    // Append to the master track: add gap first (except for the first segment), then the scene
     if (i > 0 && gap > 0) {
       sceneAudioFiles.push(gapFile);
       cursor += gap;
@@ -267,7 +267,7 @@ async function main() {
       duration: sceneDuration,
       audio: path.relative(outDir, sceneAudio),
       text: scene.raw.replace(/\[\[cue:[\w-]+\]\]/g, ''),
-      // chunks: 用于字幕逐句显示。start/end 是段内相对时间，absoluteStart/absoluteEnd 是整轨绝对时间
+      // chunks: used to render subtitles line-by-line. start/end are segment-relative; absoluteStart/absoluteEnd are absolute on the full track
       chunks: chunkRecords.map((c) => ({
         text: c.text,
         start: c.start,
@@ -285,7 +285,7 @@ async function main() {
     cursor += sceneDuration;
   }
 
-  // 合并整轨
+  // Merge into the full track
   const voiceoverPath = path.join(outDir, 'voiceover.mp3');
   ffmpegConcat(sceneAudioFiles, voiceoverPath);
   timeline.totalDuration = getDuration(voiceoverPath);
@@ -296,20 +296,20 @@ async function main() {
     JSON.stringify(timeline, null, 2),
   );
 
-  // 清理 tmp
+  // Clean up tmp
   fs.rmSync(tmpDir, { recursive: true, force: true });
 
-  console.error(`\n[narrate] 完成。`);
+  console.error(`\n[narrate] Done.`);
   console.error(`  voiceover: ${voiceoverPath}`);
   console.error(`  timeline:  ${path.join(outDir, 'timeline.json')}`);
-  console.error(`  总时长:    ${timeline.totalDuration.toFixed(2)}s (${(timeline.totalDuration / 60).toFixed(2)} min)`);
-  console.error(`  段数:      ${timeline.scenes.length}`);
+  console.error(`  Total dur: ${timeline.totalDuration.toFixed(2)}s (${(timeline.totalDuration / 60).toFixed(2)} min)`);
+  console.error(`  Scenes:    ${timeline.scenes.length}`);
   const totalCues = timeline.scenes.reduce((sum, s) => sum + s.cues.length, 0);
-  console.error(`  cue 数:    ${totalCues}`);
+  console.error(`  Cues:      ${totalCues}`);
 }
 
 main().catch((err) => {
-  console.error(`narrate-pipeline 失败：${err.message}`);
+  console.error(`narrate-pipeline failed: ${err.message}`);
   console.error(err.stack);
   process.exit(1);
 });

--- a/scripts/render-narration.sh
+++ b/scripts/render-narration.sh
@@ -1,27 +1,27 @@
 #!/usr/bin/env bash
-# render-narration.sh · 一条龙：HTML 解说动画 → 最终 MP4（带人声）
+# render-narration.sh · End-to-end: narrated HTML animation → final MP4 (with voiceover)
 #
-# 流水线：
-#   1. render-video.js  录无声 MP4（按 timeline.totalDuration）
-#   2. mix-voiceover.sh 混入 voiceover.mp3（可选 BGM）
-#   3. 输出 <basename>-narrated.mp4
+# Pipeline:
+#   1. render-video.js  records a silent MP4 (length = timeline.totalDuration)
+#   2. mix-voiceover.sh mixes in voiceover.mp3 (optional BGM)
+#   3. Output: <basename>-narrated.mp4
 #
 # Usage:
 #   bash render-narration.sh <html> --timeline=<path> [options]
 #
 # Required:
-#   <html>                解说动画的 HTML（应内嵌 NarrationStage + recording 模式 rAF 自驱）
-#   --timeline=<path>     timeline.json 路径（自动读 totalDuration 和 voiceover.mp3 路径）
+#   <html>                The narrated animation HTML (should embed NarrationStage + recording-mode rAF self-driver)
+#   --timeline=<path>     Path to timeline.json (totalDuration and voiceover.mp3 path are read from it)
 #
 # Optional:
-#   --bgm-mood=<name>     BGM 预设（educational / tech / tutorial / ...）
-#   --bgm=<path>          自定义 BGM 文件
-#   --bgm-volume=<0-1>    BGM 静态音量，默认 0.18
-#   --no-ducking          关 sidechain ducking
-#   --keep-silent         保留中间产物（无声 MP4），便于 debug
-#   --out=<path>          输出路径，默认 <html-basename>-narrated.mp4
-#   --width=<px>          视频宽度（默认 1920）
-#   --height=<px>         视频高度（默认 1080）
+#   --bgm-mood=<name>     BGM preset (educational / tech / tutorial / ...)
+#   --bgm=<path>          Custom BGM file
+#   --bgm-volume=<0-1>    BGM static volume, default 0.18
+#   --no-ducking          Disable sidechain ducking
+#   --keep-silent         Keep the intermediate silent MP4 for debugging
+#   --out=<path>          Output path, default <html-basename>-narrated.mp4
+#   --width=<px>          Video width (default 1920)
+#   --height=<px>         Video height (default 1080)
 #
 # Examples:
 #   bash render-narration.sh demo.html --timeline=_narration/timeline.json
@@ -54,7 +54,7 @@ for arg in "$@"; do
     --out=*)         OUT="${arg#*=}" ;;
     --width=*)       WIDTH="${arg#*=}" ;;
     --height=*)      HEIGHT="${arg#*=}" ;;
-    -*)              echo "未知参数：$arg" >&2; exit 1 ;;
+    -*)              echo "Unknown argument: $arg" >&2; exit 1 ;;
     *)               HTML="$arg" ;;
   esac
 done
@@ -64,22 +64,22 @@ if [ -z "$HTML" ] || [ ! -f "$HTML" ]; then
   exit 1
 fi
 if [ -z "$TIMELINE" ] || [ ! -f "$TIMELINE" ]; then
-  echo "✗ 缺 --timeline=<path>（timeline.json 由 narrate-pipeline.mjs 生成）" >&2
+  echo "✗ Missing --timeline=<path> (timeline.json is produced by narrate-pipeline.mjs)" >&2
   exit 1
 fi
 
-# ── 从 timeline.json 读 totalDuration 和 voiceover 路径 ──
+# ── Read totalDuration and voiceover path from timeline.json ──
 TIMELINE_DIR="$(cd "$(dirname "$TIMELINE")" && pwd)"
 TOTAL_DURATION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$TIMELINE','utf8')).totalDuration)")
 VOICEOVER_REL=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$TIMELINE','utf8')).voiceover || 'voiceover.mp3')")
 VOICEOVER="$TIMELINE_DIR/$VOICEOVER_REL"
 
 if [ ! -f "$VOICEOVER" ]; then
-  echo "✗ voiceover.mp3 不存在: $VOICEOVER" >&2
+  echo "✗ voiceover.mp3 not found: $VOICEOVER" >&2
   exit 1
 fi
 
-# 录制时长 = 总时长 + 1s 安全缓冲
+# Recording length = total duration + 1s safety buffer
 RECORD_DURATION=$(node -e "console.log(Math.ceil($TOTAL_DURATION + 1))")
 
 HTML_ABS="$(cd "$(dirname "$HTML")" && pwd)/$(basename "$HTML")"
@@ -95,29 +95,29 @@ echo "═══ render-narration ═══════════════�
 echo "  HTML:        $HTML_ABS"
 echo "  Timeline:    $TIMELINE"
 echo "  Voiceover:   $VOICEOVER"
-echo "  Total dur:   ${TOTAL_DURATION}s (录 ${RECORD_DURATION}s)"
-echo "  尺寸:        ${WIDTH}×${HEIGHT}"
+echo "  Total dur:   ${TOTAL_DURATION}s (recording ${RECORD_DURATION}s)"
+echo "  Size:        ${WIDTH}×${HEIGHT}"
 [ -n "$BGM_MOOD" ] && echo "  BGM mood:    $BGM_MOOD"
 [ -n "$BGM" ] && echo "  BGM:         $BGM"
-echo "  最终输出:    $OUT"
+echo "  Final out:   $OUT"
 echo "════════════════════════════════════════"
 
-# ── Step 1: 录无声 MP4 ──────────────────────
+# ── Step 1: record silent MP4 ──────────────
 echo ""
-echo "▸ Step 1/2 · 录制 HTML 动画 (无声)"
+echo "▸ Step 1/2 · Recording HTML animation (silent)"
 NODE_PATH=$(npm root -g) node "$SCRIPT_DIR/render-video.js" "$HTML_ABS" \
   --duration="$RECORD_DURATION" \
   --width="$WIDTH" \
   --height="$HEIGHT"
 
 if [ ! -f "$SILENT_MP4" ]; then
-  echo "✗ 无声 MP4 没生成: $SILENT_MP4" >&2
+  echo "✗ Silent MP4 was not produced: $SILENT_MP4" >&2
   exit 1
 fi
 
-# ── Step 2: 混入人声 ──────────────────────
+# ── Step 2: mix in the voice ──────────────
 echo ""
-echo "▸ Step 2/2 · 混入人声"
+echo "▸ Step 2/2 · Mixing in voiceover"
 MIX_ARGS=("$SILENT_MP4" "--voiceover=$VOICEOVER" "--out=$OUT")
 [ -n "$BGM_MOOD" ] && MIX_ARGS+=("--bgm-mood=$BGM_MOOD")
 [ -n "$BGM" ]      && MIX_ARGS+=("--bgm=$BGM")
@@ -126,11 +126,11 @@ MIX_ARGS=("$SILENT_MP4" "--voiceover=$VOICEOVER" "--out=$OUT")
 
 bash "$SCRIPT_DIR/mix-voiceover.sh" "${MIX_ARGS[@]}"
 
-# 清理中间产物
+# Clean up intermediate artifact
 if [ -z "$KEEP_SILENT" ]; then
   rm -f "$SILENT_MP4"
 fi
 
 echo ""
-echo "✓ 完成: $OUT"
-[ -n "$KEEP_SILENT" ] && echo "  (中间产物保留: $SILENT_MP4)"
+echo "✓ Done: $OUT"
+[ -n "$KEEP_SILENT" ] && echo "  (intermediate kept: $SILENT_MP4)"

--- a/scripts/render-video.js
+++ b/scripts/render-video.js
@@ -204,9 +204,10 @@ console.log(`  output: ${MP4_OUT}`);
   ).then(() => true).catch(() => false);
 
   if (hasReady) {
-    // 第二道防线：主动把动画 time 归零——对付 HTML 不严格遵守 starter tick 模板
-    // 的情况（例如 lastTick 用 performance.now() 导致字体加载时间被算进首帧 dt）
-    // 详见 references/animation-pitfalls.md §12
+    // Second line of defense: actively reset the animation time to zero, in case the HTML
+    // doesn't strictly follow the starter tick template (e.g. lastTick using performance.now()
+    // causes font load time to be folded into the first frame's dt).
+    // See references/animation-pitfalls.md §12.
     const seekCorrected = await page.evaluate(() => {
       if (typeof window.__seek === 'function') {
         window.__seek(0);
@@ -215,7 +216,7 @@ console.log(`  output: ${MP4_OUT}`);
       return false;
     });
     if (seekCorrected) {
-      // 等两个 rAF 让 seek 生效并渲染出 t=0 的画面
+      // Wait two rAFs for the seek to take effect and render the t=0 frame
       await page.evaluate(() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r))));
     }
     animationStartSec = (Date.now() - T0) / 1000;

--- a/scripts/tts-doubao.mjs
+++ b/scripts/tts-doubao.mjs
@@ -1,22 +1,22 @@
 #!/usr/bin/env node
 /**
- * tts-doubao.mjs · 豆包语音 TTS（火山引擎 openspeech）
+ * tts-doubao.mjs · Doubao TTS (Volcano Engine openspeech)
  *
- * 用法：
- *   node scripts/tts-doubao.mjs --text "你好" --out demo.mp3
+ * Usage:
+ *   node scripts/tts-doubao.mjs --text "Hello" --out demo.mp3
  *   node scripts/tts-doubao.mjs --text-file script.txt --out out.mp3 --speed 1.0
  *
- * 输出：
- *   - mp3 文件写到 --out 路径
- *   - stdout 打印一行 JSON: {"path":"...","duration":12.34,"bytes":54321}
+ * Output:
+ *   - mp3 file written to the --out path
+ *   - stdout prints one JSON line: {"path":"...","duration":12.34,"bytes":54321}
  *
- * 依赖：Node 18+（自带 fetch/crypto）、ffprobe（测时长，brew install ffmpeg）
+ * Dependencies: Node 18+ (built-in fetch / crypto), ffprobe (for duration; brew install ffmpeg)
  *
- * env（自动从 skill 根目录 .env 读取，也可走 process.env 覆盖）：
- *   DOUBAO_TTS_API_KEY     必填
- *   DOUBAO_TTS_VOICE_ID    必填（音色 id）
- *   DOUBAO_TTS_CLUSTER     默认 volcano_icl
- *   DOUBAO_TTS_ENDPOINT    默认 https://openspeech.bytedance.com/api/v1/tts
+ * env (auto-loaded from the skill root's .env; process.env overrides):
+ *   DOUBAO_TTS_API_KEY     required
+ *   DOUBAO_TTS_VOICE_ID    required (voice id)
+ *   DOUBAO_TTS_CLUSTER     default volcano_icl
+ *   DOUBAO_TTS_ENDPOINT    default https://openspeech.bytedance.com/api/v1/tts
  */
 
 import fs from 'node:fs';
@@ -64,14 +64,14 @@ function parseArgs(argv) {
 
 function usage() {
   console.error(`
-tts-doubao.mjs · 豆包语音 TTS
+tts-doubao.mjs · Doubao TTS
 
-  --text <str>          要合成的文本
-  --text-file <path>    从文件读取文本（与 --text 二选一）
-  --out <path>          输出 mp3 路径（必填）
-  --speed <float>       语速倍率，默认 1.0（0.5-2.0）
-  --voice <voice_id>    覆盖 .env 里的音色 id
-  --encoding <ext>      mp3 / wav / pcm，默认 mp3
+  --text <str>          text to synthesize
+  --text-file <path>    read text from file (alternative to --text)
+  --out <path>          output mp3 path (required)
+  --speed <float>       speed multiplier, default 1.0 (0.5–2.0)
+  --voice <voice_id>    override the voice id from .env
+  --encoding <ext>      mp3 / wav / pcm, default mp3
 `.trim());
   process.exit(1);
 }
@@ -96,8 +96,8 @@ async function tts({ text, voice, speed, encoding }) {
   const endpoint = process.env.DOUBAO_TTS_ENDPOINT || 'https://openspeech.bytedance.com/api/v1/tts';
   const voiceId = voice || process.env.DOUBAO_TTS_VOICE_ID;
 
-  if (!apiKey) throw new Error('缺 DOUBAO_TTS_API_KEY（检查 .env）');
-  if (!voiceId) throw new Error('缺 DOUBAO_TTS_VOICE_ID（检查 .env 或用 --voice 传）');
+  if (!apiKey) throw new Error('Missing DOUBAO_TTS_API_KEY (check .env)');
+  if (!voiceId) throw new Error('Missing DOUBAO_TTS_VOICE_ID (check .env or pass --voice)');
 
   const body = {
     app: { cluster },
@@ -129,13 +129,13 @@ async function tts({ text, voice, speed, encoding }) {
   }
 
   const json = await res.json();
-  // 豆包标准返回：{ code, message, data: "<base64 audio>", ... }
-  // code === 3000 表示成功
+  // Doubao standard response: { code, message, data: "<base64 audio>", ... }
+  // code === 3000 indicates success
   if (json.code !== undefined && json.code !== 3000) {
-    throw new Error(`API 返回错误 code=${json.code} msg=${json.message || JSON.stringify(json)}`);
+    throw new Error(`API returned error code=${json.code} msg=${json.message || JSON.stringify(json)}`);
   }
   if (!json.data) {
-    throw new Error(`API 响应无 data 字段：${JSON.stringify(json).slice(0, 500)}`);
+    throw new Error(`API response missing data field: ${JSON.stringify(json).slice(0, 500)}`);
   }
   return Buffer.from(json.data, 'base64');
 }
@@ -149,11 +149,11 @@ async function main() {
     text = fs.readFileSync(args.textFile, 'utf8').trim();
   }
   if (!text) {
-    console.error('错：缺 --text 或 --text-file');
+    console.error('Error: missing --text or --text-file');
     usage();
   }
   if (!args.out) {
-    console.error('错：缺 --out');
+    console.error('Error: missing --out');
     usage();
   }
 
@@ -179,6 +179,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(`TTS 失败：${err.message}`);
+  console.error(`TTS failed: ${err.message}`);
   process.exit(1);
 });

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 """
-verify.py — Playwright封装，用于验证claude-design产出的HTML
+verify.py — Playwright wrapper for verifying HTML produced by huashu-design
 
 Usage:
-    python verify.py path/to/design.html                    # 基础：打开+截图+抓控制台错误
-    python verify.py design.html --viewports 1920x1080,375x667  # 多viewport
-    python verify.py deck.html --slides 10                  # 幻灯片逐页截（前10张）
-    python verify.py design.html --output ./screenshots/   # 输出目录
-    python verify.py design.html --show                    # 非headless，打开真实浏览器
+    python verify.py path/to/design.html                    # basic: open + screenshot + capture console errors
+    python verify.py design.html --viewports 1920x1080,375x667  # multiple viewports
+    python verify.py deck.html --slides 10                  # slide mode: screenshot the first N slides
+    python verify.py design.html --output ./screenshots/   # output directory
+    python verify.py design.html --show                    # non-headless — open a real browser
 
-依赖：
+Dependencies:
     pip install playwright
     playwright install chromium
 """
@@ -30,13 +30,13 @@ def verify_html(html_path, viewports=None, slides=0, output_dir=None, show=False
     try:
         from playwright.sync_api import sync_playwright
     except ImportError:
-        print("ERROR: playwright未安装。")
-        print("运行: pip install playwright && playwright install chromium")
+        print("ERROR: playwright is not installed.")
+        print("Run: pip install playwright && playwright install chromium")
         sys.exit(1)
 
     html_path = Path(html_path).resolve()
     if not html_path.exists():
-        print(f"ERROR: 文件不存在: {html_path}")
+        print(f"ERROR: file not found: {html_path}")
         sys.exit(1)
 
     if output_dir is None:
@@ -63,7 +63,7 @@ def verify_html(html_path, viewports=None, slides=0, output_dir=None, show=False
             page.on("console", lambda msg: console_errors.append(f"[{msg.type}] {msg.text}") if msg.type in ("error", "warning") else None)
             page.on("pageerror", lambda err: page_errors.append(str(err)))
 
-            print(f"\n→ 打开 {file_url} @ {viewport['width']}x{viewport['height']}")
+            print(f"\n→ Opening {file_url} @ {viewport['width']}x{viewport['height']}")
             page.goto(file_url, wait_until='networkidle')
             page.wait_for_timeout(wait)
 
@@ -80,14 +80,14 @@ def verify_html(html_path, viewports=None, slides=0, output_dir=None, show=False
                 suffix = f"-{viewport['width']}x{viewport['height']}" if len(viewports) > 1 else ""
                 screenshot_path = output_dir / f"{stem}{suffix}.png"
                 page.screenshot(path=str(screenshot_path), full_page=False)
-                print(f"  ✓ 截图 → {screenshot_path.name}")
+                print(f"  ✓ Screenshot → {screenshot_path.name}")
 
                 full_path = output_dir / f"{stem}{suffix}-full.png"
                 page.screenshot(path=str(full_path), full_page=True)
-                print(f"  ✓ 完整页 → {full_path.name}")
+                print(f"  ✓ Full page → {full_path.name}")
 
             if show:
-                print("  (浏览器窗口保持打开，按Enter关闭...)")
+                print("  (browser window stays open — press Enter to close)")
                 input()
 
             context.close()
@@ -95,7 +95,7 @@ def verify_html(html_path, viewports=None, slides=0, output_dir=None, show=False
         browser.close()
 
     print("\n" + "=" * 50)
-    print("验证报告")
+    print("Verification report")
     print("=" * 50)
 
     if page_errors:
@@ -103,18 +103,18 @@ def verify_html(html_path, viewports=None, slides=0, output_dir=None, show=False
         for e in page_errors:
             print(f"  - {e}")
     else:
-        print("\n✅ 无JavaScript错误")
+        print("\n✅ No JavaScript errors")
 
     if console_errors:
         print(f"\n⚠️  Console Errors/Warnings ({len(console_errors)}):")
         for e in console_errors[:20]:
             print(f"  - {e}")
         if len(console_errors) > 20:
-            print(f"  ... 还有{len(console_errors) - 20}条")
+            print(f"  ... and {len(console_errors) - 20} more")
     else:
-        print("✅ Console干净")
+        print("✅ Console clean")
 
-    print(f"\n📸 截图保存至: {output_dir}")
+    print(f"\n📸 Screenshots saved to: {output_dir}")
 
     return 0 if not page_errors else 1
 
@@ -126,15 +126,15 @@ def main():
     )
     parser.add_argument("html_path", help="HTML file path")
     parser.add_argument("--viewports", default="1440x900",
-                        help="逗号分隔的viewport列表，格式 WxH（默认 1440x900）")
+                        help="comma-separated viewport list in WxH form (default 1440x900)")
     parser.add_argument("--slides", type=int, default=0,
-                        help="幻灯片模式：截取前N张（需要HTML支持ArrowRight翻页）")
+                        help="slide mode: screenshot the first N slides (HTML must support ArrowRight paging)")
     parser.add_argument("--output", default=None,
-                        help="输出目录（默认HTML所在目录的screenshots/）")
+                        help="output directory (default: screenshots/ next to the HTML)")
     parser.add_argument("--show", action="store_true",
-                        help="非headless，打开真实浏览器窗口")
+                        help="non-headless — open a real browser window")
     parser.add_argument("--wait", type=int, default=2000,
-                        help="打开页面后等待的毫秒数（默认2000）")
+                        help="milliseconds to wait after opening the page (default 2000)")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Translate the Huashu Design skill from Mandarin to English so it can be used by English / Portuguese / Urdu-speaking users without the surface text constantly leaking Chinese. The trigger keywords in the SKILL.md description were the proximate cause of Chinese-flavored output even when prompts were in English — that surface always sits in context.

- SKILL.md: full body + YAML description (converted to a `>-` block scalar so the now-ASCII colons inside the value don't trip the parser the way full-width `：` previously did).
- references/ (22 files): translated via parallel subagents with a locked terminology glossary (Junior Designer workflow, Core Asset Protocol, anti-AI-slop, Design Direction Advisor / Fallback Mode, ironclad rule, etc.).
- assets/*.jsx: doc-comment headers and the few visible button labels in animations.jsx.
- scripts/*: usage banners, error messages, and inline comments.
- Dead absolute paths to the original author's machine inside three reference "References" sections replaced with "(not bundled with this skill)" notes.
- Surviving CJK: a single Japanese kanji `間` in `ma (間)` (Kenya Hara design term) — intentional.

README.zh.md, demos/*.html, and the original Chinese in the README/license attribution are left untouched.