### PR TITLE
feat: Add Cognition Engine - Intent-Driven Generative UI Layer

### DIFF
--- a/cognition/CognitionEngine.ts
+++ b/cognition/CognitionEngine.ts
@@ -1,0 +1,35 @@
+import { CognitiveMatrix, UrgencyLevel, InteractionIntent, CognitiveToken } from './tokens';
+
+// Guarda de Carga Cognitiva: Previne que a tela tenha mais de uma ação crítica
+let activeCriticalActions = 0;
+const MAX_CRITICAL_ACTIONS = 1;
+
+export function resolveCognitiveToken(
+  intent: InteractionIntent,
+  urgency: UrgencyLevel
+): CognitiveToken {
+  // Regra de Acessibilidade e Psicologia: Só pode haver UMA urgência crítica por contexto
+  if (urgency === 'critical' && intent !== 'cancel') {
+    activeCriticalActions++;
+    if (activeCriticalActions > MAX_CRITICAL_ACTIONS) {
+      console.warn(
+        '[Huashu Cognition Engine] ⚠️ Cognitive Overload Warning: You have multiple critical urgency components competing for attention. This causes decision paralysis in users.'
+      );
+    }
+  }
+
+  const token = CognitiveMatrix[urgency]?.[intent];
+
+  if (!token) {
+    console.error(`[Huashu Cognition Engine] Invalid mapping for Urgency: ${urgency}, Intent: ${intent}`);
+    // Fallback seguro para não quebrar a UI
+    return { componentAlias: 'Button', props: { variant: 'outline' } };
+  }
+
+  return token;
+}
+
+// Reseta o contador de carga cognitiva (útil em trocas de tela/unmount)
+export function resetCognitiveLoad() {
+  activeCriticalActions = 0;
+}

--- a/cognition/HuashuCognition.tsx
+++ b/cognition/HuashuCognition.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import { resolveCognitiveToken, resetCognitiveLoad } from './CognitionEngine';
+import { UrgencyLevel, InteractionIntent } from './tokens';
+
+export interface HuashuCognitionProps {
+  /**
+   * A intenção de negócio dessa interação.
+   * O Engine vai decidir o visual com base nisso.
+   */
+  intent: InteractionIntent;
+  
+  /**
+   * O nível de urgência psicológica.
+   */
+  urgency: UrgencyLevel;
+  
+  /**
+   * O conteúdo do componente (texto, ícones, etc.)
+   */
+  children: React.ReactNode;
+  
+  /**
+   * Callback de click
+   */
+  onClick?: () => void;
+}
+
+/**
+ * HuashuCognition: O Compilador de Intenção Visual.
+ * Desenvolvedores param de escolher variantes de botões e passam a declarar intenções de negócio.
+ */
+export const HuashuCognition: React.FC<HuashuCognitionProps> = ({
+  intent,
+  urgency,
+  children,
+  onClick,
+}) => {
+  // 1. Resolve a intenção no Token Cognitivo
+  const cognitiveToken = resolveCognitiveToken(intent, urgency);
+
+  // 2. Mapeia o alias para o componente real do huashu-design
+  // NOTA: Nesta prova de conceito, renderizamos um botão nativo estilizado com as props resolvidas.
+  // Em integração real, isso faria um import dinâmico do componente 'huashu-design/Button'
+  const RenderedComponent = (props: any) => <button {...props} />;
+
+  // 3. Reseta a carga cognitiva ao desmontar (limpeza de contexto)
+  useEffect(() => {
+    return () => {
+      if (urgency === 'critical' && intent !== 'cancel') {
+        resetCognitiveLoad();
+      }
+    };
+  }, [urgency, intent]);
+
+  return (
+    <RenderedComponent
+      {...cognitiveToken.props}
+      onClick={onClick}
+      data-cognition-intent={intent}
+      data-cognition-urgency={urgency}
+      className={`huashu-cognition ${cognitiveToken.microInteraction || ''}`}
+    >
+      {children}
+    </RenderedComponent>
+  );
+};

--- a/cognition/README.md
+++ b/cognition/README.md
@@ -1,0 +1,29 @@
+🧠 Huashu Cognition Engine
+Shift your Design System from "Component-Driven" to "Intent-Driven".
+
+The Cognition Engine is a generative layer that translates Business Intent and Cognitive Psychology into perfect UI instantiations, eliminating the need for developers to make micro-design decisions.
+
+The Paradigm Shift
+Instead of choosing UI components and variants manually, developers declare the cognitive purpose of the interaction. The Engine compiles the correct visual representation, accessibility, and micro-interactions automatically.
+
+Before (Manual Stitching)
+<Button variant="destructive" size="lg" className="animate-pulse" aria-live="assertive">  Delete Account</Button>
+
+After (Intent-Driven)
+
+<HuashuCognition intent="delete" urgency="critical">
+  Delete Account
+</HuashuCognition>
+
+Architecture
+tokens.ts: The Semantic Cognitive Dictionary. Maps Urgency + Intent to UI properties.
+CognitionEngine.ts: The Compiler. Resolves intents and enforces psychological constraints (e.g., preventing Cognitive Overload).
+HuashuCognition.tsx: The Developer Interface. The dynamic wrapper that renders the resolved component.
+Cognitive Safety Features
+The Engine enforces rules of human psychology automatically:
+
+Cognitive Overload Guard: If you try to render more than one urgency="critical" element in the same view, the Engine warns you in the console. Users cannot process multiple critical actions simultaneously.
+
+Next Steps for Integration
+Map componentAlias directly to huashu-design core components.
+Build a Figma plugin that reads the Cognition Tokens to generate screens automatically.

--- a/cognition/tokens.ts
+++ b/cognition/tokens.ts
@@ -1,0 +1,46 @@
+/**
+ * Huashu Cognition Engine - Semantic Cognitive Tokens
+ * Traduz Intenção do Negócio e Carga Cognitiva em Decisões de UI.
+ */
+
+export type UrgencyLevel = 'critical' | 'high' | 'medium' | 'low';
+export type CognitiveLoad = 'high' | 'low'; // O usuário precisa focar ou explorar?
+export type InteractionIntent = 'submit' | 'cancel' | 'explore' | 'delete' | 'confirm';
+
+export interface CognitiveToken {
+  componentAlias: string; // Mapeia para o componente real do huashu-design
+  props: Record<string, any>; // Props visuais e de acessibilidade injetadas
+  microInteraction?: string; // Animações cognitivas (ex: pulse para atrair atenção)
+}
+
+// A Matriz de Decisão
+export const CognitiveMatrix: Record<UrgencyLevel, Record<InteractionIntent, CognitiveToken>> = {
+  critical: {
+    submit: { componentAlias: 'Button', props: { variant: 'primary', size: 'lg', 'aria-live': 'assertive' }, microInteraction: 'pulse' },
+    delete: { componentAlias: 'Button', props: { variant: 'destructive', size: 'lg', 'aria-live': 'assertive' }, microInteraction: 'shake' },
+    cancel: { componentAlias: 'Button', props: { variant: 'ghost', size: 'sm', 'aria-live': 'polite' } },
+    explore: { componentAlias: 'Button', props: { variant: 'outline', size: 'md', 'aria-live': 'off' } },
+    confirm: { componentAlias: 'Button', props: { variant: 'destructive', size: 'lg', 'aria-live': 'assertive' } },
+  },
+  high: {
+    submit: { componentAlias: 'Button', props: { variant: 'primary', size: 'md', 'aria-live': 'polite' } },
+    delete: { componentAlias: 'Button', props: { variant: 'destructive', size: 'md', 'aria-live': 'polite' } },
+    cancel: { componentAlias: 'Button', props: { variant: 'ghost', size: 'sm' } },
+    explore: { componentAlias: 'Button', props: { variant: 'outline', size: 'md' } },
+    confirm: { componentAlias: 'Button', props: { variant: 'primary', size: 'md' } },
+  },
+  medium: {
+    submit: { componentAlias: 'Button', props: { variant: 'primary', size: 'md' } },
+    delete: { componentAlias: 'Button', props: { variant: 'outline', size: 'sm' } },
+    cancel: { componentAlias: 'Button', props: { variant: 'ghost', size: 'sm' } },
+    explore: { componentAlias: 'Button', props: { variant: 'ghost', size: 'md' } },
+    confirm: { componentAlias: 'Button', props: { variant: 'secondary', size: 'md' } },
+  },
+  low: {
+    submit: { componentAlias: 'Button', props: { variant: 'link', size: 'sm' } },
+    delete: { componentAlias: 'Button', props: { variant: 'link', size: 'sm' } },
+    cancel: { componentAlias: 'Button', props: { variant: 'link', size: 'sm' } },
+    explore: { componentAlias: 'Button', props: { variant: 'link', size: 'md' } },
+    confirm: { componentAlias: 'Button', props: { variant: 'link', size: 'sm' } },
+  },
+};


### PR DESCRIPTION
### Summary
Adds a generative layer that translates Business Intent and Cognitive Psychology into UI, shifting the design system from "Component-Driven" to "Intent-Driven".

### The Paradigm Shift
Currently, developers search for components and manually decide variants, sizes, and ARIA attributes. This creates a gap between Business Intent and UI Implementation.

With the Cognition Engine, developers declare the cognitive purpose of the interaction (e.g., intent="delete" urgency="critical"), and the Engine dynamically compiles the correct visual representation, animations, and accessibility traits.

### Concept Example
// BEFORE (Manual stitching, developer makes design decisions):<Button variant="destructive" size="lg" className="animate-pulse" aria-live="assertive">  Delete Account</Button>// AFTER (Intent-Driven, system enforces design psychology):<HuashuCognition intent="delete" urgency="critical">  Delete Account</HuashuCognition>

### What this PR includes
cognition/tokens.ts: Semantic Cognitive Mapping (Urgency + Intent = UI).
cognition/CognitionEngine.ts: The resolver and Cognitive Overload Guard (prevents multiple critical actions from competing for attention).
cognition/HuashuCognition.tsx: The React wrapper for intent-driven development.
cognition/README.md: Full documentation on the architecture and paradigm shift.

### Why this is non-invasive
This PR adds the Cognition Engine as an isolated experimental layer (cognition/). It does not modify any existing huashu-design core components, ensuring zero breaking changes. It acts as a proof-of-concept that can be deeply integrated later if approved.

### How to test
Import <HuashuCognition> from cognition/HuashuCognition.tsx.
Pass intent="submit" and urgency="critical".
Observe the resolved props and the Cognitive Overload Guard in the console if multiple critical intents are rendered.