### PR TITLE
fix(demos): restore fallback advisor images

### DIFF
--- a/demos/w3-fallback-advisor-en.html
+++ b/demos/w3-fallback-advisor-en.html
@@ -347,7 +347,7 @@
         <div class="feature">Terracotta · Vast whitespace · Paper grain</div>
       </div>
       <div class="thumb-wrap" id="thumb1">
-        <img src="demo-takram.png" alt="demo takram" />
+        <img src="../assets/showcases/website-saas/saas-takram.png" alt="demo takram" />
       </div>
     </div>
     <div class="fg-card" id="card2">
@@ -358,7 +358,7 @@
         <div class="feature">Strict grid · High contrast · Editorial</div>
       </div>
       <div class="thumb-wrap" id="thumb2">
-        <img src="demo-pentagram.png" alt="demo pentagram" />
+        <img src="../assets/showcases/website-saas/saas-pentagram.png" alt="demo pentagram" />
       </div>
     </div>
     <div class="fg-card" id="card3">
@@ -369,7 +369,7 @@
         <div class="feature">Broken type · Brutal geometry · Visual shock</div>
       </div>
       <div class="thumb-wrap" id="thumb3">
-        <img src="demo-build.png" alt="demo build" />
+        <img src="../assets/showcases/website-saas/saas-build.png" alt="demo build" />
       </div>
     </div>
   </div>

--- a/demos/w3-fallback-advisor.html
+++ b/demos/w3-fallback-advisor.html
@@ -354,7 +354,7 @@
         <div class="feature">赤土橙 · 大量留白 · 宣纸质感</div>
       </div>
       <div class="thumb-wrap" id="thumb1">
-        <img src="demo-takram.png" alt="demo takram" />
+        <img src="../assets/showcases/website-saas/saas-takram.png" alt="demo takram" />
       </div>
     </div>
     <!-- card 2: Pentagram · 信息建筑 -->
@@ -366,7 +366,7 @@
         <div class="feature">强网格 · 高对比 · 理性版式</div>
       </div>
       <div class="thumb-wrap" id="thumb2">
-        <img src="demo-pentagram.png" alt="demo pentagram" />
+        <img src="../assets/showcases/website-saas/saas-pentagram.png" alt="demo pentagram" />
       </div>
     </div>
     <!-- card 3: David Carson · 实验先锋 -->
@@ -378,7 +378,7 @@
         <div class="feature">破格排印 · 粗野几何 · 视觉冲击</div>
       </div>
       <div class="thumb-wrap" id="thumb3">
-        <img src="demo-build.png" alt="demo build" />
+        <img src="../assets/showcases/website-saas/saas-build.png" alt="demo build" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Fix broken image paths in the Chinese and English fallback advisor demos.
- Reuse existing screenshots under assets/showcases/website-saas instead of adding duplicate PNGs.

Fixes #42

## Verification
- Confirmed referenced PNG files exist with Test-Path.
